### PR TITLE
Add missing year_of_sale column to mydec_sales subquery in vw_pin_sale

### DIFF
--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -186,7 +186,8 @@ mydec_sales AS (
             ) > 0 AS sale_filter_ptax_flag,
             COUNT() OVER (
                 PARTITION BY line_1_primary_pin, line_4_instrument_date
-            ) AS num_cards_sale
+            ) AS num_cards_sale,
+            year_of_sale
         FROM sale.mydec
         WHERE is_earliest_within_doc_no
     )


### PR DESCRIPTION
It seems like `vw_pin_sale` is missing a column in the `mydec_sales` subquery, causing dbt to raise this error when attempting to build the models:

```
18:53:31  Runtime Error in model vw_pin_sale_test (models/default/vw_pin_sale_test.sql)
18:53:31    line 212:18: Column 'mydec_sales.year_of_sale' cannot be resolved
```

This isn't a problem in the production Athena view, so this probably represents a discrepancy caused by drift between the prod view definition and the view definition stored in this repo. This PR updates the view definition in this repo to correctly select `year_of_sale` when generating the `mydec_sales` subquery.