### PR TITLE
Add sqlfmt pre-commit hook for autoformatting dbt files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,17 @@ repos:
     hooks:
     -   id: sqlfluff-lint
     -   id: sqlfluff-fix
+  - repo: https://github.com/tconbeer/sqlfmt
+    rev: v0.19.2
+    hooks:
+      - id: sqlfmt
+        entry: >-
+          sqlfmt -v dbt
+            --exclude dbt/venv/**/*
+            --exclude dbt/models/**/*
+            --exclude dbt/target/**/*
+            --exclude dbt/dbt_packages/**/*
+            --exclude dbt/dbt_modules/**/*
+        files: ^dbt/
+        language_version: python
+        additional_dependencies: ['.[jinjafmt]']

--- a/dbt/.sqlfluff
+++ b/dbt/.sqlfluff
@@ -1,0 +1,29 @@
+# These rules are required to support sqlfmt. See:
+# https://docs.sqlfmt.com/integrations/sqlfluff
+[sqlfluff]
+exclude_rules = layout.indent, layout.cte_bracket, layout.select_targets, ambiguous.column_count, structure.column_order, RF04, ST05
+max_line_length = 88
+
+[sqlfluff:rules]
+capitalisation_policy = lower
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:convention.terminator]
+multiline_newline = True
+
+# These rules are required to override the sqlfluff config at the root of
+# the project repo, since those rules interfere with sqlfmt standards.
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.identifiers]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.literals]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.types]
+extended_capitalisation_policy = lower

--- a/dbt/macros/generate_schema_name.sql
+++ b/dbt/macros/generate_schema_name.sql
@@ -2,13 +2,17 @@
 -- and replace it with our own namespacing on dev and CI.
 -- See: https://docs.getdbt.com/docs/build/custom-schemas
 {% macro generate_schema_name(custom_schema_name, node) -%}
-    {{ return(_generate_schema_name(
-        custom_schema_name,
-        node,
-        target,
-        env_var,
-        exceptions.raise_compiler_error
-    )) }}
+    {{
+        return(
+            _generate_schema_name(
+                custom_schema_name,
+                node,
+                target,
+                env_var,
+                exceptions.raise_compiler_error,
+            )
+        )
+    }}
 {%- endmacro %}
 
 -- Helper implementation of generate_schema_name where no arguments
@@ -25,12 +29,9 @@
     {%- if target.name == "dev" -%}
         {%- set schema_prefix = "dev_" ~ env_var_func("USER") ~ "_" -%}
     {%- elif target.name == "ci" -%}
-        {%- set github_head_ref = kebab_slugify(
-            env_var_func("GITHUB_HEAD_REF")
-        ) -%}
+        {%- set github_head_ref = kebab_slugify(env_var_func("GITHUB_HEAD_REF")) -%}
         {%- set schema_prefix = "ci_" ~ github_head_ref ~ "_" -%}
-    {%- else -%}
-        {%- set schema_prefix = "" -%}
+    {%- else -%} {%- set schema_prefix = "" -%}
     {%- endif -%}
 
     {%- if custom_schema_name is none -%}
@@ -39,11 +40,17 @@
             The default schema name is not allowed, since we use subdirectory
             organization to map tables/views to their Athena database
         #}
-        {{ return(raise_error_func(
-            "Missing schema definition for " ~ node.name ~ ". " ~
-            "Its containing subdirectory is probably missing a `+schema` " ~
-            "attribute under the `models` config in dbt_project.yml."
-        )) }}
+        {{
+            return(
+                raise_error_func(
+                    "Missing schema definition for "
+                    ~ node.name
+                    ~ ". "
+                    ~ "Its containing subdirectory is probably missing a `+schema` "
+                    ~ "attribute under the `models` config in dbt_project.yml."
+                )
+            )
+        }}
 
     {%- else -%}
 

--- a/dbt/macros/slugify.sql
+++ b/dbt/macros/slugify.sql
@@ -4,13 +4,13 @@
     {% set string = string | lower %}
 
     {#- Replace spaces, slashes, and underscores with hyphens -#}
-    {% set string = modules.re.sub('[ _/]+', '-', string) %}
+    {% set string = modules.re.sub("[ _/]+", "-", string) %}
 
     {#- Only take letters, numbers, and hyphens -#}
-    {% set string = modules.re.sub('[^a-z0-9-]+', '', string) %}
+    {% set string = modules.re.sub("[^a-z0-9-]+", "", string) %}
 
     {#- Prepends "_" if string begins with a number -#}
-    {% set string = modules.re.sub('^[0-9]', '_' + string[0], string) %}
+    {% set string = modules.re.sub("^[0-9]", "_" + string[0], string) %}
 
     {{ return(string) }}
 {% endmacro %}

--- a/dbt/macros/tests/test_all.sql
+++ b/dbt/macros/tests/test_all.sql
@@ -1,6 +1,5 @@
 -- dbt macro unit testing inspired by this blog post:
 -- https://docs.getdbt.com/blog/unit-testing-dbt-packages
 {% macro test_all() %}
-    {% do test_slugify() %}
-    {% do test_generate_schema_name() %}
+    {% do test_slugify() %} {% do test_generate_schema_name() %}
 {% endmacro %}

--- a/dbt/macros/tests/test_generate_schema_name.sql
+++ b/dbt/macros/tests/test_generate_schema_name.sql
@@ -6,12 +6,9 @@
 {% endmacro %}
 
 {% macro mock_env_var(var_name) %}
-    {% if var_name == "USER" %}
-        {{ return("testuser") }}
-    {% elif var_name == "GITHUB_HEAD_REF" %}
-        {{ return("testuser/feature-branch-1") }}
-    {% else %}
-        {{ return("") }}
+    {% if var_name == "USER" %} {{ return("testuser") }}
+    {% elif var_name == "GITHUB_HEAD_REF" %} {{ return("testuser/feature-branch-1") }}
+    {% else %} {{ return("") }}
     {% endif %}
 {% endmacro %}
 
@@ -27,9 +24,9 @@
             {"name": "test"},
             {"schema": "default", "name": "dev"},
             mock_env_var,
-            exceptions.raise_compiler_error
+            exceptions.raise_compiler_error,
         ),
-        "dev_testuser_test"
+        "dev_testuser_test",
     ) %}
 {% endmacro %}
 
@@ -41,9 +38,9 @@
             {"name": "test"},
             {"schema": "default", "name": "ci"},
             mock_env_var,
-            exceptions.raise_compiler_error
+            exceptions.raise_compiler_error,
         ),
-        "ci_testuser-feature-branch-1_test"
+        "ci_testuser-feature-branch-1_test",
     ) %}
 {% endmacro %}
 
@@ -55,9 +52,9 @@
             {"name": "test"},
             {"schema": "default", "name": "prod"},
             mock_env_var,
-            exceptions.raise_compiler_error
+            exceptions.raise_compiler_error,
         ),
-        "test"
+        "test",
     ) %}
 {% endmacro %}
 
@@ -69,8 +66,8 @@
             {"name": "test"},
             {"schema": "default", "name": "prod"},
             mock_env_var,
-            mock_raise_compiler_error
+            mock_raise_compiler_error,
         ),
-        "Compiler error raised"
+        "Compiler error raised",
     ) %}
 {% endmacro %}

--- a/dbt/macros/tests/test_slugify.sql
+++ b/dbt/macros/tests/test_slugify.sql
@@ -1,6 +1,4 @@
-{% macro test_slugify() %}
-    {% do test_kebab_slugify() %}
-{% endmacro %}
+{% macro test_slugify() %} {% do test_kebab_slugify() %} {% endmacro %}
 
 {% macro test_kebab_slugify() %}
     {% do test_kebab_slugify_lowercases_strings() %}
@@ -12,49 +10,55 @@
 {% endmacro %}
 
 {% macro test_kebab_slugify_lowercases_strings() %}
-    {{ assert_equals(
-        "test_kebab_slugify_lowercases_strings",
-        kebab_slugify("TEST"),
-        "test"
-    ) }}
+    {{
+        assert_equals(
+            "test_kebab_slugify_lowercases_strings", kebab_slugify("TEST"), "test"
+        )
+    }}
 {% endmacro %}
 
 {% macro test_kebab_slugify_replaces_spaces() %}
-    {{ assert_equals(
-        "test_kebab_slugify_replaces_spaces",
-        kebab_slugify("t e s t"),
-        "t-e-s-t"
-    ) }}
+    {{
+        assert_equals(
+            "test_kebab_slugify_replaces_spaces", kebab_slugify("t e s t"), "t-e-s-t"
+        )
+    }}
 {% endmacro %}
 
 {% macro test_kebab_slugify_replaces_slashes() %}
-    {{ assert_equals(
-        "test_kebab_slugify_replaces_slashes",
-        kebab_slugify("t/e/s/t"),
-        "t-e-s-t"
-    ) }}
+    {{
+        assert_equals(
+            "test_kebab_slugify_replaces_slashes", kebab_slugify("t/e/s/t"), "t-e-s-t"
+        )
+    }}
 {% endmacro %}
 
 {% macro test_kebab_slugify_replaces_underscores() %}
-    {{ assert_equals(
-        "test_kebab_slugify_replaces_underscores",
-        kebab_slugify("t_e_s_t"),
-        "t-e-s-t"
-    ) }}
+    {{
+        assert_equals(
+            "test_kebab_slugify_replaces_underscores",
+            kebab_slugify("t_e_s_t"),
+            "t-e-s-t",
+        )
+    }}
 {% endmacro %}
 
 {% macro test_kebab_slugify_removes_special_characters() %}
-    {{ assert_equals(
-        "test_kebab_slugify_removes_special_characters",
-        kebab_slugify("t!@#e$%^s&*()t"),
-        "test"
-    ) }}
+    {{
+        assert_equals(
+            "test_kebab_slugify_removes_special_characters",
+            kebab_slugify("t!@#e$%^s&*()t"),
+            "test",
+        )
+    }}
 {% endmacro %}
 
 {% macro test_kebab_slugify_handles_leading_numbers() %}
-    {{ assert_equals(
-        "test_kebab_slugify_handles_leading_numbers",
-        kebab_slugify("123test"),
-        "_123test"
-    ) }}
+    {{
+        assert_equals(
+            "test_kebab_slugify_handles_leading_numbers",
+            kebab_slugify("123test"),
+            "_123test",
+        )
+    }}
 {% endmacro %}

--- a/dbt/macros/tests/utils.sql
+++ b/dbt/macros/tests/utils.sql
@@ -1,9 +1,8 @@
 {% macro assert_equals(test_name, value, expected) %}
-    {% if value == expected %}
-        {% do log(test_name ~ " - PASS", info=True) %}
+    {% if value == expected %} {% do log(test_name ~ " - PASS", info=True) %}
     {% else %}
         {% do exceptions.raise_compiler_error(
-            test_name ~ " - FAIL: " ~ value~ " != " ~ expected
+            test_name ~ " - FAIL: " ~ value ~ " != " ~ expected
         ) %}
     {% endif %}
 {% endmacro %}

--- a/dbt/tests/generic/test_column_length.sql
+++ b/dbt/tests/generic/test_column_length.sql
@@ -6,41 +6,39 @@
 -- If additional columns should be returned along with the length columns,
 -- e.g. to add an identifiable key for the row, use the
 -- additional_select_columns argument.
-{% test column_length(
-  model, columns, length, additional_select_columns=[]
-) %}
+{% test column_length(model, columns, length, additional_select_columns=[]) %}
 
-    {%- set columns_csv = additional_select_columns | join(', ') %}
+    {%- set columns_csv = additional_select_columns | join(", ") %}
 
     {%- set length_columns = [] %}
     {% for column in columns %}
-    {%- set length_columns = length_columns.append(
-        [column, 'len_' + column]
-    ) %}
-{% endfor %}
+        {%- set length_columns = length_columns.append([column, "len_" + column]) %}
+    {% endfor %}
 
     {%- set select_columns = additional_select_columns %}
     {% set filter_conditions = [] %}
 
     {% for column, length_column in length_columns %}
-    {%- set select_columns = select_columns.append(
-        'length(' + column + ') as ' + length_column
-    ) %}
-    {%- set filter_conditions = filter_conditions.append(
-        '(' + length_column + ' is not null and ' + length_column + ' > ' +
-        length|string + ')'
-    ) %}
-{% endfor %}
+        {%- set select_columns = select_columns.append(
+            "length(" + column + ") as " + length_column
+        ) %}
+        {%- set filter_conditions = filter_conditions.append(
+            "("
+            + length_column
+            + " is not null and "
+            + length_column
+            + " > "
+            + length
+            | string + ")"
+        ) %}
+    {% endfor %}
 
-    {%- set columns_csv = select_columns | join(', ') %}
-    {%- set filter_conditions_str = filter_conditions | join(' or ') %}
+    {%- set columns_csv = select_columns | join(", ") %}
+    {%- set filter_conditions_str = filter_conditions | join(" or ") %}
 
-with column_lengths as (
-    select {{ columns_csv }}
-    from {{ model }}
-)
-select *
-from column_lengths
-where {{ filter_conditions_str }}
+    with column_lengths as (select {{ columns_csv }} from {{ model }})
+    select *
+    from column_lengths
+    where {{ filter_conditions_str }}
 
 {% endtest %}

--- a/dbt/tests/generic/test_count_is_consistent.sql
+++ b/dbt/tests/generic/test_count_is_consistent.sql
@@ -3,20 +3,21 @@
 -- across years
 {% test count_is_consistent(model, group_column, count_column) %}
 
-with counts as (
-    select {{ group_column }}, count(distinct({{ count_column }})) as cnt
-    from {{ model }}
-    group by {{ group_column }}
-),
-ranked_counts as (
-    select {{ group_column }}, cnt, rank() over (order by cnt desc) as rnk
-    from counts
-)
-select {{ group_column }}, cnt as count
-from ranked_counts
--- If all rows have the same count, they should all have a rank of 1 when
--- ranked according to count
-where rnk > 1
-order by cnt desc
+    with
+        counts as (
+            select {{ group_column }}, count(distinct({{ count_column }})) as cnt
+            from {{ model }}
+            group by {{ group_column }}
+        ),
+        ranked_counts as (
+            select {{ group_column }}, cnt, rank() over (order by cnt desc) as rnk
+            from counts
+        )
+    select {{ group_column }}, cnt as count
+    from ranked_counts
+    -- If all rows have the same count, they should all have a rank of 1 when
+    -- ranked according to count
+    where rnk > 1
+    order by cnt desc
 
 {% endtest %}

--- a/dbt/tests/generic/test_no_extra_whitespace.sql
+++ b/dbt/tests/generic/test_no_extra_whitespace.sql
@@ -1,22 +1,26 @@
 -- Test that one or more string columns do not contain extraneous whitespace
 {% test no_extra_whitespace(model, column_names) %}
 
-    {%- set columns = column_names | join(', ') %}
+    {%- set columns = column_names | join(", ") %}
 
     {%- set conditions_list = [] %}
     {% for column_name in column_names %}
-    {%- set conditions_list = conditions_list.append(
-        '(' + column_name + " like '%  %' or " + column_name +
-        " like '% ' or " + column_name + " like ' %')"
-    ) %}
-{%- endfor %}
-{%- set conditions = conditions_list | join(' or ') %}
+        {%- set conditions_list = conditions_list.append(
+            "("
+            + column_name
+            + " like '%  %' or "
+            + column_name
+            + " like '% ' or "
+            + column_name
+            + " like ' %')"
+        ) %}
+    {%- endfor %}
+    {%- set conditions = conditions_list | join(" or ") %}
 
-    with validation_errors as (
-        select {{ columns }}
-        from {{ model }}
-        where {{ conditions }}
-    )
+    with
+        validation_errors as (
+            select {{ columns }} from {{ model }} where {{ conditions }}
+        )
     select *
     from validation_errors
 

--- a/dbt/tests/generic/test_unique_combination_of_columns.sql
+++ b/dbt/tests/generic/test_unique_combination_of_columns.sql
@@ -9,16 +9,15 @@
 --
 -- Adapted from dbt_utils.unique_combination_of_columns, and adjusted to add the
 -- optional duplicate threshold and to only report one row for each dupe.
-
 {% test unique_combination_of_columns(
-  model, combination_of_columns, allowed_duplicates=0)
-%}
+    model, combination_of_columns, allowed_duplicates=0
+) %}
 
-{%- set columns_csv = combination_of_columns | join(', ') %}
+    {%- set columns_csv = combination_of_columns | join(", ") %}
 
-select {{ columns_csv }}, count(*) as num_duplicates
-from {{ model }}
-group by {{ columns_csv }}
-having count(*) > {{ allowed_duplicates }} + 1
+    select {{ columns_csv }}, count(*) as num_duplicates
+    from {{ model }}
+    group by {{ columns_csv }}
+    having count(*) > {{ allowed_duplicates }} + 1
 
 {% endtest %}


### PR DESCRIPTION
This PR sets up a pre-commit hook for [sqlfmt](https://docs.sqlfmt.com/) so that we can autoformat our dbt files and check for consistency on CI. It also runs sqlfmt autoformatting on all of our existing dbt files except our models, to which we are currently attempting to minimize edits as we build out the data catalog on the `data-catalog` branch.

Closes #30.