### PR TITLE
Deploy dbt docs to GitHub Pages

### DIFF
--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -1,0 +1,45 @@
+name: Deploy dbt docs
+
+on:
+  push:
+    branches:
+      - master
+      - data-catalog
+      # TODO: Remove this after testing
+      - 'jeancochrane/34-data-catalog-define-github-actions-workflow-for-rebuilding-and-deploying-docs-site'
+
+jobs:
+  deploy-dbt-docs:
+    runs-on: ubuntu-latest
+    # These permissions are required to make a GitHub Pages deployment
+    permissions:
+      pages: write      # To deploy to Pages
+      id-token: write   # To verify the deployment comes from an valid source
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dbt requirements
+        uses: ./.github/actions/install_dbt_requirements
+
+      - name: Load environment variables
+        uses: ./.github/actions/load_environment_variables
+
+      - name: Generate docs
+        run: dbt docs generate
+        working-directory: ${{ env.PROJECT_DIR }}
+        shell: bash
+
+      - name: Upload docs directory artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "target/"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for deploying our dbt docs to GitHub Pages. It implements the flow outlined in the GitHub documentation on [creating a custom GitHub Actions workflow to publish your site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site); this felt like a more appropriate choice than [publishing from a branch](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch) because we don't want to keep our generated docs files under version control if we can avoid it.

Closes https://github.com/ccao-data/data-architecture/issues/34.