### PR TITLE
Fix cleanup-dbt-resources workflow to run on data-catalog branch

### DIFF
--- a/.github/actions/configure_dbt_environment/action.yaml
+++ b/.github/actions/configure_dbt_environment/action.yaml
@@ -6,9 +6,8 @@ runs:
     - name: Configure dbt environment
       run: |
         # GITHUB_REF_NAME is only set on pull_request events, so if it's
-        # present, we must be in a PR context. Use the +x param expansion:
-        # https://stackoverflow.com/a/13864829
-        if [ -z ${GITHUB_REF_NAME+x} ]; then
+        # present, we must be in a PR context
+        if [ -z $GITHUB_REF_NAME} ]; then
           echo "On pull request branch, setting dbt env to CI"
           {
             echo "TARGET=ci";

--- a/.github/actions/configure_dbt_environment/action.yaml
+++ b/.github/actions/configure_dbt_environment/action.yaml
@@ -6,9 +6,8 @@ runs:
     - name: Configure dbt environment
       run: |
         # GITHUB_HEAD_REF is only set on pull_request events, so if it's
-        # present, we must be in a PR context. Use the +x param expansion
-        # to distinguish empty strings: https://stackoverflow.com/a/13864829
-        if [ ! -z ${GITHUB_HEAD_REF+x} ]; then
+        # present, we must be in a PR context
+        if [ -n "$GITHUB_HEAD_REF" ]; then
           echo "On pull request branch, setting dbt env to CI"
           {
             echo "TARGET=ci";

--- a/.github/actions/configure_dbt_environment/action.yaml
+++ b/.github/actions/configure_dbt_environment/action.yaml
@@ -5,7 +5,17 @@ runs:
   steps:
     - name: Configure dbt environment
       run: |
-        if [[ $GITHUB_REF_NAME == 'master' ]]; then
+        # GITHUB_REF_NAME is only set on pull_request events, so if it's
+        # present, we must be in a PR context. Use the +x param expansion:
+        # https://stackoverflow.com/a/13864829
+        if [ -z ${GITHUB_REF_NAME+x} ]; then
+          echo "On pull request branch, setting dbt env to CI"
+          {
+            echo "TARGET=ci";
+            echo "CACHE_KEY=$GITHUB_HEAD_REF";
+            echo "HEAD_REF=$GITHUB_HEAD_REF"
+          } >> "$GITHUB_ENV"
+        elif [[ $GITHUB_REF_NAME == 'master' ]]; then
           echo "On master branch, setting dbt env to prod"
           {
             echo "TARGET=prod";
@@ -19,11 +29,7 @@ runs:
             echo "HEAD_REF=data-catalog";
           } >> "$GITHUB_ENV"
         else
-          echo "On pull request branch, setting dbt env to CI"
-          {
-            echo "TARGET=ci";
-            echo "CACHE_KEY=$GITHUB_HEAD_REF";
-            echo "HEAD_REF=$GITHUB_HEAD_REF"
-          } >> "$GITHUB_ENV"
+          echo "CI context did not match any of the expected environments"
+          exit 1
         fi
       shell: bash

--- a/.github/actions/configure_dbt_environment/action.yaml
+++ b/.github/actions/configure_dbt_environment/action.yaml
@@ -6,11 +6,9 @@ runs:
     - name: Configure dbt environment
       run: |
         # GITHUB_HEAD_REF is only set on pull_request events, so if it's
-        # present, we must be in a PR context. Use the +x param expansion:
-        # https://stackoverflow.com/a/13864829
-        echo "GITHUB_HEAD_REF:"
-        echo "$GITHUB_HEAD_REF"
-        if [ -z ${GITHUB_HEAD_REF+x} ]; then
+        # present, we must be in a PR context. Use the +x param expansion
+        # to distinguish empty strings: https://stackoverflow.com/a/13864829
+        if [ ! -z ${GITHUB_HEAD_REF+x} ]; then
           echo "On pull request branch, setting dbt env to CI"
           {
             echo "TARGET=ci";

--- a/.github/actions/configure_dbt_environment/action.yaml
+++ b/.github/actions/configure_dbt_environment/action.yaml
@@ -8,6 +8,8 @@ runs:
         # GITHUB_HEAD_REF is only set on pull_request events, so if it's
         # present, we must be in a PR context. Use the +x param expansion:
         # https://stackoverflow.com/a/13864829
+        echo "GITHUB_HEAD_REF:"
+        echo "$GITHUB_HEAD_REF"
         if [ -z ${GITHUB_HEAD_REF+x} ]; then
           echo "On pull request branch, setting dbt env to CI"
           {

--- a/.github/actions/configure_dbt_environment/action.yaml
+++ b/.github/actions/configure_dbt_environment/action.yaml
@@ -5,10 +5,10 @@ runs:
   steps:
     - name: Configure dbt environment
       run: |
-        # GITHUB_REF_NAME is only set on pull_request events, so if it's
+        # GITHUB_HEAD_REF is only set on pull_request events, so if it's
         # present, we must be in a PR context. Use the +x param expansion:
         # https://stackoverflow.com/a/13864829
-        if [ -z ${GITHUB_REF_NAME+x} ]; then
+        if [ -z ${GITHUB_HEAD_REF+x} ]; then
           echo "On pull request branch, setting dbt env to CI"
           {
             echo "TARGET=ci";

--- a/.github/actions/configure_dbt_environment/action.yaml
+++ b/.github/actions/configure_dbt_environment/action.yaml
@@ -6,8 +6,9 @@ runs:
     - name: Configure dbt environment
       run: |
         # GITHUB_REF_NAME is only set on pull_request events, so if it's
-        # present, we must be in a PR context
-        if [ -z $GITHUB_REF_NAME} ]; then
+        # present, we must be in a PR context. Use the +x param expansion:
+        # https://stackoverflow.com/a/13864829
+        if [ -z ${GITHUB_REF_NAME+x} ]; then
           echo "On pull request branch, setting dbt env to CI"
           {
             echo "TARGET=ci";


### PR DESCRIPTION
The `cleanup-dbt-resources` workflow is [currently failing](https://github.com/ccao-data/data-architecture/actions/runs/5801014337/job/15724340945) on the `data-catalog` branch because `GITHUB_REF_NAME` appears to be set to `data-catalog` even though the workflow is triggered from a `pull_request` event:

> Deleting the following schemas from Athena:
>
> "ci_data-catalog_default"
> "ci_data-catalog_location"
>
> An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database ci_data-catalog_default not found.

This PR adjusts the `configure-dbt-environment` action to give higher priority to environments that have `GITHUB_HEAD_REF` set when setting the `HEAD_REF` variable for a pull request, since this variable is guaranteed to only be set on `pull_request` events, whereas `GITHUB_REF_NAME` can be set on both `pull_request` and `push` ([docs](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)).