### PR TITLE
Tweak failing dbt tests to make them easier to debug

### DIFF
--- a/dbt/README.md
+++ b/dbt/README.md
@@ -118,7 +118,7 @@ to debug the test failure.
 ### A special note on failures related to code changes
 
 To quickly rule out a failure related to a code change, you can switch to the
-main branch of this repo (or to an earlier commit where we know tests passed,
-if tests are failing on the main branch) and rerun the test. If the test
-continues to fail in the same fashion, then we can be confident that the root
-cause is the data and not the code change.
+main branch of this repository (or to an earlier commit where we know tests
+passed, if tests are failing on the main branch) and rerun the test. If the
+test continues to fail in the same fashion, then we can be confident that the
+root cause is the data and not the code change.

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -90,3 +90,35 @@ Run tests for dbt macros:
 ```
 dbt run-operation test_all
 ```
+
+## Debugging dbt test failures
+
+Most of our dbt tests are simple SQL statements that we run against our
+models in order to confirm that models conform to spec. If a test is
+failing, you can run or edit the underlying query in order to investigate
+the failure and determine whether the root cause is a code change we made,
+new data that was pushed to the system of record, or a misunderstanding about
+the data specification.
+
+To edit or run the query underlying a test, first run the test in isolation:
+
+```
+dbt test --select <test_name>
+```
+
+Then, navigate to the [Recent
+queries](https://us-east-1.console.aws.amazon.com/athena/home?region=us-east-1#/query-editor/history)
+tab in Athena. Your test will likely be one of the most recent queries; it
+will also start with the string `-- /* {"app": "dbt", ...`, which can be
+helpful for spotting it in the list of recent queries.
+
+Open the query in the Athena query editor, and edit or run it as necessary
+to debug the test failure.
+
+### A special note on failures related to code changes
+
+To quickly rule out a failure related to a code change, you can switch to the
+main branch of this repo (or to an earlier commit where we know tests passed,
+if tests are failing on the main branch) and rerun the test. If the test
+continues to fail in the same fashion, then we can be confident that the root
+cause is the data and not the code change.

--- a/dbt/models/default/schema.yml
+++ b/dbt/models/default/schema.yml
@@ -41,13 +41,18 @@ models:
           config:
             error_if: ">365905"
       # `change` should be an enum
-      - dbt_utils.expression_is_true:
+      - expression_is_true:
           name: vw_pin_appeal_no_unexpected_change_values
           expression: change is null or change in ('change', 'no change')
+          select_columns:
+            - pin
+            - year
+            - case_no
+            - change
           config:
             error_if: ">43"
       # If there is a `change`, the values should reflect this
-      - dbt_utils.expression_is_true:
+      - expression_is_true:
           name: vw_pin_appeal_change_matches_appeal_outcome
           expression: >-
             (change = 'no change' AND
@@ -63,6 +68,16 @@ models:
             )
             OR
             (change is null)
+          select_columns:
+            - pin
+            - year
+            - case_no
+            - mailed_bldg
+            - certified_bldg
+            - mailed_land
+            - certified_land
+            - mailed_tot
+            - certified_tot
           config:
             error_if: ">266758"
   - name: vw_card_res_char
@@ -77,13 +92,18 @@ models:
           config:
             error_if: ">913"
       # char_recent_renovation correlates with char_renovation
-      - dbt_utils.expression_is_true:
+      - expression_is_true:
           name: vw_card_res_char_renovation_fields_match
           # char_renovation can be null, which we count here as falsey
           expression: >-
             char_recent_renovation = (
               case when char_renovation = '1' then true else false end
             )
+          select_columns:
+            - card
+            - year
+            - char_renovation
+            - char_recent_renovation
           config:
             error_if: ">73941"
       # TODO: Characteristics columns should adhere to pre-determined criteria

--- a/dbt/tests/generic/test_expression_is_true.sql
+++ b/dbt/tests/generic/test_expression_is_true.sql
@@ -1,0 +1,13 @@
+-- Filter for rows where a given `expression` is false.
+--
+-- Adapted from `dbt_utils.expression_is_true`, and extended to support
+-- an optional `select_columns` option representing an array of columns to
+-- select for failing rows. If no `select_columns` array is provided, defaults
+-- to selecting 1 for failing rows.
+{% test expression_is_true(model, expression, select_columns=[1]) %}
+    {%- set columns_csv = select_columns | join(", ") %}
+
+    select {{ columns_csv }}
+    from {{ model }}
+    where not ({{ expression }})
+{% endtest %}


### PR DESCRIPTION
In the process of producing a list of failing dbt tests along with queries to help investigate them (https://github.com/ccao-data/data-architecture/issues/60), I realized that tests that build on the `dbt_utils.expression_is_true` generic test are hard to debug because they don't select the columns relevant to the expression by default. This PR defines our own `expression_is_true` generic test that allows us to configure a `select_columns` attribute to select relevant columns when constructing the test query.

See [this comment](https://github.com/ccao-data/data-architecture/pull/63#issuecomment-1673366467) for a detailed explanation of the effect of this change, including example queries.

The PR also adds a brief section to the README explaining the process for editing and running queries generated by the dbt tests.

Closes https://github.com/ccao-data/data-architecture/issues/60.