### PR TITLE
Separate dbt target and state directories to properly support slim CI

### DIFF
--- a/.github/variables/dbt.env
+++ b/.github/variables/dbt.env
@@ -1,3 +1,3 @@
 CACHE_NAME=dbt-cache
-MANIFEST_DIR=dbt/target
+MANIFEST_DIR=dbt/state
 PROJECT_DIR=dbt

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -61,11 +61,11 @@ jobs:
       - name: Build models
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
-            echo "Running build on modified resources only"
-            dbt run --target "$TARGET" -s state:modified --defer --state target/
+            echo "Running build on modified/new resources only"
+            dbt run -t "$TARGET" -s state:modified state:new --defer --state "$MANIFEST_DIR"
           else
             echo "Running build on all resources"
-            dbt run --target "$TARGET"
+            dbt run -t "$TARGET"
           fi
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
@@ -73,11 +73,16 @@ jobs:
       - name: Test models
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
-            echo "Running tests on modified resources only"
-            dbt test --target "$TARGET" -s state:modified --state target/
+            echo "Running tests on modified/new resources only"
+            dbt test -t "$TARGET" -s state:modified state:new --state "$MANIFEST_DIR"
           else
             echo "Running tests on all resources"
-            dbt test --target "$TARGET"
+            dbt test -t "$TARGET"
           fi
+        working-directory: ${{ env.PROJECT_DIR }}
+        shell: bash
+
+      - name: Move dbt manifest directory to update cache
+        run: mv target "$MANIFEST_DIR"
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash


### PR DESCRIPTION
One underdocumented subtlety of dbt's [state selection options](https://docs.getdbt.com/reference/node-selection/methods#the-state-method) is that when selecting resources based on state attributes (e.g. selecting only resources that are new or modified since last run, for "slim CI") you have to point to a _separate_ state directory containing a manifest file from the previous run, you can't just point to the default state directory that dbt uses (`target/`). I had assumed it was best practice to use one state directory, so I designed the `build-and-test-dbt` workflow to save/restore the state cache from the default `target/` state directory; however, it appears that dbt updates its own manifest file before comparing it to the state manifest file to see which resources have changed, so if those manifest files are the same file then dbt will never think that any resources have changed.

This PR fixes our `build-and-test-dbt` workflow such that we compare dbt state to the cached manifest file using a new `state/` directory that is separate from `target/`.

Closes https://github.com/ccao-data/data-architecture/issues/68.