### PR TITLE
Fix dbt production deploy problems

### DIFF
--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -82,6 +82,6 @@ jobs:
         shell: bash
 
       - name: Move dbt manifest directory to update cache
-        run: mv "$TARGET_DIR" "$STATE_DIR"
+        run: rsync -av --delete "$TARGET_DIR/" "$STATE_DIR"
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -33,21 +33,35 @@ jobs:
       - name: Configure dbt environment
         uses: ./.github/actions/configure_dbt_environment
 
-      - name: Cache dbt state directory
+      # We have to use the separate `restore`/`save` actions instead of the
+      # unified `cache` action because only `restore` provides access to the
+      # `cache-matched-key` and `cache-primary-key` outputs as of v3
+      - name: Restore dbt state cache
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
           key: ${{ env.CACHE_NAME }}-${{ env.CACHE_KEY }}
           restore-keys: |
             ${{ env.CACHE_NAME }}-master
 
-      - if: ${{ steps.cache.outputs.cache-hit == 'true' }}
+      # If we restore the cache from the `restore-keys` key, the `cache-hit`
+      # output will be 'false' but the `cache-matched-key` output will be
+      # the name of the `restore-keys` key; we want to count this case as a hit
+      - if: |
+          steps.cache.outputs.cache-hit == 'true' ||
+          steps.cache.outputs.cache-matched-key == format(
+            '{0}-master', env.CACHE_NAME
+          )
         name: Set command args to build/test modified resources
         run: echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"
         shell: bash
 
-      - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      - if: |
+          steps.cache.outputs.cache-hit != 'true' &&
+          steps.cache.outputs.cache-matched-key != format(
+            '{0}-master', env.CACHE_NAME
+          )
         name: Set command args to build/test all resources
         run: echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
         shell: bash
@@ -81,7 +95,8 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
 
-      - name: Move dbt manifest directory to update cache
-        run: rsync -av --delete "$TARGET_DIR/" "$STATE_DIR"
-        working-directory: ${{ env.PROJECT_DIR }}
-        shell: bash
+      - name: Update dbt state cache
+        uses: actions/cache/save@v3
+        with:
+          path: ${{ env.PROJECT_DIR }}/${{ env.TARGET_DIR }}
+          key: ${{ env.CACHE_NAME }}-${{ env.CACHE_KEY }}

--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -31,6 +31,9 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
           aws-region: us-east-1
 
+      - name: Configure dbt environment
+        uses: ./.github/actions/configure_dbt_environment
+
       - name: Generate docs
         run: dbt docs generate --target "$TARGET"
         working-directory: ${{ env.PROJECT_DIR }}


### PR DESCRIPTION
Three problems that emerged out of merging the data catalog branch into master (#78):

1. [Docs are not deploying](https://github.com/ccao-data/data-architecture/actions/runs/5905883640/job/16020814093) because we neglected to set up environment variables properly for the prod context
2. [Updating the dbt cache can fail](https://github.com/ccao-data/data-architecture/actions/runs/5906036003/job/16021252615) due to a naive `mv` call that is not actually performing the correct directory renaming
3. `$MODIFIED_RESOURCES_ONLY` [can be set to `false`](https://github.com/ccao-data/data-architecture/actions/runs/5906092110/job/16021431024) when we want it to be `true` in cases where we have to restore the cache from the `restore-keys` fallback

This PR fixes those three problems.