### PR TITLE
Add new scheduled workflow to run source freshness checks every morning

### DIFF
--- a/.github/actions/setup_dbt/action.yaml
+++ b/.github/actions/setup_dbt/action.yaml
@@ -1,0 +1,23 @@
+name: Setup dbt
+description: Install dependencies for dbt and configure it for use in CI.
+inputs:
+  role-to-assume:
+    description: AWS IAM role to assume when running dbt operations.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install dbt requirements
+      uses: ./.github/actions/install_dbt_requirements
+
+    - name: Load environment variables
+      uses: ./.github/actions/load_environment_variables
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: us-east-1
+
+    - name: Configure dbt environment
+      uses: ./.github/actions/configure_dbt_environment

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -18,20 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install dbt requirements
-        uses: ./.github/actions/install_dbt_requirements
-
-      - name: Load environment variables
-        uses: ./.github/actions/load_environment_variables
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: Setup dbt
+        uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
-          aws-region: us-east-1
-
-      - name: Configure dbt environment
-        uses: ./.github/actions/configure_dbt_environment
 
       # We have to use the separate `restore`/`save` actions instead of the
       # unified `cache` action because only `restore` provides access to the

--- a/.github/workflows/cleanup_dbt_resources.yaml
+++ b/.github/workflows/cleanup_dbt_resources.yaml
@@ -17,24 +17,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install dbt requirements
-        uses: ./.github/actions/install_dbt_requirements
+      - name: Setup dbt
+        uses: ./.github/actions/setup_dbt
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
 
       - name: Install requirements for cleaning up dbt resources
         run: sudo apt-get update && sudo apt-get install jq
         shell: bash
-
-      - name: Load environment variables
-        uses: ./.github/actions/load_environment_variables
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
-          aws-region: us-east-1
-
-      - name: Configure dbt environment
-        uses: ./.github/actions/configure_dbt_environment
 
       - name: Clean up dbt resources
         run: ../.github/scripts/cleanup_dbt_resources.sh ci

--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -19,20 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install dbt requirements
-        uses: ./.github/actions/install_dbt_requirements
-
-      - name: Load environment variables
-        uses: ./.github/actions/load_environment_variables
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: Setup dbt
+        uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
-          aws-region: us-east-1
-
-      - name: Configure dbt environment
-        uses: ./.github/actions/configure_dbt_environment
 
       - name: Generate docs
         run: dbt docs generate --target "$TARGET"

--- a/.github/workflows/test_dbt_models.yaml
+++ b/.github/workflows/test_dbt_models.yaml
@@ -14,20 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install dbt requirements
-        uses: ./.github/actions/install_dbt_requirements
-
-      - name: Load environment variables
-        uses: ./.github/actions/load_environment_variables
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: Setup dbt
+        uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
-          aws-region: us-east-1
-
-      - name: Configure dbt environment
-        uses: ./.github/actions/configure_dbt_environment
 
       - name: Test models
         run: dbt test --target "$TARGET"

--- a/.github/workflows/test_dbt_source_freshness.yaml
+++ b/.github/workflows/test_dbt_source_freshness.yaml
@@ -1,0 +1,40 @@
+name: test-dbt-source-freshness
+
+on:
+  schedule:
+    # Every day at 9am CST (3pm UTC)
+    - cron: '0 15 * * *'
+
+jobs:
+  test-dbt-source-freshness:
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint
+    # so that we can authenticate with AWS
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dbt requirements
+        uses: ./.github/actions/install_dbt_requirements
+
+      - name: Load environment variables
+        uses: ./.github/actions/load_environment_variables
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          aws-region: us-east-1
+
+      - name: Configure dbt environment
+        uses: ./.github/actions/configure_dbt_environment
+
+      - name: Test source freshness
+        run: dbt source freshness --target "$TARGET"
+        working-directory: ${{ env.PROJECT_DIR }}
+        shell: bash
+
+

--- a/.github/workflows/test_dbt_source_freshness.yaml
+++ b/.github/workflows/test_dbt_source_freshness.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
     # Every day at 9am CST (3pm UTC)
     - cron: '0 15 * * *'
+  # TODO: Remove this once testing is complete
+  pull_request:
+    branches: [master]
+
 
 jobs:
   test-dbt-source-freshness:

--- a/.github/workflows/test_dbt_source_freshness.yaml
+++ b/.github/workflows/test_dbt_source_freshness.yaml
@@ -17,24 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install dbt requirements
-        uses: ./.github/actions/install_dbt_requirements
-
-      - name: Load environment variables
-        uses: ./.github/actions/load_environment_variables
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: Setup dbt
+        uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
-          aws-region: us-east-1
-
-      - name: Configure dbt environment
-        uses: ./.github/actions/configure_dbt_environment
 
       - name: Test source freshness
         run: dbt source freshness --target "$TARGET"
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
-
-

--- a/.github/workflows/test_dbt_source_freshness.yaml
+++ b/.github/workflows/test_dbt_source_freshness.yaml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Every day at 9am CST (3pm UTC)
     - cron: '0 15 * * *'
-  # TODO: Remove this once testing is complete
-  pull_request:
-    branches: [master]
-
 
 jobs:
   test-dbt-source-freshness:

--- a/dbt/models/iasworld/schema.yml
+++ b/dbt/models/iasworld/schema.yml
@@ -12,8 +12,8 @@ sources:
       - name: asmt_all
         freshness:
           filter: &latest_taxyr taxyr >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: &24_hours {count: 24, period: hour}
+          error_after: &48_hours {count: 48, period: hour}
       - name: asmt_hist
       - name: cname
       - name: comdat
@@ -33,8 +33,8 @@ sources:
       - name: htpar
         freshness:
           filter: *latest_taxyr
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: *24_hours
+          error_after: *48_hours
       - name: land
       - name: legdat
       - name: lpmod
@@ -45,8 +45,8 @@ sources:
       - name: permit
         freshness:
           filter: date_format(date_parse(permdt, '%Y-%m-%d %H:%i:%s.0'), '%Y') >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 48, period: hour}
-          error_after: {count: 72, period: hour}
+          warn_after: *48_hours
+          error_after: &72_hours {count: 72, period: hour}
       - name: rcoby
       - name: sales
       - name: splcom

--- a/dbt/models/iasworld/schema.yml
+++ b/dbt/models/iasworld/schema.yml
@@ -3,12 +3,17 @@ version: 2
 
 sources:
   - name: iasworld
+    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
     tables:
       - name: aasysjur
       - name: addn
       - name: addrindx
       - name: aprval
       - name: asmt_all
+        freshness:
+          filter: taxyr = date_format(current_date, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
       - name: asmt_hist
       - name: cname
       - name: comdat
@@ -26,6 +31,10 @@ sources:
       - name: htagnt
       - name: htdates
       - name: htpar
+        freshness:
+          filter: taxyr = date_format(current_date, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
       - name: land
       - name: legdat
       - name: lpmod
@@ -34,6 +43,10 @@ sources:
       - name: owndat
       - name: pardat
       - name: permit
+        freshness:
+          filter: date_format(date_parse(permdt, '%Y-%m-%d %H:%i:%s.0'), '%Y') = date_format(current_date, '%Y')
+          warn_after: {count: 48, period: hour}
+          error_after: {count: 72, period: hour}
       - name: rcoby
       - name: sales
       - name: splcom

--- a/dbt/models/iasworld/schema.yml
+++ b/dbt/models/iasworld/schema.yml
@@ -11,7 +11,7 @@ sources:
       - name: aprval
       - name: asmt_all
         freshness:
-          filter: taxyr = date_format(current_date, '%Y')
+          filter: &latest_taxyr taxyr >= date_format(current_date - interval '1' year, '%Y')
           warn_after: {count: 24, period: hour}
           error_after: {count: 48, period: hour}
       - name: asmt_hist
@@ -32,7 +32,7 @@ sources:
       - name: htdates
       - name: htpar
         freshness:
-          filter: taxyr = date_format(current_date, '%Y')
+          filter: *latest_taxyr
           warn_after: {count: 24, period: hour}
           error_after: {count: 48, period: hour}
       - name: land
@@ -44,7 +44,7 @@ sources:
       - name: pardat
       - name: permit
         freshness:
-          filter: date_format(date_parse(permdt, '%Y-%m-%d %H:%i:%s.0'), '%Y') = date_format(current_date, '%Y')
+          filter: date_format(date_parse(permdt, '%Y-%m-%d %H:%i:%s.0'), '%Y') >= date_format(current_date - interval '1' year, '%Y')
           warn_after: {count: 48, period: hour}
           error_after: {count: 72, period: hour}
       - name: rcoby


### PR DESCRIPTION
This PR implements [source freshness checks](https://docs.getdbt.com/reference/commands/source#dbt-source-freshness) for our data catalog and initializes the checks with tests for three iasWorld tables (`htpar`, `asmt_all`, and `permit`). To run these checks, it adds a new CI workflow and schedules it to run at 9am CST every morning.

While adding the new workflow, I noticed that all of our dbt workflows currently share the same four setup steps. In the spirit of DRY, this PR also factors those steps out into a new `setup_dbt` composite action, and refactors the existing dbt workflows to use it.

Sample successful run [here](https://github.com/ccao-data/data-architecture/actions/runs/5931242660/job/16082679946?pr=84).

Closes https://github.com/ccao-data/data-architecture/issues/75.