### PR TITLE
Move dbt cache to remote S3 storage

### DIFF
--- a/.github/actions/configure_dbt_environment/action.yaml
+++ b/.github/actions/configure_dbt_environment/action.yaml
@@ -11,14 +11,16 @@ runs:
           echo "On pull request branch, setting dbt env to CI"
           {
             echo "TARGET=ci";
-            echo "CACHE_KEY=$GITHUB_HEAD_REF";
+            echo "CACHE_KEY=pr-caches/$GITHUB_HEAD_REF";
+            echo "CACHE_RESTORE_KEY=master-cache"
             echo "HEAD_REF=$GITHUB_HEAD_REF"
           } >> "$GITHUB_ENV"
         elif [[ $GITHUB_REF_NAME == 'master' ]]; then
           echo "On master branch, setting dbt env to prod"
           {
             echo "TARGET=prod";
-            echo "CACHE_KEY=master";
+            echo "CACHE_KEY=master-cache";
+            echo "CACHE_RESTORE_KEY=master-cache"
           } >> "$GITHUB_ENV"
         else
           echo "CI context did not match any of the expected environments"

--- a/.github/actions/restore_dbt_cache/action.yaml
+++ b/.github/actions/restore_dbt_cache/action.yaml
@@ -30,7 +30,6 @@ outputs:
 runs:
   using: composite
   steps:
-    # Check if there is an exact or fallback match for the cache key
     - name: Check for a cache key match
       id: query-cache-keys
       run: |
@@ -65,7 +64,6 @@ runs:
         RESTORE_KEY: ${{ inputs.restore-key }}
         BUCKET: ${{ inputs.bucket }}
 
-    # In case of a cache hit, copy the contents of the cache to the path
     - if: steps.query-cache-keys.outputs.cache-hit == 'true'
       name: Copy cache to path
       run: aws s3 cp "s3://$BUCKET/$KEY/manifest.json" "$CACHE_PATH/manifest.json"

--- a/.github/actions/restore_dbt_cache/action.yaml
+++ b/.github/actions/restore_dbt_cache/action.yaml
@@ -1,0 +1,73 @@
+name: Restore dbt cache
+description: Attempts to restore dbt cache from S3 storage.
+inputs:
+  path:
+    description: The local path to restore the cache to in case of a hit.
+    required: true
+  key:
+    description: The cache key to query for.
+    required: true
+  restore-key:
+    description: An additional key to use as a fallback for the cache.
+    required: true
+  bucket:
+    description: The S3 bucket that stores caches.
+    required: false
+    default: ccao-dbt-cache-us-east-1
+outputs:
+  cache-hit:
+    description: >-
+      Boolean indicating whether a match was found for the cache key.
+    value: ${{ steps.query-cache-keys.outputs.cache-hit }}
+  exact-match:
+    description: >-
+      Boolean indicating whether a cache hit was an exact match. Always
+      false if cache-hit is false.
+    value: ${{ steps.query-cache-keys.outputs.exact-match }}
+  cache-matched-key:
+    description: The cache key that matched, if any. Empty if cache-hit is false.
+    value: ${{ steps.query-cache-keys.outputs.cache-matched-key }}
+runs:
+  using: composite
+  steps:
+    # Check if there is an exact or fallback match for the cache key
+    - name: Check for a cache key match
+      id: query-cache-keys
+      run: |
+        if aws s3api head-object --bucket "$BUCKET" --key "$KEY/manifest.json"; then
+          echo "Cache hit: Found exact match"
+          {
+            echo "cache-hit=true";
+            echo "exact-match=true";
+            echo "cache-matched-key=$KEY"
+          } >> $GITHUB_OUTPUT
+        else
+          echo "Did not find exact match for cache key, checking fallback"
+          if aws s3api head-object --bucket "$BUCKET" --key "$RESTORE_KEY/manifest.json"; then
+            echo "Cache hit: Found fallback match"
+            {
+              echo "cache-hit=true";
+              echo "exact-match=false";
+              echo "cache-matched-key=$RESTORE_KEY"
+            } >> $GITHUB_OUTPUT
+          else
+            echo "Cache miss: Did not find fallback match for cache key"
+            {
+              echo "cache-hit=false";
+              echo "exact-match=false";
+              echo "cache-matched-key=''";
+            } >> $GITHUB_OUTPUT
+          fi
+        fi
+      env:
+        KEY: ${{ inputs.key }}
+        RESTORE_KEY: ${{ inputs.restore-key }}
+        BUCKET: ${{ inputs.bucket }}
+
+    # In case of a cache hit, copy the contents of the cache to the path
+    - if: steps.query-cache-keys.outputs.cache-hit == 'true'
+      name: Copy cache to path
+      run: aws s3 cp "s3://$BUCKET/$KEY/manifest.json" "$PATH/manifest.json"
+      env:
+        KEY: ${{ steps.query-cache-keys.outputs.cache-matched-key }}
+        PATH: ${{ inputs.path }}

--- a/.github/actions/restore_dbt_cache/action.yaml
+++ b/.github/actions/restore_dbt_cache/action.yaml
@@ -59,6 +59,7 @@ runs:
             } >> $GITHUB_OUTPUT
           fi
         fi
+      shell: bash
       env:
         KEY: ${{ inputs.key }}
         RESTORE_KEY: ${{ inputs.restore-key }}
@@ -68,6 +69,7 @@ runs:
     - if: steps.query-cache-keys.outputs.cache-hit == 'true'
       name: Copy cache to path
       run: aws s3 cp "s3://$BUCKET/$KEY/manifest.json" "$PATH/manifest.json"
+      shell: bash
       env:
         KEY: ${{ steps.query-cache-keys.outputs.cache-matched-key }}
         PATH: ${{ inputs.path }}

--- a/.github/actions/restore_dbt_cache/action.yaml
+++ b/.github/actions/restore_dbt_cache/action.yaml
@@ -11,7 +11,7 @@ inputs:
     description: An additional key to use as a fallback for the cache.
     required: true
   bucket:
-    description: The S3 bucket that stores caches.
+    description: The S3 bucket that should store the cache.
     required: false
     default: ccao-dbt-cache-us-east-1
 outputs:
@@ -71,3 +71,4 @@ runs:
       env:
         KEY: ${{ steps.query-cache-keys.outputs.cache-matched-key }}
         PATH: ${{ inputs.path }}
+        BUCKET: ${{ inputs.bucket }}

--- a/.github/actions/restore_dbt_cache/action.yaml
+++ b/.github/actions/restore_dbt_cache/action.yaml
@@ -68,9 +68,9 @@ runs:
     # In case of a cache hit, copy the contents of the cache to the path
     - if: steps.query-cache-keys.outputs.cache-hit == 'true'
       name: Copy cache to path
-      run: aws s3 cp "s3://$BUCKET/$KEY/manifest.json" "$PATH/manifest.json"
+      run: aws s3 cp "s3://$BUCKET/$KEY/manifest.json" "$CACHE_PATH/manifest.json"
       shell: bash
       env:
         KEY: ${{ steps.query-cache-keys.outputs.cache-matched-key }}
-        PATH: ${{ inputs.path }}
+        CACHE_PATH: ${{ inputs.path }}
         BUCKET: ${{ inputs.bucket }}

--- a/.github/actions/save_dbt_cache/action.yaml
+++ b/.github/actions/save_dbt_cache/action.yaml
@@ -16,6 +16,7 @@ runs:
   steps:
     - name: Save dbt cache
       run: aws s3 cp "$PATH/manifest.json" "s3://$BUCKET/$KEY/manifest.json"
+      shell: bash
       env:
         KEY: ${{ inputs.key }}
         PATH: ${{ inputs.path }}

--- a/.github/actions/save_dbt_cache/action.yaml
+++ b/.github/actions/save_dbt_cache/action.yaml
@@ -15,9 +15,9 @@ runs:
   using: composite
   steps:
     - name: Save dbt cache
-      run: aws s3 cp "$PATH/manifest.json" "s3://$BUCKET/$KEY/manifest.json"
+      run: aws s3 cp "$CACHE_PATH/manifest.json" "s3://$BUCKET/$KEY/manifest.json"
       shell: bash
       env:
         KEY: ${{ inputs.key }}
-        PATH: ${{ inputs.path }}
+        CACHE_PATH: ${{ inputs.path }}
         BUCKET: ${{ inputs.bucket }}

--- a/.github/actions/save_dbt_cache/action.yaml
+++ b/.github/actions/save_dbt_cache/action.yaml
@@ -1,0 +1,22 @@
+name: Save dbt cache
+description: Updates dbt cache using S3 storage.
+inputs:
+  path:
+    description: The local path to the state dir to upload as the new cache.
+    required: true
+  key:
+    description: The key to use for the cache.
+    required: true
+  bucket:
+    description: The S3 bucket that should store the cache.
+    required: false
+    default: ccao-dbt-cache-us-east-1
+runs:
+  using: composite
+  steps:
+    - name: Save dbt cache
+      run: aws s3 cp "$PATH/manifest.json" "s3://$BUCKET/$KEY/manifest.json"
+      env:
+        KEY: ${{ inputs.key }}
+        PATH: ${{ inputs.path }}
+        BUCKET: ${{ inputs.bucket }}

--- a/.github/variables/dbt.env
+++ b/.github/variables/dbt.env
@@ -1,4 +1,3 @@
-CACHE_NAME=dbt-cache
 PROJECT_DIR=dbt
 STATE_DIR=state
 TARGET_DIR=target

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -95,8 +95,18 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
 
+      - name: Move dbt state directory to prepare for updating cache
+        run: |
+          if [ -d "$STATE_DIR" ]; then
+            echo "Moving existing state directory to prepare for update"
+            mv "$STATE_DIR" "$STATE_DIR.bk"
+          fi
+          mv "$TARGET_DIR" "$STATE_DIR"
+        working-directory: ${{ env.PROJECT_DIR }}
+        shell: bash
+
       - name: Update dbt state cache
         uses: actions/cache/save@v3
         with:
-          path: ${{ env.PROJECT_DIR }}/${{ env.TARGET_DIR }}
+          path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
           key: ${{ env.CACHE_NAME }}-${{ env.CACHE_KEY }}

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -28,8 +28,8 @@ jobs:
         uses: ./.github/actions/restore_dbt_cache
         with:
           path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
-          key: ${{ env.CACHE_NAME }}-${{ env.CACHE_KEY }}
-          restore-key: ${{ env.CACHE_NAME }}-master
+          key: ${{ env.CACHE_KEY }}
+          restore-key: ${{ env.CACHE_RESTORE_KEY }}
 
       - if: steps.cache.outputs.cache-hit == 'true'
         name: Set command args to build/test modified resources
@@ -74,4 +74,4 @@ jobs:
         uses: ./.github/actions/save_dbt_cache
         with:
           path: ${{ env.PROJECT_DIR }}/${{ env.TARGET_DIR }}
-          key: ${{ env.CACHE_NAME }}-${{ env.CACHE_KEY }}
+          key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -33,39 +33,20 @@ jobs:
       - name: Configure dbt environment
         uses: ./.github/actions/configure_dbt_environment
 
-      # We have to use the separate `restore`/`save` actions instead of the
-      # unified `cache` action because only `restore` provides access to the
-      # `cache-matched-key` and `cache-primary-key` outputs as of v3
       - name: Restore dbt state cache
         id: cache
-        uses: actions/cache/restore@v3
+        uses: ./.github/actions/restore_dbt_cache
         with:
           path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
           key: ${{ env.CACHE_NAME }}-${{ env.CACHE_KEY }}
-          restore-keys: |
-            ${{ env.CACHE_NAME }}-master
+          restore-key: ${{ env.CACHE_NAME }}-master
 
-      - name: Pull dbt state cache from S3
-        id: cache
-        uses: ./.github/actions/restore_dbt_cache
-
-      # If we restore the cache from the `restore-keys` key, the `cache-hit`
-      # output will be 'false' but the `cache-matched-key` output will be
-      # the name of the `restore-keys` key; we want to count this case as a hit
-      - if: |
-          steps.cache.outputs.cache-hit == 'true' ||
-          steps.cache.outputs.cache-matched-key == format(
-            '{0}-master', env.CACHE_NAME
-          )
+      - if: steps.cache.outputs.cache-hit == 'true'
         name: Set command args to build/test modified resources
         run: echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"
         shell: bash
 
-      - if: |
-          steps.cache.outputs.cache-hit != 'true' &&
-          steps.cache.outputs.cache-matched-key != format(
-            '{0}-master', env.CACHE_NAME
-          )
+      - if: steps.cache.outputs.cache-hit != 'true'
         name: Set command args to build/test all resources
         run: echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
         shell: bash
@@ -99,18 +80,8 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
 
-      - name: Move dbt state directory to prepare for updating cache
-        run: |
-          if [ -d "$STATE_DIR" ]; then
-            echo "Moving existing state directory to prepare for update"
-            mv "$STATE_DIR" "$STATE_DIR.bk"
-          fi
-          mv "$TARGET_DIR" "$STATE_DIR"
-        working-directory: ${{ env.PROJECT_DIR }}
-        shell: bash
-
       - name: Update dbt state cache
-        uses: actions/cache/save@v3
+        uses: ./.github/actions/save_dbt_cache
         with:
-          path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
+          path: ${{ env.PROJECT_DIR }}/${{ env.TARGET_DIR }}
           key: ${{ env.CACHE_NAME }}-${{ env.CACHE_KEY }}

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -45,6 +45,10 @@ jobs:
           restore-keys: |
             ${{ env.CACHE_NAME }}-master
 
+      - name: Pull dbt state cache from S3
+        id: cache
+        uses: ./.github/actions/restore_dbt_cache
+
       # If we restore the cache from the `restore-keys` key, the `cache-hit`
       # output will be 'false' but the `cache-matched-key` output will be
       # the name of the `restore-keys` key; we want to count this case as a hit

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -70,6 +70,12 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          detached: true
+          limit-access-to-actor: true
+
       - name: Update dbt state cache
         uses: ./.github/actions/save_dbt_cache
         with:

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -70,12 +70,6 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          detached: true
-          limit-access-to-actor: true
-
       - name: Update dbt state cache
         uses: ./.github/actions/save_dbt_cache
         with:


### PR DESCRIPTION
This PR adjusts the way that we store our dbt state caches to get around the fact that GitHub Actions caches cannot be updated once they've been created. By moving our state caches to S3, we can ensure that the cache always gets updated at the end of every successful run of the `build-and-test-dbt` workflow, which will allow subsequent runs to only build and test resources that have been modified since the last successful run.

See [this run](https://github.com/ccao-data/data-architecture/actions/runs/5968306499/job/16194026297) for evidence of the remote cache being used successfully.

Closes https://github.com/ccao-data/data-architecture/issues/89.