### PR TITLE
Remove prefix underscore from slugified schema names

### DIFF
--- a/dbt/macros/slugify.sql
+++ b/dbt/macros/slugify.sql
@@ -9,8 +9,5 @@
     {#- Only take letters, numbers, and hyphens -#}
     {% set string = modules.re.sub("[^a-z0-9-]+", "", string) %}
 
-    {#- Prepends "_" if string begins with a number -#}
-    {% set string = modules.re.sub("^[0-9]", "_" + string[0], string) %}
-
     {{ return(string) }}
 {% endmacro %}

--- a/dbt/macros/tests/test_slugify.sql
+++ b/dbt/macros/tests/test_slugify.sql
@@ -52,13 +52,3 @@
         )
     }}
 {% endmacro %}
-
-{% macro test_kebab_slugify_handles_leading_numbers() %}
-    {{
-        assert_equals(
-            "test_kebab_slugify_handles_leading_numbers",
-            kebab_slugify("123test"),
-            "_123test",
-        )
-    }}
-{% endmacro %}

--- a/dbt/macros/tests/test_slugify.sql
+++ b/dbt/macros/tests/test_slugify.sql
@@ -6,7 +6,6 @@
     {% do test_kebab_slugify_replaces_slashes() %}
     {% do test_kebab_slugify_replaces_underscores() %}
     {% do test_kebab_slugify_removes_special_characters() %}
-    {% do test_kebab_slugify_handles_leading_numbers() %}
 {% endmacro %}
 
 {% macro test_kebab_slugify_lowercases_strings() %}


### PR DESCRIPTION
This PR updates our schema name generator so that schemas that start with numbers _are not_ prefixed with an underscore. The prefix underscore is designed to prevent invalid schemas (ones that start with numbers), but it is unnecessary for our use case since all dbt-generated schemas for non-main branches are prefixed with `dev_` or `ci_`.

Including the underscore prefix in the name generator results in schema names with repeated underscores when the feature branch is generated from an issue, i.e. `ci__70-create-reporting-view-with-most-recent-boundaries_census`.