### PR TITLE
Add deploy environment config to deploy_dbt_docs workflow

### DIFF
--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -5,6 +5,8 @@ on:
     workflows: [build-and-test-dbt]
     branches: [master]
     types: [completed]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 
 jobs:
@@ -17,7 +19,7 @@ jobs:
     permissions:
       pages: write      # To deploy to Pages
       id-token: write   # To verify the deployment comes from an valid source
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    # if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -10,6 +10,9 @@ on:
 jobs:
   deploy-dbt-docs:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     # These permissions are required to make a GitHub Pages deployment
     permissions:
       pages: write      # To deploy to Pages

--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -5,8 +5,6 @@ on:
     workflows: [build-and-test-dbt]
     branches: [master]
     types: [completed]
-  pull_request:
-    branches: [master]
   workflow_dispatch:
 
 jobs:
@@ -19,7 +17,7 @@ jobs:
     permissions:
       pages: write      # To deploy to Pages
       id-token: write   # To verify the deployment comes from an valid source
-    # if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Dan noticed that the [Deployments view](https://github.com/ccao-data/data-architecture/deployments) for this repo isn't showing any successful docs deployments to GitHub Pages, despite the fact that we can see successful runs for the [`deploy-dbt-docs` workflow](https://github.com/ccao-data/data-architecture/actions/workflows/deploy_dbt_docs.yaml). Comparing this repo to [assesspy](https://github.com/ccao-data/assesspy), I noticed that we're missing an `environment` attribute in the `deploy-dbt-docs` workflow, which I suspect is the culprit.

```yaml
    environment:
      name: github-pages
      url: ${{ steps.deployment.outputs.page_url }}
```

This PR adds an `environment` attribute to the `deploy-dbt-docs` workflow in order to get our Deployments view to show the correct status of our Pages deployments.

In order to test this change, I temporarily updated the deployment workflow to deploy from this PR in 59a994c. While the deployment failed due to environment branch protection rules, you can confirm in the [Deployments view](https://github.com/ccao-data/data-architecture/deployments) that we did in fact attempt a deployment from this commit.