### PR TITLE
Don't exit with a nonzero status when `delete-database` call returns 404 in cleanup workflow

### DIFF
--- a/.github/scripts/cleanup_dbt_resources.sh
+++ b/.github/scripts/cleanup_dbt_resources.sh
@@ -16,10 +16,9 @@ delete_database() {
         echo "$output"
         if [[ $output =~ "EntityNotFoundException" ]]; then
             # This case is expected, since it's likely that not all models
-            # will be built during CI runs. Exit with a non-255 status so
+            # will be built during CI runs. Suppress the error so
             # that xargs continues executing.
             echo "Continuing execution due to expected 404 response."
-            exit 254
         else
             exit 255  # Unexpected error; signal to xargs to quit
         fi


### PR DESCRIPTION
It turns out that https://github.com/ccao-data/data-architecture/issues/105 did not quite fix the issue described in #104. I had thought that `xargs` would continue execution and exit 0 if its subcommand returned a non-255 exit status, but it turns out that it continues execution and exits 123, which causes the workflow run to fail ([example](https://github.com/ccao-data/data-architecture/actions/runs/6026176207/job/16348510525#step:5:1)).

This PR adjusts the `EntityNotFoundException` conditional in `cleanup_dbt_resources.sh` so that we don't exit with a nonzero status in the case of a 404 response from the `aws glue delete-database` call.

Sample output demonstrating that this change works:

```console
(venv) jecochr@21CCAO-LAPTOP54:~/code/data-architecture/dbt$ ../.github/scripts/cleanup_dbt_resources.sh dev
Deleting the following schemas from Athena:

"dev_jecochr_census"
"dev_jecochr_default"
"dev_jecochr_location"
"dev_jecochr_model"
"dev_jecochr_proximity"
"dev_jecochr_reporting"
"dev_jecochr_rpie"

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database dev_jecochr_census not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database dev_jecochr_default not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database dev_jecochr_location not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database dev_jecochr_model not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database dev_jecochr_proximity not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database dev_jecochr_reporting not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database dev_jecochr_rpie not found.
Continuing execution due to expected 404 response.

Done!
(venv) jecochr@21CCAO-LAPTOP54:~/code/data-architecture/dbt$ echo $?
0
```