### PR TITLE
Fix `default.vw_card_res_char` tests to better match the reality of the view

### DIFF
--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
             echo "Running tests on modified/new resources only"
-            dbt test -t "$TARGET" -s state:modified state:new --state "$STATE_DIR"
+            dbt test -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR"
           else
             echo "Running tests on all resources"
             dbt test -t "$TARGET"

--- a/dbt/models/default/schema.yml
+++ b/dbt/models/default/schema.yml
@@ -69,27 +69,11 @@ models:
     tests:
       # Unique by card and year
       - dbt_utils.unique_combination_of_columns:
-          name: vw_card_res_char_unique_by_card_and_year
+          name: vw_card_res_char_unique_by_pin_card_and_year
           combination_of_columns:
+            - pin
             - year
             - card
-          config:
-            error_if: ">913"
-      # char_recent_renovation correlates with char_renovation
-      - expression_is_true:
-          name: vw_card_res_char_renovation_fields_match
-          # char_renovation can be null, which we count here as falsey
-          expression: >-
-            char_recent_renovation = (
-              case when char_renovation = '1' then true else false end
-            )
-          select_columns:
-            - card
-            - year
-            - char_renovation
-            - char_recent_renovation
-          config:
-            error_if: ">73942"
       # TODO: Characteristics columns should adhere to pre-determined criteria
   - name: default.vw_pin_address
     description: '{{ doc("vw_pin_address") }}'


### PR DESCRIPTION
In Teams discussion with Nicole and Billy, I discovered two small problems with our `default.vw_card_res_char` tests:

1. `vw_card_res_char_unique_by_card_and_year` is incorrect, since this table is actually unique by card, year, and _PIN_

> [12:46 PM] Nicole Jardine (Assessor)
> I believe this view is unique to pin, year, and card

2. `vw_card_res_char_renovation_fields_match` is not actually useful, since it's just checking derived data, and the logic that generates these data is much more complicated than a simple test like "`char_renovation` should be the same value as `char_recent_renovation`"

> [1:40 PM] Jean Cochrane (Assessor)
>
> I'm wondering if the test checking whether `char_renovation` matches `char_recent_renovation` in `default.vw_card_res_char` needs some refinement... currently we have a naive check to make sure that these fields match, but I think in theory its plausible for them not to match, right? E.g. if a card was not renovated in a given year, but it was renovated in the prior two years, then we would have char_renovation=0 and char_recent_renovation=true; or vice versa, if a card was renovated in a given year, and it was also renovated in the prior three years, then we would have char_renovation=0 and char_recent_renovation=false. Do either of these seem like plausible scenarios? I don't totally get what `char_renovation` is indicating so I expect my assumptions may be wrong!

> [1:41 PM] William Ridgeway (Assessor)
> you're exactly right that they can have different values, perhaps it's not even worth implementing a test since all it would be doing is reiterating the logic that's already defined in the original view

This PR adjusts these two tests to better reflect these properties of the underlying data, and to fix tests that are currently failing ([example](https://github.com/ccao-data/data-architecture/actions/runs/6036357813)).

We also make one quick tweak to the command that runs dbt tests in the case of a cache hit, which allows us to properly run tests against upstream models.