### PR TITLE
Refactor Athena table definitions to move them into the dbt DAG

### DIFF
--- a/.github/actions/setup_dbt/action.yaml
+++ b/.github/actions/setup_dbt/action.yaml
@@ -4,6 +4,10 @@ inputs:
   role-to-assume:
     description: AWS IAM role to assume when running dbt operations.
     required: true
+  role-duration-seconds:
+    description: Expiration time for AWS OIDC token. Default is one hour.
+    required: false
+    default: 3600
 runs:
   using: composite
   steps:
@@ -18,6 +22,7 @@ runs:
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: us-east-1
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure dbt environment
       uses: ./.github/actions/configure_dbt_environment

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          role-duration-seconds: 14400  # Worst-case time for full build
 
       - name: Restore dbt state cache
         id: cache

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -51,7 +51,7 @@ jobs:
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
             echo "Running build on modified/new resources only"
-            dbt run -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR"
+            dbt run -t "$TARGET" --select location.tax --defer --state "$STATE_DIR"
           else
             echo "Running build on all resources"
             dbt run -t "$TARGET"

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -51,7 +51,7 @@ jobs:
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
             echo "Running build on modified/new resources only"
-            dbt run -t "$TARGET" --select location.tax --defer --state "$STATE_DIR"
+            dbt run -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR"
           else
             echo "Running build on all resources"
             dbt run -t "$TARGET"

--- a/aws-athena/ctas/location-census.sql
+++ b/aws-athena/ctas/location-census.sql
@@ -1,22 +1,23 @@
-CREATE TABLE IF NOT EXISTS location.census
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION = 's3://ccao-athena-ctas-us-east-1/location/census',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH census AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years_rhs AS (
         SELECT DISTINCT year
-        FROM spatial.census
+        FROM {{ source('spatial', 'census') }}
     ),
 
     distinct_joined AS (
@@ -64,7 +65,7 @@ WITH (
             END) AS census_zcta_geoid,
             cen.year
         FROM distinct_pins AS dp
-        LEFT JOIN spatial.census AS cen
+        LEFT JOIN {{ source('spatial', 'census') }} AS cen
             ON ST_WITHIN(
                 ST_POINT(dp.x_3435, dp.y_3435),
                 ST_GEOMFROMBINARY(cen.geometry_3435)
@@ -89,10 +90,12 @@ WITH (
         dj.census_zcta_geoid,
         dj.year AS census_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     LEFT JOIN distinct_joined AS dj
         ON pcl.year = dj.year
         AND pcl.x_3435 = dj.x_3435
         AND pcl.y_3435 = dj.y_3435
     WHERE pcl.year >= (SELECT MIN(year) FROM distinct_years_rhs)
 )
+
+SELECT * FROM census

--- a/aws-athena/ctas/location-census_acs5.sql
+++ b/aws-athena/ctas/location-census_acs5.sql
@@ -94,16 +94,16 @@ WITH census_acs5 AS (
 
     SELECT
         pcl.pin10,
-        ayf.census_acs5_congressional_district_geoid,
-        ayf.census_acs5_county_subdivision_geoid,
-        ayf.census_acs5_place_geoid,
-        ayf.census_acs5_puma_geoid,
-        ayf.census_acs5_school_district_elementary_geoid,
-        ayf.census_acs5_school_district_secondary_geoid,
-        ayf.census_acs5_school_district_unified_geoid,
-        ayf.census_acs5_state_representative_geoid,
-        ayf.census_acs5_state_senate_geoid,
-        ayf.census_acs5_tract_geoid,
+        dj.census_acs5_congressional_district_geoid,
+        dj.census_acs5_county_subdivision_geoid,
+        dj.census_acs5_place_geoid,
+        dj.census_acs5_puma_geoid,
+        dj.census_acs5_school_district_elementary_geoid,
+        dj.census_acs5_school_district_secondary_geoid,
+        dj.census_acs5_school_district_unified_geoid,
+        dj.census_acs5_state_representative_geoid,
+        dj.census_acs5_state_senate_geoid,
+        dj.census_acs5_tract_geoid,
         dj.year AS census_acs5_data_year,
         pcl.year
     FROM {{ source('spatial', 'parcel') }} AS pcl

--- a/aws-athena/ctas/location-other.sql
+++ b/aws-athena/ctas/location-other.sql
@@ -1,28 +1,31 @@
-CREATE TABLE IF NOT EXISTS location.other
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION = 's3://ccao-athena-ctas-us-east-1/location/other',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH other AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years AS (
         SELECT DISTINCT year
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years_rhs AS (
-        SELECT DISTINCT '2021' AS year FROM spatial.subdivision
+        SELECT DISTINCT '2021' AS year
+        FROM {{ source('spatial', 'subdivision') }}
         UNION ALL
-        SELECT DISTINCT '2014' AS year FROM spatial.enterprise_zone
+        SELECT DISTINCT '2014' AS year
+        FROM {{ source('spatial', 'enterprise_zone') }}
     ),
 
     subdivision AS (
@@ -41,12 +44,12 @@ WITH (
                 SELECT
                     dy.year AS pin_year,
                     MAX(df.year) AS fill_year
-                FROM spatial.subdivision AS df
+                FROM {{ source('spatial', 'subdivision') }} AS df
                 CROSS JOIN distinct_years AS dy
                 WHERE dy.year >= df.year
                 GROUP BY dy.year
             ) AS fill_years
-            LEFT JOIN spatial.subdivision AS fill_data
+            LEFT JOIN {{ source('spatial', 'subdivision') }} AS fill_data
                 ON fill_years.fill_year = fill_data.year
         ) AS cprod
             ON ST_WITHIN(
@@ -61,10 +64,12 @@ WITH (
         sub.misc_subdivision_id,
         sub.misc_subdivision_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     LEFT JOIN subdivision AS sub
         ON pcl.x_3435 = sub.x_3435
         AND pcl.y_3435 = sub.y_3435
         AND pcl.year = sub.pin_year
     WHERE pcl.year >= (SELECT MIN(year) FROM distinct_years_rhs)
 )
+
+SELECT * FROM other

--- a/aws-athena/ctas/proximity-cnt_pin_num_bus_stop.sql
+++ b/aws-athena/ctas/proximity-cnt_pin_num_bus_stop.sql
@@ -1,31 +1,31 @@
 -- CTAS to create a table counting the number of bus stops within a half mile
 -- of each PIN
-CREATE TABLE IF NOT EXISTS proximity.cnt_pin_num_bus_stop
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-ctas-us-east-1/proximity/cnt_pin_num_bus_stop',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH cnt_pin_num_bus_stop AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years_rhs AS (
         SELECT DISTINCT year
-        FROM spatial.transit_stop
+        FROM {{ source('spatial', 'transit_stop') }}
         WHERE route_type = 3
     ),
 
     stop_locations AS (
         SELECT *
-        FROM spatial.transit_stop
+        FROM {{ source('spatial', 'transit_stop') }}
         WHERE route_type = 3
     ),
 
@@ -41,7 +41,7 @@ WITH (
                 ST_BUFFER(ST_GEOMFROMBINARY(loc.geometry_3435), 2640),
                 ST_POINT(dp.x_3435, dp.y_3435)
             )
-        GROUP BY dp.x_3435, dp.y_3435, dp.year
+        GROUP BY dp.x_3435, dp.y_3435, loc.year
     )
 
     SELECT
@@ -49,10 +49,12 @@ WITH (
         COALESCE(xy.num_bus_stop_in_half_mile, 0) AS num_bus_stop_in_half_mile,
         xy.year AS num_bus_stop_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     LEFT JOIN xy_stop_counts AS xy
         ON pcl.x_3435 = xy.x_3435
         AND pcl.y_3435 = xy.y_3435
         AND pcl.year = xy.year
     WHERE pcl.year >= (SELECT MIN(year) FROM distinct_years_rhs)
 )
+
+SELECT * FROM cnt_pin_num_bus_stop

--- a/aws-athena/ctas/proximity-crosswalk_year_fill.sql
+++ b/aws-athena/ctas/proximity-crosswalk_year_fill.sql
@@ -7,13 +7,9 @@ missing equivalent proximity data are filled thus:
    2021.
 2. Current data is filled BACKWARD to account for missing historical data.
 */
-CREATE TABLE IF NOT EXISTS proximity.crosswalk_year_fill
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-ctas-us-east-1/proximity/crosswalk_year_fill'
-) AS (
+{{ config(materialized='table') }}
+
+WITH crosswalk_year_fill AS (
     WITH unfilled AS (
         SELECT
             pin.year,
@@ -51,12 +47,13 @@ WITH (
                 AS nearest_railroad_data_year,
             MAX(dist_pin_to_water.nearest_water_data_year)
                 AS nearest_water_data_year
-        FROM (SELECT DISTINCT year FROM spatial.parcel) AS pin
+        FROM
+            (SELECT DISTINCT year FROM {{ source('spatial', 'parcel') }}) AS pin
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 num_bus_stop_data_year
-            FROM proximity.cnt_pin_num_bus_stop
+            FROM {{ ref('proximity.cnt_pin_num_bus_stop') }}
         ) AS cnt_pin_num_bus_stop ON pin.year = cnt_pin_num_bus_stop.year
         LEFT JOIN (
             SELECT DISTINCT
@@ -65,93 +62,93 @@ WITH (
                 -- which can't be used for joins
                 SUBSTR(num_foreclosure_data_year, 8, 11)
                     AS num_foreclosure_data_year
-            FROM proximity.cnt_pin_num_foreclosure
+            FROM {{ ref('proximity.cnt_pin_num_foreclosure') }}
         ) AS cnt_pin_num_foreclosure ON pin.year = cnt_pin_num_foreclosure.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 num_school_data_year,
                 num_school_rating_data_year
-            FROM proximity.cnt_pin_num_school
+            FROM {{ ref('proximity.cnt_pin_num_school') }}
         ) AS cnt_pin_num_school ON pin.year = cnt_pin_num_school.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_bike_trail_data_year
-            FROM proximity.dist_pin_to_bike_trail
+            FROM {{ ref('proximity.dist_pin_to_bike_trail') }}
         ) AS dist_pin_to_bike_trail ON pin.year = dist_pin_to_bike_trail.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_cemetery_data_year
-            FROM proximity.dist_pin_to_cemetery
+            FROM {{ ref('proximity.dist_pin_to_cemetery') }}
         ) AS dist_pin_to_cemetery ON pin.year = dist_pin_to_cemetery.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_cta_route_data_year
-            FROM proximity.dist_pin_to_cta_route
+            FROM {{ ref('proximity.dist_pin_to_cta_route') }}
         ) AS dist_pin_to_cta_route ON pin.year = dist_pin_to_cta_route.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_cta_stop_data_year
-            FROM proximity.dist_pin_to_cta_stop
+            FROM {{ ref('proximity.dist_pin_to_cta_stop') }}
         ) AS dist_pin_to_cta_stop ON pin.year = dist_pin_to_cta_stop.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_golf_course_data_year
-            FROM proximity.dist_pin_to_golf_course
+            FROM {{ ref('proximity.dist_pin_to_golf_course') }}
         ) AS dist_pin_to_golf_course ON pin.year = dist_pin_to_golf_course.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_hospital_data_year
-            FROM proximity.dist_pin_to_hospital
+            FROM {{ ref('proximity.dist_pin_to_hospital') }}
         ) AS dist_pin_to_hospital ON pin.year = dist_pin_to_hospital.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 lake_michigan_data_year
-            FROM proximity.dist_pin_to_lake_michigan
+            FROM {{ ref('proximity.dist_pin_to_lake_michigan') }}
         ) AS dist_pin_to_lake_michigan
             ON pin.year = dist_pin_to_lake_michigan.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_major_road_data_year
-            FROM proximity.dist_pin_to_major_road
+            FROM {{ ref('proximity.dist_pin_to_major_road') }}
         ) AS dist_pin_to_major_road ON pin.year = dist_pin_to_major_road.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_metra_route_data_year
-            FROM proximity.dist_pin_to_metra_route
+            FROM {{ ref('proximity.dist_pin_to_metra_route') }}
         ) AS dist_pin_to_metra_route ON pin.year = dist_pin_to_metra_route.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_metra_stop_data_year
-            FROM proximity.dist_pin_to_metra_stop
+            FROM {{ ref('proximity.dist_pin_to_metra_stop') }}
         ) AS dist_pin_to_metra_stop ON pin.year = dist_pin_to_metra_stop.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_park_data_year
-            FROM proximity.dist_pin_to_park
+            FROM {{ ref('proximity.dist_pin_to_park') }}
         ) AS dist_pin_to_park ON pin.year = dist_pin_to_park.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_railroad_data_year
-            FROM proximity.dist_pin_to_railroad
+            FROM {{ ref('proximity.dist_pin_to_railroad') }}
         ) AS dist_pin_to_railroad ON pin.year = dist_pin_to_railroad.year
         LEFT JOIN (
             SELECT DISTINCT
                 year,
                 nearest_water_data_year
-            FROM proximity.dist_pin_to_water
+            FROM {{ ref('proximity.dist_pin_to_water') }}
         ) AS dist_pin_to_water ON pin.year = dist_pin_to_water.year
 
         GROUP BY pin.year
@@ -260,3 +257,5 @@ WITH (
     FROM unfilled
     ORDER BY year
 )
+
+SELECT * FROM crosswalk_year_fill

--- a/aws-athena/ctas/proximity-dist_pin_to_bike_trail.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_bike_trail.sql
@@ -1,24 +1,24 @@
 -- CTAS to create a table of distance to the nearest bike trail for each PIN
-CREATE TABLE IF NOT EXISTS proximity.dist_pin_to_bike_trail
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-ctas-us-east-1/proximity/dist_pin_to_bike_trail',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH dist_pin_to_bike_trail AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years AS (
         SELECT DISTINCT year
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     bike_trail_location AS (
@@ -29,12 +29,12 @@ WITH (
             SELECT
                 dy.year AS pin_year,
                 MAX(df.year) AS fill_year
-            FROM spatial.bike_trail AS df
+            FROM {{ source('spatial', 'bike_trail') }} AS df
             CROSS JOIN distinct_years AS dy
             WHERE dy.year >= df.year
             GROUP BY dy.year
         ) AS fill_years
-        LEFT JOIN spatial.bike_trail AS fill_data
+        LEFT JOIN {{ source('spatial', 'bike_trail') }} AS fill_data
             ON fill_years.fill_year = fill_data.year
     ),
 
@@ -86,10 +86,12 @@ WITH (
         ARBITRARY(xy.dist_ft) AS nearest_bike_trail_dist_ft,
         ARBITRARY(xy.year) AS nearest_bike_trail_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     INNER JOIN xy_to_bike_trail_dist AS xy
         ON pcl.x_3435 = xy.x_3435
         AND pcl.y_3435 = xy.y_3435
         AND pcl.year = xy.pin_year
     GROUP BY pcl.pin10, pcl.year
 )
+
+SELECT * FROM dist_pin_to_bike_trail

--- a/aws-athena/ctas/proximity-dist_pin_to_cemetery.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_cemetery.sql
@@ -1,24 +1,24 @@
 -- CTAS to create a table of distance to the nearest cemetery for each PIN
-CREATE TABLE IF NOT EXISTS proximity.dist_pin_to_cemetery
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-ctas-us-east-1/proximity/dist_pin_to_cemetery',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH dist_pin_to_cemetery AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years AS (
         SELECT DISTINCT year
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     cemetery_location AS (
@@ -29,12 +29,12 @@ WITH (
             SELECT
                 dy.year AS pin_year,
                 MAX(df.year) AS fill_year
-            FROM spatial.cemetery AS df
+            FROM {{ source('spatial', 'cemetery') }} AS df
             CROSS JOIN distinct_years AS dy
             WHERE dy.year >= df.year
             GROUP BY dy.year
         ) AS fill_years
-        LEFT JOIN spatial.cemetery AS fill_data
+        LEFT JOIN {{ source('spatial', 'cemetery') }} AS fill_data
             ON fill_years.fill_year = fill_data.year
     ),
 
@@ -87,10 +87,12 @@ WITH (
         ARBITRARY(xy.dist_ft) AS nearest_cemetery_dist_ft,
         ARBITRARY(xy.year) AS nearest_cemetery_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     INNER JOIN xy_to_cemetery_dist AS xy
         ON pcl.x_3435 = xy.x_3435
         AND pcl.y_3435 = xy.y_3435
         AND pcl.year = xy.pin_year
     GROUP BY pcl.pin10, pcl.year
 )
+
+SELECT * FROM dist_pin_to_cemetery

--- a/aws-athena/ctas/proximity-dist_pin_to_cta_route.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_cta_route.sql
@@ -1,24 +1,24 @@
 -- CTAS to create a table of distance to the nearest CTA route for each PIN
-CREATE TABLE IF NOT EXISTS proximity.dist_pin_to_cta_route
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-ctas-us-east-1/proximity/dist_pin_to_cta_route',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH dist_pin_to_cta_route AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years AS (
         SELECT DISTINCT year
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     cta_route_location AS (
@@ -29,12 +29,12 @@ WITH (
             SELECT
                 dy.year AS pin_year,
                 MAX(df.year) AS fill_year
-            FROM spatial.transit_route AS df
+            FROM {{ source('spatial', 'transit_route') }} AS df
             CROSS JOIN distinct_years AS dy
             WHERE dy.year >= df.year
             GROUP BY dy.year
         ) AS fill_years
-        LEFT JOIN spatial.transit_route AS fill_data
+        LEFT JOIN {{ source('spatial', 'transit_route') }} AS fill_data
             ON fill_years.fill_year = fill_data.year
         WHERE fill_data.agency = 'cta'
             AND fill_data.route_type = 1
@@ -88,10 +88,12 @@ WITH (
         ARBITRARY(xy.dist_ft) AS nearest_cta_route_dist_ft,
         ARBITRARY(xy.year) AS nearest_cta_route_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     INNER JOIN xy_to_cta_route_dist AS xy
         ON pcl.x_3435 = xy.x_3435
         AND pcl.y_3435 = xy.y_3435
         AND pcl.year = xy.pin_year
     GROUP BY pcl.pin10, pcl.year
 )
+
+SELECT * FROM dist_pin_to_cta_route

--- a/aws-athena/ctas/proximity-dist_pin_to_cta_stop.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_cta_stop.sql
@@ -1,24 +1,24 @@
 -- CTAS to create a table of distance to the nearest CTA stop for each PIN
-CREATE TABLE IF NOT EXISTS proximity.dist_pin_to_cta_stop
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-ctas-us-east-1/proximity/dist_pin_to_cta_stop',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH dist_pin_to_cta_stop AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years AS (
         SELECT DISTINCT year
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     cta_stop_location AS (
@@ -29,12 +29,12 @@ WITH (
             SELECT
                 dy.year AS pin_year,
                 MAX(df.year) AS fill_year
-            FROM spatial.transit_stop AS df
+            FROM {{ source('spatial', 'transit_stop') }} AS df
             CROSS JOIN distinct_years AS dy
             WHERE dy.year >= df.year
             GROUP BY dy.year
         ) AS fill_years
-        LEFT JOIN spatial.transit_stop AS fill_data
+        LEFT JOIN {{ source('spatial', 'transit_stop') }} AS fill_data
             ON fill_years.fill_year = fill_data.year
         WHERE fill_data.agency = 'cta'
             AND fill_data.route_type = 1
@@ -88,10 +88,12 @@ WITH (
         ARBITRARY(xy.dist_ft) AS nearest_cta_stop_dist_ft,
         ARBITRARY(xy.year) AS nearest_cta_stop_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     INNER JOIN xy_to_cta_stop_dist AS xy
         ON pcl.x_3435 = xy.x_3435
         AND pcl.y_3435 = xy.y_3435
         AND pcl.year = xy.pin_year
     GROUP BY pcl.pin10, pcl.year
 )
+
+SELECT * FROM dist_pin_to_cta_stop

--- a/aws-athena/ctas/proximity-dist_pin_to_golf_course.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_golf_course.sql
@@ -1,24 +1,24 @@
 -- CTAS to create a table of distance to the nearest golf course for each PIN
-CREATE TABLE IF NOT EXISTS proximity.dist_pin_to_golf_course
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-ctas-us-east-1/proximity/dist_pin_to_golf_course',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH dist_pin_to_golf_course AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years AS (
         SELECT DISTINCT year
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     golf_course_location AS (
@@ -29,12 +29,12 @@ WITH (
             SELECT
                 dy.year AS pin_year,
                 MAX(df.year) AS fill_year
-            FROM spatial.golf_course AS df
+            FROM {{ source('spatial', 'golf_course') }} AS df
             CROSS JOIN distinct_years AS dy
             WHERE dy.year >= df.year
             GROUP BY dy.year
         ) AS fill_years
-        LEFT JOIN spatial.golf_course AS fill_data
+        LEFT JOIN {{ source('spatial', 'golf_course') }} AS fill_data
             ON fill_years.fill_year = fill_data.year
     ),
 
@@ -83,10 +83,12 @@ WITH (
         ARBITRARY(xy.dist_ft) AS nearest_golf_course_dist_ft,
         ARBITRARY(xy.year) AS nearest_golf_course_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     INNER JOIN xy_to_golf_course_dist AS xy
         ON pcl.x_3435 = xy.x_3435
         AND pcl.y_3435 = xy.y_3435
         AND pcl.year = xy.pin_year
     GROUP BY pcl.pin10, pcl.year
 )
+
+SELECT * FROM dist_pin_to_golf_course

--- a/aws-athena/ctas/proximity-dist_pin_to_hospital.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_hospital.sql
@@ -1,24 +1,24 @@
 -- CTAS to create a table of distance to the nearest hospital for each PIN
-CREATE TABLE IF NOT EXISTS proximity.dist_pin_to_hospital
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-ctas-us-east-1/proximity/dist_pin_to_hospital',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH dist_pin_to_hospital AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years AS (
         SELECT DISTINCT year
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     hospital_location AS (
@@ -29,12 +29,12 @@ WITH (
             SELECT
                 dy.year AS pin_year,
                 MAX(df.year) AS fill_year
-            FROM spatial.hospital AS df
+            FROM {{ source('spatial', 'hospital') }} AS df
             CROSS JOIN distinct_years AS dy
             WHERE dy.year >= df.year
             GROUP BY dy.year
         ) AS fill_years
-        LEFT JOIN spatial.hospital AS fill_data
+        LEFT JOIN {{ source('spatial', 'hospital') }} AS fill_data
             ON fill_years.fill_year = fill_data.year
     ),
 
@@ -87,10 +87,12 @@ WITH (
         ARBITRARY(xy.dist_ft) AS nearest_hospital_dist_ft,
         ARBITRARY(xy.year) AS nearest_hospital_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     INNER JOIN xy_to_hospital_dist AS xy
         ON pcl.x_3435 = xy.x_3435
         AND pcl.y_3435 = xy.y_3435
         AND pcl.year = xy.pin_year
     GROUP BY pcl.pin10, pcl.year
 )
+
+SELECT * FROM dist_pin_to_hospital

--- a/aws-athena/ctas/proximity-dist_pin_to_metra_route.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_metra_route.sql
@@ -1,24 +1,24 @@
 -- CTAS to create a table of distance to the nearest Metra route for each PIN
-CREATE TABLE IF NOT EXISTS proximity.dist_pin_to_metra_route
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-ctas-us-east-1/proximity/dist_pin_to_metra_route',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH dist_pin_to_metra_route AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years AS (
         SELECT DISTINCT year
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     metra_route_location AS (
@@ -29,12 +29,12 @@ WITH (
             SELECT
                 dy.year AS pin_year,
                 MAX(df.year) AS fill_year
-            FROM spatial.transit_route AS df
+            FROM {{ source('spatial', 'transit_route') }} AS df
             CROSS JOIN distinct_years AS dy
             WHERE dy.year >= df.year
             GROUP BY dy.year
         ) AS fill_years
-        LEFT JOIN spatial.transit_route AS fill_data
+        LEFT JOIN {{ source('spatial', 'transit_route') }} AS fill_data
             ON fill_years.fill_year = fill_data.year
         WHERE fill_data.agency = 'metra'
             AND fill_data.route_type = 2
@@ -88,10 +88,12 @@ WITH (
         ARBITRARY(xy.dist_ft) AS nearest_metra_route_dist_ft,
         ARBITRARY(xy.year) AS nearest_metra_route_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     INNER JOIN xy_to_metra_route_dist AS xy
         ON pcl.x_3435 = xy.x_3435
         AND pcl.y_3435 = xy.y_3435
         AND pcl.year = xy.pin_year
     GROUP BY pcl.pin10, pcl.year
 )
+
+SELECT * FROM dist_pin_to_metra_route

--- a/aws-athena/ctas/proximity-dist_pin_to_pin.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin.sql
@@ -1,12 +1,14 @@
 -- CTAS to find the 3 nearest neighbor PINs for every PIN for every year
-CREATE TABLE IF NOT EXISTS proximity.dist_pin_to_pin_temp
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-results-us-east-1/dist_pin_to_pin_temp',
-    PARTITIONED_BY = ARRAY['year']
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH dist_pin_to_pin AS (
     WITH pin_locations AS (
         SELECT
             pin10,
@@ -14,7 +16,7 @@ WITH (
             x_3435,
             y_3435,
             ST_POINT(x_3435, y_3435) AS point
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     most_recent_pins AS (
@@ -25,7 +27,7 @@ WITH (
             x_3435,
             y_3435,
             RANK() OVER (PARTITION BY pin10 ORDER BY year DESC) AS r
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_pins AS (
@@ -87,7 +89,7 @@ WITH (
                 WHEN pd.row_num = 4 THEN pd.dist
             END) AS nearest_neighbor_3_dist_ft,
             pcl.year
-        FROM spatial.parcel AS pcl
+        FROM {{ source('spatial', 'parcel') }} AS pcl
         INNER JOIN pin_dists AS pd
             ON pcl.x_3435 = pd.x_3435
             AND pcl.y_3435 = pd.y_3435
@@ -99,38 +101,4 @@ WITH (
         AND nearest_neighbor_3_pin10 IS NOT NULL
 )
 
--- Consolidate unbucketed files into single files and delete temp table
-CREATE TABLE IF NOT EXISTS proximity.dist_pin_to_pin
-WITH (
-    format='Parquet',
-    write_compression = 'SNAPPY',
-    external_location='s3://ccao-athena-ctas-us-east-1/proximity/dist_pin_to_pin',
-    partitioned_by = ARRAY['year'],
-    bucketed_by = ARRAY['pin10'],
-    bucket_count = 1
-) AS (
-    SELECT
-        pin10,
-        nearest_neighbor_1_pin10,
-        nearest_neighbor_1_dist_ft,
-        nearest_neighbor_2_pin10,
-        nearest_neighbor_2_dist_ft,
-        nearest_neighbor_3_pin10,
-        nearest_neighbor_3_dist_ft,
-        year
-    FROM proximity.dist_pin_to_pin_temp
-    UNION
-    SELECT
-        pin10,
-        nearest_neighbor_1_pin10,
-        nearest_neighbor_1_dist_ft,
-        nearest_neighbor_2_pin10,
-        nearest_neighbor_2_dist_ft,
-        nearest_neighbor_3_pin10,
-        nearest_neighbor_3_dist_ft,
-        year
-    FROM proximity.dist_pin_to_pin_temp2
-);
-
-DROP TABLE IF EXISTS proximity.dist_pin_to_pin_temp
-DROP TABLE IF EXISTS proximity.dist_pin_to_pin_temp2
+SELECT * FROM dist_pin_to_pin

--- a/aws-athena/ctas/proximity-dist_pin_to_railroad.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_railroad.sql
@@ -1,24 +1,24 @@
 -- CTAS to create a table of distance to the nearest rail tracks for each PIN
-CREATE TABLE IF NOT EXISTS proximity.dist_pin_to_railroad
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-ctas-us-east-1/proximity/dist_pin_to_railroad',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH dist_pin_to_railroad AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years AS (
         SELECT DISTINCT year
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     railroad_location AS (
@@ -29,12 +29,12 @@ WITH (
             SELECT
                 dy.year AS pin_year,
                 MAX(df.year) AS fill_year
-            FROM spatial.railroad AS df
+            FROM {{ source('spatial', 'railroad') }} AS df
             CROSS JOIN distinct_years AS dy
             WHERE dy.year >= df.year
             GROUP BY dy.year
         ) AS fill_years
-        LEFT JOIN spatial.railroad AS fill_data
+        LEFT JOIN {{ source('spatial', 'railroad') }} AS fill_data
             ON fill_years.fill_year = fill_data.year
     ),
 
@@ -86,10 +86,12 @@ WITH (
         ARBITRARY(xy.dist_ft) AS nearest_railroad_dist_ft,
         ARBITRARY(xy.year) AS nearest_railroad_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     INNER JOIN xy_to_railroad_dist AS xy
         ON pcl.x_3435 = xy.x_3435
         AND pcl.y_3435 = xy.y_3435
         AND pcl.year = xy.pin_year
     GROUP BY pcl.pin10, pcl.year
 )
+
+SELECT * FROM dist_pin_to_railroad

--- a/aws-athena/ctas/proximity-dist_pin_to_water.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_water.sql
@@ -1,24 +1,24 @@
 -- CTAS to create a table of distance to the nearest water for each PIN
-CREATE TABLE IF NOT EXISTS proximity.dist_pin_to_water
-WITH (
-    FORMAT = 'Parquet',
-    WRITE_COMPRESSION = 'SNAPPY',
-    EXTERNAL_LOCATION
-    = 's3://ccao-athena-ctas-us-east-1/proximity/dist_pin_to_water',
-    PARTITIONED_BY = ARRAY['year'],
-    BUCKETED_BY = ARRAY['pin10'],
-    BUCKET_COUNT = 1
-) AS (
+{{
+    config(
+        materialized='table',
+        partitioned_by=['year'],
+        bucketed_by=['pin10'],
+        bucket_count=1
+    )
+}}
+
+WITH dist_pin_to_water AS (
     WITH distinct_pins AS (
         SELECT DISTINCT
             x_3435,
             y_3435
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     distinct_years AS (
         SELECT DISTINCT year
-        FROM spatial.parcel
+        FROM {{ source('spatial', 'parcel') }}
     ),
 
     water_location AS (
@@ -29,12 +29,12 @@ WITH (
             SELECT
                 dy.year AS pin_year,
                 MAX(df.year) AS fill_year
-            FROM spatial.hydrology AS df
+            FROM {{ source('spatial', 'hydrology') }} AS df
             CROSS JOIN distinct_years AS dy
             WHERE dy.year >= df.year
             GROUP BY dy.year
         ) AS fill_years
-        LEFT JOIN spatial.hydrology AS fill_data
+        LEFT JOIN {{ source('spatial', 'hydrology') }} AS fill_data
             ON fill_years.fill_year = fill_data.year
     ),
 
@@ -86,10 +86,12 @@ WITH (
         ARBITRARY(xy.dist_ft) AS nearest_water_dist_ft,
         ARBITRARY(xy.year) AS nearest_water_data_year,
         pcl.year
-    FROM spatial.parcel AS pcl
+    FROM {{ source('spatial', 'parcel') }} AS pcl
     INNER JOIN xy_to_water_dist AS xy
         ON pcl.x_3435 = xy.x_3435
         AND pcl.y_3435 = xy.y_3435
         AND pcl.year = xy.pin_year
     GROUP BY pcl.pin10, pcl.year
 )
+
+SELECT * FROM dist_pin_to_water

--- a/aws-athena/views/location-vw_pin10_location.sql
+++ b/aws-athena/views/location-vw_pin10_location.sql
@@ -112,33 +112,33 @@ SELECT
     other.misc_subdivision_data_year
 
 FROM {{ source('spatial', 'parcel') }} AS pin
-LEFT JOIN {{ source('location', 'census') }} AS census
+LEFT JOIN {{ ref('location.census') }} AS census
     ON pin.pin10 = census.pin10
     AND pin.year = census.year
-LEFT JOIN {{ source('location', 'census_acs5') }} AS census_acs5
+LEFT JOIN {{ ref('location.census_acs5') }} AS census_acs5
     ON pin.pin10 = census_acs5.pin10
     AND pin.year = census_acs5.year
-LEFT JOIN {{ source('location', 'political') }} AS political
+LEFT JOIN {{ ref('location.political') }} AS political
     ON pin.pin10 = political.pin10
     AND pin.year = political.year
-LEFT JOIN {{ source('location', 'chicago') }} AS chicago
+LEFT JOIN {{ ref('location.chicago') }} AS chicago
     ON pin.pin10 = chicago.pin10
     AND pin.year = chicago.year
-LEFT JOIN {{ source('location', 'economy') }} AS economy
+LEFT JOIN {{ ref('location.economy') }} AS economy
     ON pin.pin10 = economy.pin10
     AND pin.year = economy.year
-LEFT JOIN {{ source('location', 'environment') }} AS environment
+LEFT JOIN {{ ref('location.environment') }} AS environment
     ON pin.pin10 = environment.pin10
     AND pin.year = environment.year
-LEFT JOIN {{ source('location', 'school') }} AS school
+LEFT JOIN {{ ref('location.school') }} AS school
     ON pin.pin10 = school.pin10
     AND pin.year = school.year
-LEFT JOIN {{ source('location', 'tax') }} AS tax
+LEFT JOIN {{ ref('location.tax') }} AS tax
     ON pin.pin10 = tax.pin10
     AND pin.year = tax.year
-LEFT JOIN {{ source('location', 'access') }} AS access
+LEFT JOIN {{ ref('location.access') }} AS access
     ON pin.pin10 = access.pin10
     AND pin.year = access.year
-LEFT JOIN {{ source('location', 'other') }} AS other
+LEFT JOIN {{ ref('location.other') }} AS other
     ON pin.pin10 = other.pin10
     AND pin.year = other.year

--- a/aws-athena/views/location-vw_pin10_location_fill.sql
+++ b/aws-athena/views/location-vw_pin10_location_fill.sql
@@ -105,77 +105,77 @@ SELECT
     other.misc_subdivision_id,
     other.misc_subdivision_data_year
 FROM {{ source('spatial', 'parcel') }} AS pin
-INNER JOIN {{ source('location', 'crosswalk_year_fill') }} AS cyf
+INNER JOIN {{ ref('location.crosswalk_year_fill') }} AS cyf
     ON pin.year = cyf.year
-LEFT JOIN {{ source('location', 'census') }} AS census
+LEFT JOIN {{ ref('location.census') }} AS census
     ON pin.pin10 = census.pin10
     AND cyf.census_data_year = census.year
-LEFT JOIN {{ source('location', 'census_acs5') }} AS census_acs5
+LEFT JOIN {{ ref('location.census_acs5') }} AS census_acs5
     ON pin.pin10 = census_acs5.pin10
     AND cyf.census_acs5_data_year = census_acs5.year
-LEFT JOIN {{ source('location', 'political') }} AS cook_board_of_review_district
+LEFT JOIN {{ ref('location.political') }} AS cook_board_of_review_district
     ON pin.pin10 = cook_board_of_review_district.pin10
     AND cyf.cook_board_of_review_district_data_year
     = cook_board_of_review_district.year
-LEFT JOIN {{ source('location', 'political') }} AS cook_commissioner_district
+LEFT JOIN {{ ref('location.political') }} AS cook_commissioner_district
     ON pin.pin10 = cook_commissioner_district.pin10
     AND cyf.cook_commissioner_district_data_year
     = cook_commissioner_district.year
-LEFT JOIN {{ source('location', 'political') }} AS cook_judicial_district
+LEFT JOIN {{ ref('location.political') }} AS cook_judicial_district
     ON pin.pin10 = cook_judicial_district.pin10
     AND cyf.cook_judicial_district_data_year = cook_judicial_district.year
-LEFT JOIN {{ source('location', 'political') }} AS ward_chicago
+LEFT JOIN {{ ref('location.political') }} AS ward_chicago
     ON pin.pin10 = ward_chicago.pin10
     AND cyf.ward_chicago_data_year = ward_chicago.year
-LEFT JOIN {{ source('location', 'political') }} AS ward_evanston
+LEFT JOIN {{ ref('location.political') }} AS ward_evanston
     ON pin.pin10 = ward_evanston.pin10
     AND cyf.ward_evanston_data_year = ward_evanston.year
-LEFT JOIN {{ source('location', 'chicago') }} AS chicago_community_area
+LEFT JOIN {{ ref('location.chicago') }} AS chicago_community_area
     ON pin.pin10 = chicago_community_area.pin10
     AND cyf.chicago_community_area_data_year = chicago_community_area.year
-LEFT JOIN {{ source('location', 'chicago') }} AS chicago_industrial_corridor
+LEFT JOIN {{ ref('location.chicago') }} AS chicago_industrial_corridor
     ON pin.pin10 = chicago_industrial_corridor.pin10
     AND cyf.chicago_industrial_corridor_data_year
     = chicago_industrial_corridor.year
-LEFT JOIN {{ source('location', 'chicago') }} AS chicago_police_district
+LEFT JOIN {{ ref('location.chicago') }} AS chicago_police_district
     ON pin.pin10 = chicago_police_district.pin10
     AND cyf.chicago_police_district_data_year = chicago_police_district.year
-LEFT JOIN {{ source('location', 'economy') }} AS econ_coordinated_care_area
+LEFT JOIN {{ ref('location.economy') }} AS econ_coordinated_care_area
     ON pin.pin10 = econ_coordinated_care_area.pin10
     AND cyf.econ_coordinated_care_area_data_year
     = econ_coordinated_care_area.year
-LEFT JOIN {{ source('location', 'economy') }} AS econ_enterprise_zone
+LEFT JOIN {{ ref('location.economy') }} AS econ_enterprise_zone
     ON pin.pin10 = econ_enterprise_zone.pin10
     AND cyf.econ_enterprise_zone_data_year = econ_enterprise_zone.year
-LEFT JOIN {{ source('location', 'economy') }} AS econ_industrial_growth_zone
+LEFT JOIN {{ ref('location.economy') }} AS econ_industrial_growth_zone
     ON pin.pin10 = econ_industrial_growth_zone.pin10
     AND cyf.econ_industrial_growth_zone_data_year
     = econ_industrial_growth_zone.year
-LEFT JOIN {{ source('location', 'economy') }} AS econ_qualified_opportunity_zone
+LEFT JOIN {{ ref('location.economy') }} AS econ_qualified_opportunity_zone
     ON pin.pin10 = econ_qualified_opportunity_zone.pin10
     AND cyf.econ_qualified_opportunity_zone_data_year
     = econ_qualified_opportunity_zone.year
-LEFT JOIN {{ source('location', 'environment') }} AS env_flood_fema
+LEFT JOIN {{ ref('location.environment') }} AS env_flood_fema
     ON pin.pin10 = env_flood_fema.pin10
     AND cyf.env_flood_fema_data_year = env_flood_fema.year
-LEFT JOIN {{ source('location', 'environment') }} AS env_flood_fs
+LEFT JOIN {{ ref('location.environment') }} AS env_flood_fs
     ON pin.pin10 = env_flood_fs.pin10
     AND cyf.env_flood_fs_data_year = env_flood_fs.year
-LEFT JOIN {{ source('location', 'environment') }} AS env_ohare_noise_contour
+LEFT JOIN {{ ref('location.environment') }} AS env_ohare_noise_contour
     ON pin.pin10 = env_ohare_noise_contour.pin10
     AND cyf.env_ohare_noise_contour_data_year = env_ohare_noise_contour.year
-LEFT JOIN {{ source('location', 'environment') }} AS env_airport_noise
+LEFT JOIN {{ ref('location.environment') }} AS env_airport_noise
     ON pin.pin10 = env_airport_noise.pin10
     AND cyf.env_airport_noise_data_year = env_airport_noise.year
-LEFT JOIN {{ source('location', 'school') }} AS school
+LEFT JOIN {{ ref('location.school') }} AS school
     ON pin.pin10 = school.pin10
     AND cyf.school_data_year = school.year
-LEFT JOIN {{ source('location', 'tax') }} AS tax
+LEFT JOIN {{ ref('location.tax') }} AS tax
     ON pin.pin10 = tax.pin10
     AND cyf.tax_data_year = tax.year
-LEFT JOIN {{ source('location', 'access') }} AS access
+LEFT JOIN {{ ref('location.access') }} AS access
     ON pin.pin10 = access.pin10
     AND cyf.access_cmap_walk_data_year = access.year
-LEFT JOIN {{ source('location', 'other') }} AS other
+LEFT JOIN {{ ref('location.other') }} AS other
     ON pin.pin10 = other.pin10
     AND cyf.misc_subdivision_data_year = other.year

--- a/aws-athena/views/proximity-vw_pin10_proximity.sql
+++ b/aws-athena/views/proximity-vw_pin10_proximity.sql
@@ -89,73 +89,67 @@ SELECT
 
 FROM {{ source('spatial', 'parcel') }} AS pin
 LEFT JOIN
-    {{ source('proximity', 'cnt_pin_num_bus_stop') }} AS cnt_pin_num_bus_stop
+    {{ ref('proximity.cnt_pin_num_bus_stop') }} AS cnt_pin_num_bus_stop
     ON pin.pin10 = cnt_pin_num_bus_stop.pin10
     AND pin.year = cnt_pin_num_bus_stop.year
 LEFT JOIN
-    {{ source('proximity', 'cnt_pin_num_foreclosure') }}
-        AS cnt_pin_num_foreclosure
+    {{ ref('proximity.cnt_pin_num_foreclosure') }} AS cnt_pin_num_foreclosure
     ON pin.pin10 = cnt_pin_num_foreclosure.pin10
     AND pin.year = cnt_pin_num_foreclosure.year
-LEFT JOIN {{ source('proximity', 'cnt_pin_num_school') }} AS cnt_pin_num_school
+LEFT JOIN {{ ref('proximity.cnt_pin_num_school') }} AS cnt_pin_num_school
     ON pin.pin10 = cnt_pin_num_school.pin10
     AND pin.year = cnt_pin_num_school.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_bike_trail') }}
-        AS dist_pin_to_bike_trail
+    {{ ref('proximity.dist_pin_to_bike_trail') }} AS dist_pin_to_bike_trail
     ON pin.pin10 = dist_pin_to_bike_trail.pin10
     AND pin.year = dist_pin_to_bike_trail.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_cemetery') }} AS dist_pin_to_cemetery
+    {{ ref('proximity.dist_pin_to_cemetery') }} AS dist_pin_to_cemetery
     ON pin.pin10 = dist_pin_to_cemetery.pin10
     AND pin.year = dist_pin_to_cemetery.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_cta_route') }} AS dist_pin_to_cta_route
+    {{ ref('proximity.dist_pin_to_cta_route') }} AS dist_pin_to_cta_route
     ON pin.pin10 = dist_pin_to_cta_route.pin10
     AND pin.year = dist_pin_to_cta_route.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_cta_stop') }} AS dist_pin_to_cta_stop
+    {{ ref('proximity.dist_pin_to_cta_stop') }} AS dist_pin_to_cta_stop
     ON pin.pin10 = dist_pin_to_cta_stop.pin10
     AND pin.year = dist_pin_to_cta_stop.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_golf_course') }}
-        AS dist_pin_to_golf_course
+    {{ ref('proximity.dist_pin_to_golf_course') }} AS dist_pin_to_golf_course
     ON pin.pin10 = dist_pin_to_golf_course.pin10
     AND pin.year = dist_pin_to_golf_course.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_hospital') }} AS dist_pin_to_hospital
+    {{ ref('proximity.dist_pin_to_hospital') }} AS dist_pin_to_hospital
     ON pin.pin10 = dist_pin_to_hospital.pin10
     AND pin.year = dist_pin_to_hospital.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_lake_michigan') }}
+    {{ ref('proximity.dist_pin_to_lake_michigan') }}
         AS dist_pin_to_lake_michigan
     ON pin.pin10 = dist_pin_to_lake_michigan.pin10
     AND pin.year = dist_pin_to_lake_michigan.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_major_road') }}
-        AS dist_pin_to_major_road
+    {{ ref('proximity.dist_pin_to_major_road') }} AS dist_pin_to_major_road
     ON pin.pin10 = dist_pin_to_major_road.pin10
     AND pin.year = dist_pin_to_major_road.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_metra_route') }}
-        AS dist_pin_to_metra_route
+    {{ ref('proximity.dist_pin_to_metra_route') }} AS dist_pin_to_metra_route
     ON pin.pin10 = dist_pin_to_metra_route.pin10
     AND pin.year = dist_pin_to_metra_route.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_metra_stop') }}
-        AS dist_pin_to_metra_stop
+    {{ ref('proximity.dist_pin_to_metra_stop') }} AS dist_pin_to_metra_stop
     ON pin.pin10 = dist_pin_to_metra_stop.pin10
     AND pin.year = dist_pin_to_metra_stop.year
-LEFT JOIN {{ source('proximity', 'dist_pin_to_park') }} AS dist_pin_to_park
+LEFT JOIN {{ ref('proximity.dist_pin_to_park') }} AS dist_pin_to_park
     ON pin.pin10 = dist_pin_to_park.pin10
     AND pin.year = dist_pin_to_park.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_railroad') }} AS dist_pin_to_railroad
+    {{ ref('proximity.dist_pin_to_railroad') }} AS dist_pin_to_railroad
     ON pin.pin10 = dist_pin_to_railroad.pin10
     AND pin.year = dist_pin_to_railroad.year
-LEFT JOIN {{ source('proximity', 'dist_pin_to_water') }} AS dist_pin_to_water
+LEFT JOIN {{ ref('proximity.dist_pin_to_water') }} AS dist_pin_to_water
     ON pin.pin10 = dist_pin_to_water.pin10
     AND pin.year = dist_pin_to_water.year
-LEFT JOIN {{ source('proximity', 'dist_pin_to_pin') }} AS dist_pin_to_pin
+LEFT JOIN {{ ref('proximity.dist_pin_to_pin') }} AS dist_pin_to_pin
     ON pin.pin10 = dist_pin_to_pin.pin10
     AND pin.year = dist_pin_to_pin.year

--- a/aws-athena/views/proximity-vw_pin10_proximity.sql
+++ b/aws-athena/views/proximity-vw_pin10_proximity.sql
@@ -150,6 +150,6 @@ LEFT JOIN
 LEFT JOIN {{ ref('proximity.dist_pin_to_water') }} AS dist_pin_to_water
     ON pin.pin10 = dist_pin_to_water.pin10
     AND pin.year = dist_pin_to_water.year
-LEFT JOIN {{ ref('proximity.dist_pin_to_pin') }} AS dist_pin_to_pin
+LEFT JOIN {{ source('proximity', 'dist_pin_to_pin') }} AS dist_pin_to_pin
     ON pin.pin10 = dist_pin_to_pin.pin10
     AND pin.year = dist_pin_to_pin.year

--- a/aws-athena/views/proximity-vw_pin10_proximity_fill.sql
+++ b/aws-athena/views/proximity-vw_pin10_proximity_fill.sql
@@ -88,79 +88,73 @@ SELECT
     dist_pin_to_pin.nearest_neighbor_3_dist_ft
 
 FROM {{ source('spatial', 'parcel') }} AS pin
-INNER JOIN {{ source('proximity', 'crosswalk_year_fill') }} AS cyf
+INNER JOIN {{ ref('proximity.crosswalk_year_fill') }} AS cyf
     ON pin.year = cyf.year
 LEFT JOIN
-    {{ source('proximity', 'cnt_pin_num_bus_stop') }} AS cnt_pin_num_bus_stop
+    {{ ref('proximity.cnt_pin_num_bus_stop') }} AS cnt_pin_num_bus_stop
     ON pin.pin10 = cnt_pin_num_bus_stop.pin10
     AND cyf.num_bus_stop_data_year = cnt_pin_num_bus_stop.year
 LEFT JOIN
-    {{ source('proximity', 'cnt_pin_num_foreclosure') }}
-        AS cnt_pin_num_foreclosure
+    {{ ref('proximity.cnt_pin_num_foreclosure') }} AS cnt_pin_num_foreclosure
     ON pin.pin10 = cnt_pin_num_foreclosure.pin10
     AND cyf.num_foreclosure_data_year = cnt_pin_num_foreclosure.year
-LEFT JOIN {{ source('proximity', 'cnt_pin_num_school') }} AS num_school
+LEFT JOIN {{ ref('proximity.cnt_pin_num_school') }} AS num_school
     ON pin.pin10 = num_school.pin10
     AND cyf.num_school_data_year = num_school.year
-LEFT JOIN {{ source('proximity', 'cnt_pin_num_school') }} AS num_school_rating
+LEFT JOIN {{ ref('proximity.cnt_pin_num_school') }} AS num_school_rating
     ON pin.pin10 = num_school_rating.pin10
     AND cyf.num_school_rating_data_year = num_school_rating.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_bike_trail') }}
-        AS dist_pin_to_bike_trail
+    {{ ref('proximity.dist_pin_to_bike_trail') }} AS dist_pin_to_bike_trail
     ON pin.pin10 = dist_pin_to_bike_trail.pin10
     AND cyf.nearest_bike_trail_data_year = dist_pin_to_bike_trail.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_cemetery') }} AS dist_pin_to_cemetery
+    {{ ref('proximity.dist_pin_to_cemetery') }} AS dist_pin_to_cemetery
     ON pin.pin10 = dist_pin_to_cemetery.pin10
     AND cyf.nearest_cemetery_data_year = dist_pin_to_cemetery.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_cta_route') }} AS dist_pin_to_cta_route
+    {{ ref('proximity.dist_pin_to_cta_route') }} AS dist_pin_to_cta_route
     ON pin.pin10 = dist_pin_to_cta_route.pin10
     AND cyf.nearest_cta_route_data_year = dist_pin_to_cta_route.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_cta_stop') }} AS dist_pin_to_cta_stop
+    {{ ref('proximity.dist_pin_to_cta_stop') }} AS dist_pin_to_cta_stop
     ON pin.pin10 = dist_pin_to_cta_stop.pin10
     AND cyf.nearest_cta_stop_data_year = dist_pin_to_cta_stop.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_golf_course') }}
-        AS dist_pin_to_golf_course
+    {{ ref('proximity.dist_pin_to_golf_course') }} AS dist_pin_to_golf_course
     ON pin.pin10 = dist_pin_to_golf_course.pin10
     AND cyf.nearest_golf_course_data_year = dist_pin_to_golf_course.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_hospital') }} AS dist_pin_to_hospital
+    {{ ref('proximity.dist_pin_to_hospital') }} AS dist_pin_to_hospital
     ON pin.pin10 = dist_pin_to_hospital.pin10
     AND cyf.nearest_hospital_data_year = dist_pin_to_hospital.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_lake_michigan') }}
+    {{ ref('proximity.dist_pin_to_lake_michigan') }}
         AS dist_pin_to_lake_michigan
     ON pin.pin10 = dist_pin_to_lake_michigan.pin10
     AND cyf.lake_michigan_data_year = dist_pin_to_lake_michigan.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_major_road') }}
-        AS dist_pin_to_major_road
+    {{ ref('proximity.dist_pin_to_major_road') }} AS dist_pin_to_major_road
     ON pin.pin10 = dist_pin_to_major_road.pin10
     AND cyf.nearest_major_road_data_year = dist_pin_to_major_road.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_metra_route') }}
-        AS dist_pin_to_metra_route
+    {{ ref('proximity.dist_pin_to_metra_route') }} AS dist_pin_to_metra_route
     ON pin.pin10 = dist_pin_to_metra_route.pin10
     AND cyf.nearest_metra_route_data_year = dist_pin_to_metra_route.year
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_metra_stop') }}
-        AS dist_pin_to_metra_stop
+    {{ ref('proximity.dist_pin_to_metra_stop') }} AS dist_pin_to_metra_stop
     ON pin.pin10 = dist_pin_to_metra_stop.pin10
     AND cyf.nearest_metra_stop_data_year = dist_pin_to_metra_stop.year
-LEFT JOIN {{ source('proximity', 'dist_pin_to_park') }} AS dist_pin_to_park
+LEFT JOIN {{ ref('proximity.dist_pin_to_park') }} AS dist_pin_to_park
     ON pin.pin10 = dist_pin_to_park.pin10
     AND cyf.nearest_park_data_year = dist_pin_to_park.year
-LEFT JOIN {{ source('proximity', 'dist_pin_to_pin') }} AS dist_pin_to_pin
+LEFT JOIN {{ ref('proximity.dist_pin_to_pin') }} AS dist_pin_to_pin
     ON pin.pin10 = dist_pin_to_pin.pin10
     AND cyf.year = dist_pin_to_pin.year -- NOTE, doesn't need to be filled
 LEFT JOIN
-    {{ source('proximity', 'dist_pin_to_railroad') }} AS dist_pin_to_railroad
+    {{ ref('proximity.dist_pin_to_railroad') }} AS dist_pin_to_railroad
     ON pin.pin10 = dist_pin_to_railroad.pin10
     AND cyf.nearest_railroad_data_year = dist_pin_to_railroad.year
-LEFT JOIN {{ source('proximity', 'dist_pin_to_water') }} AS dist_pin_to_water
+LEFT JOIN {{ ref('proximity.dist_pin_to_water') }} AS dist_pin_to_water
     ON pin.pin10 = dist_pin_to_water.pin10
     AND cyf.nearest_water_data_year = dist_pin_to_water.year

--- a/aws-athena/views/proximity-vw_pin10_proximity_fill.sql
+++ b/aws-athena/views/proximity-vw_pin10_proximity_fill.sql
@@ -148,7 +148,7 @@ LEFT JOIN
 LEFT JOIN {{ ref('proximity.dist_pin_to_park') }} AS dist_pin_to_park
     ON pin.pin10 = dist_pin_to_park.pin10
     AND cyf.nearest_park_data_year = dist_pin_to_park.year
-LEFT JOIN {{ ref('proximity.dist_pin_to_pin') }} AS dist_pin_to_pin
+LEFT JOIN {{ source('proximity', 'dist_pin_to_pin') }} AS dist_pin_to_pin
     ON pin.pin10 = dist_pin_to_pin.pin10
     AND cyf.year = dist_pin_to_pin.year -- NOTE, doesn't need to be filled
 LEFT JOIN

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -28,6 +28,8 @@ clean-targets:
 models:
   athena:
     +materialized: view
+    +write_compression: SNAPPY
+    +format: PARQUET
     census:
       +schema: census
     default:

--- a/dbt/models/default/schema.yml
+++ b/dbt/models/default/schema.yml
@@ -115,7 +115,7 @@ models:
             - mail_address_zipcode_1
             - mail_address_zipcode_2
           config:
-            error_if: ">880615"
+            error_if: ">880634"
       # TODO: Mailing address changes after validated sale(?)
       # TODO: Site addresses are all in Cook County
   - name: default.vw_pin_condo_char

--- a/dbt/models/location/location.access.sql
+++ b/dbt/models/location/location.access.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/location-access.sql

--- a/dbt/models/location/location.census.sql
+++ b/dbt/models/location/location.census.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/location-census.sql

--- a/dbt/models/location/location.census_acs5.sql
+++ b/dbt/models/location/location.census_acs5.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/location-census_acs5.sql

--- a/dbt/models/location/location.chicago.sql
+++ b/dbt/models/location/location.chicago.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/location-chicago.sql

--- a/dbt/models/location/location.crosswalk_year_fill.sql
+++ b/dbt/models/location/location.crosswalk_year_fill.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/location-crosswalk_year_fill.sql

--- a/dbt/models/location/location.economy.sql
+++ b/dbt/models/location/location.economy.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/location-economy.sql

--- a/dbt/models/location/location.environment.sql
+++ b/dbt/models/location/location.environment.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/location-environment.sql

--- a/dbt/models/location/location.other.sql
+++ b/dbt/models/location/location.other.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/location-other.sql

--- a/dbt/models/location/location.political.sql
+++ b/dbt/models/location/location.political.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/location-political.sql

--- a/dbt/models/location/location.school.sql
+++ b/dbt/models/location/location.school.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/location-school.sql

--- a/dbt/models/location/location.tax.sql
+++ b/dbt/models/location/location.tax.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/location-tax.sql

--- a/dbt/models/location/schema.yml
+++ b/dbt/models/location/schema.yml
@@ -1,22 +1,18 @@
 version: 2
 
 
-sources:
-  - name: location
-    tables:
-      - name: access
-      - name: census
-      - name: census_acs5
-      - name: chicago
-      - name: crosswalk_year_fill
-      - name: economy
-      - name: environment
-      - name: other
-      - name: political
-      - name: school
-      - name: tax
-
 models:
+  - name: location.access
+  - name: location.census
+  - name: location.census_acs5
+  - name: location.chicago
+  - name: location.crosswalk_year_fill
+  - name: location.economy
+  - name: location.environment
+  - name: location.other
+  - name: location.political
+  - name: location.school
+  - name: location.tax
   - name: location.vw_pin10_location
     description: '{{ doc("vw_pin10_location") }}'
     tests:

--- a/dbt/models/proximity/proximity.cnt_pin_num_bus_stop.sql
+++ b/dbt/models/proximity/proximity.cnt_pin_num_bus_stop.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-cnt_pin_num_bus_stop.sql

--- a/dbt/models/proximity/proximity.cnt_pin_num_foreclosure.sql
+++ b/dbt/models/proximity/proximity.cnt_pin_num_foreclosure.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-cnt_pin_num_foreclosure.sql

--- a/dbt/models/proximity/proximity.cnt_pin_num_school.sql
+++ b/dbt/models/proximity/proximity.cnt_pin_num_school.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-cnt_pin_num_school.sql

--- a/dbt/models/proximity/proximity.crosswalk_year_fill.sql
+++ b/dbt/models/proximity/proximity.crosswalk_year_fill.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-crosswalk_year_fill.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_bike_trail.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_bike_trail.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_bike_trail.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_cemetery.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_cemetery.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_cemetery.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_cta_route.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_cta_route.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_cta_route.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_cta_stop.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_cta_stop.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_cta_stop.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_golf_course.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_golf_course.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_golf_course.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_hospital.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_hospital.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_hospital.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_lake_michigan.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_lake_michigan.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_lake_michigan.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_major_road.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_major_road.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_major_road.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_metra_route.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_metra_route.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_metra_route.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_metra_stop.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_metra_stop.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_metra_stop.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_park.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_park.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_park.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_pin.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_pin.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_pin.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_pin.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_pin.sql
@@ -1,1 +1,0 @@
-../../../aws-athena/ctas/proximity-dist_pin_to_pin.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_railroad.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_railroad.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_railroad.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_water.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_water.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_water.sql

--- a/dbt/models/proximity/schema.yml
+++ b/dbt/models/proximity/schema.yml
@@ -1,28 +1,24 @@
 version: 2
 
 
-sources:
-  - name: proximity
-    tables:
-      - name: cnt_pin_num_bus_stop
-      - name: cnt_pin_num_foreclosure
-      - name: cnt_pin_num_school
-      - name: crosswalk_year_fill
-      - name: dist_pin_to_bike_trail
-      - name: dist_pin_to_cemetery
-      - name: dist_pin_to_cta_route
-      - name: dist_pin_to_cta_stop
-      - name: dist_pin_to_golf_course
-      - name: dist_pin_to_hospital
-      - name: dist_pin_to_lake_michigan
-      - name: dist_pin_to_major_road
-      - name: dist_pin_to_metra_route
-      - name: dist_pin_to_metra_stop
-      - name: dist_pin_to_park
-      - name: dist_pin_to_pin
-      - name: dist_pin_to_railroad
-      - name: dist_pin_to_water
-
 models:
+  - name: proximity.cnt_pin_num_bus_stop
+  - name: proximity.cnt_pin_num_foreclosure
+  - name: proximity.cnt_pin_num_school
+  - name: proximity.crosswalk_year_fill
+  - name: proximity.dist_pin_to_bike_trail
+  - name: proximity.dist_pin_to_cemetery
+  - name: proximity.dist_pin_to_cta_route
+  - name: proximity.dist_pin_to_cta_stop
+  - name: proximity.dist_pin_to_golf_course
+  - name: proximity.dist_pin_to_hospital
+  - name: proximity.dist_pin_to_lake_michigan
+  - name: proximity.dist_pin_to_major_road
+  - name: proximity.dist_pin_to_metra_route
+  - name: proximity.dist_pin_to_metra_stop
+  - name: proximity.dist_pin_to_park
+  - name: proximity.dist_pin_to_pin
+  - name: proximity.dist_pin_to_railroad
+  - name: proximity.dist_pin_to_water
   - name: proximity.vw_pin10_proximity
   - name: proximity.vw_pin10_proximity_fill

--- a/dbt/models/proximity/schema.yml
+++ b/dbt/models/proximity/schema.yml
@@ -1,6 +1,11 @@
 version: 2
 
 
+sources:
+  - name: proximity
+    tables:
+      - name: dist_pin_to_pin
+
 models:
   - name: proximity.cnt_pin_num_bus_stop
   - name: proximity.cnt_pin_num_foreclosure
@@ -17,7 +22,6 @@ models:
   - name: proximity.dist_pin_to_metra_route
   - name: proximity.dist_pin_to_metra_stop
   - name: proximity.dist_pin_to_park
-  - name: proximity.dist_pin_to_pin
   - name: proximity.dist_pin_to_railroad
   - name: proximity.dist_pin_to_water
   - name: proximity.vw_pin10_proximity

--- a/dbt/models/spatial/schema.yml
+++ b/dbt/models/spatial/schema.yml
@@ -16,7 +16,7 @@ sources:
       - name: congressional_district
       - name: coordinated_care
       - name: county
-      - name: enterprize_zone
+      - name: enterprise_zone
       - name: fire_protection_district
       - name: flood_fema
       - name: geojson

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -3,8 +3,9 @@ athena:
   outputs:
     dev:
       type: athena
-      s3_staging_dir: s3://ccao-dbt-athena-test-us-east-1/results/
-      s3_data_dir: s3://ccao-dbt-athena-test-us-east-1/data/
+      s3_staging_dir: s3://ccao-dbt-athena-dev-us-east-1/results/
+      s3_data_dir: s3://ccao-dbt-athena-dev-us-east-1/data/
+      s3_data_naming: schema_table
       region_name: us-east-1
       # "schema" here corresponds to a Glue database
       schema: dbt-test
@@ -15,17 +16,16 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-ci-us-east-1/results/
       s3_data_dir: s3://ccao-dbt-athena-ci-us-east-1/data/
+      s3_data_naming: schema_table
       region_name: us-east-1
       schema: dbt-test
       database: awsdatacatalog
-      # Prefix all generated data by schema, so that we can delete it when the
-      # PR is merged
-      s3_data_naming: schema_table
       threads: 5
     prod:
       type: athena
       s3_staging_dir: s3://ccao-athena-results-us-east-1/
-      s3_data_dir: s3://ccao-athena-data-us-east-1/
+      s3_data_dir: s3://ccao-athena-ctas-us-east-1/
+      s3_data_naming: schema_table
       region_name: us-east-1
       schema: default
       database: awsdatacatalog


### PR DESCRIPTION
# Overview

This PR adds symlinks and dbt model definitions for the Athena tables defined in the `aws-athena/ctas/` directory. It also tweaks those table definitions to fit them into the DAG and properly define their lineage.

## Additional complexities

Note that this change introduces two new areas of complexity to our dbt environments:

### 1. More resources to clean up

Since Athena `CREATE TABLE AS` statements store their output in S3, and since we expect to occasionally rebuild these tables as part of CI runs, we need to add an additional layer on top of the [`cleanup_dbt_resources.sh` script](https://github.com/ccao-data/data-architecture/blob/0424d980316a53a5403bd722ba749a05d99aaeb9/.github/scripts/cleanup_dbt_resources.sh#L1-L55) that is run on CI in order to clean up S3 resources that may be created on CI as part of the model building process. In order to handle this, I've added a new lifecycle rule to the `ccao-dbt-athena-ci-us-east-1` bucket to delete all old data with the `data/` prefix after 30 days, which should be more than enough time to close any PRs that may make use of those data.

Note that I did not add a corresponding lifecycle rule to the `ccao-dbt-athena-dev-us-east-1` bucket; my reasoning is that it's more likely that developers will want to persist their development table state over the long term.

### 2. More complex state selection for local development

These tables are more complicated to keep in the DAG than the views defined in `aws-athena/views/`, since the processing they perform is CPU intensive and they need to store their table output in S3. We shouldn't need to worry about this on CI since we use [deferral](https://docs.getdbt.com/reference/node-selection/defer) and [state selection](https://docs.getdbt.com/reference/node-selection/methods#the-state-method) to avoid rebuilding models unless they are new or have changed, but we will need an additional layer of safeguards for local development to ensure that developers who are less experienced with dbt don't accidentally waste time and resources rebuilding these tables unnecessarily.

To this end, we plan to introduce a wrapper script around dbt that beginning dbt developers can use to abstract away the complexity of remote state management.

Closes https://github.com/ccao-data/data-architecture/issues/101.