### PR TITLE
Add dbt wrapper script to facilitate local development

### DIFF
--- a/dbt/.gitignore
+++ b/dbt/.gitignore
@@ -5,3 +5,4 @@ target/
 dbt_modules/
 dbt_packages/
 assets/*.svg
+.remote_state/

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -42,12 +42,22 @@ You must also authenticate with AWS using MFA if you haven't already today:
 aws-mfa
 ```
 
+The following commands use the `dbt` wrapper script defined in this library
+rather than the native `dbt` binary in order to run dbt Core commands. The
+wrapper script abstracts away some of the options required to run development
+commands without needing to build all of the tables in the DAG, which can
+take a long time. We recommend that anyone who does not feel comfortable with
+[dbt state
+selection](https://docs.getdbt.com/reference/node-selection/methods#the-state-method)
+use the wrapper script instead of the native binary, but if you feel comfortable
+managing your own state, you can forego the wrapper script.
+
 ### Build tables and views
 
 Build the models to create tables and views in our Athena warehouse:
 
 ```
-dbt run
+./dbt run
 ```
 
 By default, all `dbt` commands will run against the `dev` environment, which
@@ -57,32 +67,19 @@ when `dbt` is run on Jean's machine). To instead **run commands against prod**,
 use the `--target` flag:
 
 ```
-dbt run --target prod
+./dbt run --target prod
 ```
 
 ### Generate documentation
 
-Note that we configure dbt's [`asset-paths`
-attribute](https://docs.getdbt.com/reference/project-configs/asset-paths) in
-order to link to images in our documentation. Some of those images, like the
-Mermaid diagram defined in `assets/dataflow-diagram.md`, are generated
-automatically during the `deploy-dbt-docs` deployment workflow. To generate
-them locally, make sure you have
-[`mermaid-cli`](https://github.com/mermaid-js/mermaid-cli) installed (we
-recommend a [local
-installation](https://github.com/mermaid-js/mermaid-cli#install-locally)) and
-run the following command:
+Generating documentation requires that [Node and
+npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+be installed with a Node version >= 16 in order to generate bundled images.
 
-```bash
-for file in assets/*.mmd; do
-  ./node_modules/.bin/mmdc -i "$file" -o "${file/.mmd/.svg}"
-done
-```
-
-Then, generate the documentation:
+Once you have Node and npm installed, generate the documentation:
 
 ```
-dbt docs generate
+./dbt docs generate
 ```
 
 This will create a set of static files in the `target/` subdirectory that can
@@ -91,7 +88,7 @@ be used to serve the docs site.
 To serve the docs locally:
 
 ```
-dbt docs serve
+./dbt docs serve
 ```
 
 Then, navigate to http://localhost:8080 to view the site.
@@ -101,19 +98,19 @@ Then, navigate to http://localhost:8080 to view the site.
 Run the tests:
 
 ```
-dbt test
+./dbt test
 ```
 
 Run tests for only one model:
 
 ```
-dbt test --select <model_name>
+./dbt test --select <model_name>
 ```
 
 Run tests for dbt macros:
 
 ```
-dbt run-operation test_all
+./dbt run-operation test_all
 ```
 
 #### Debugging dbt test failures
@@ -128,7 +125,7 @@ the data specification.
 To edit or run the query underlying a test, first run the test in isolation:
 
 ```
-dbt test --select <test_name>
+./dbt test --select <test_name>
 ```
 
 Then, navigate to the [Recent

--- a/dbt/dbt
+++ b/dbt/dbt
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+USAGE=$(cat << END
+Usage: ./dbt [OPTIONS] [COMMAND] [COMMAND_OPTIONS]
+
+    Thin wrapper around dbt to ensure that we defer to prod state when possible.
+    Accepts most options that the dbt command accepts, in addition to
+    the options listed below that are specific to this wrapper command.
+
+    For documentation of underlying dbt commands, run dbt --help or
+    dbt <subcommand> --help without using this script.
+
+Options:
+    --sync      Force a sync of the remote state to your local machine, so that
+                the local state cache reflects the state of the remote cache.
+                When running this command without the --sync option, a sync
+                will still be performed if no local cache is found, but the
+                --sync option can be useful if you would like to force an
+                update of a local cache that already exists.
+    -h, --help  Show this message and exit.
+
+Commands:
+    docs:          Generate or serve the documentation website for your project.
+    run:           Compile SQL and execute against the current target database.
+    run-operation: Run the named macro with any supplied arguments.
+    test:          Runs tests on data in deployed models.
+
+Command options:
+    For command options, run dbt <command> -h.
+END
+)
+STATE_COMPARISON_BUCKET="s3://ccao-dbt-cache-us-east-1/master-cache"
+STATE_COMPARISON_DIR=".remote_state/"
+TARGET_DIR="target/"
+
+sync_local_cache() {
+    aws s3 cp "$STATE_COMPARISON_BUCKET" "$STATE_COMPARISON_DIR" --recursive
+}
+
+if [[ "$#" -eq 0 ]]; then
+    echo "$USAGE"
+    echo
+    echo "Error: Missing required arguments"
+    exit 1
+fi
+
+case "$1" in
+
+    "-h" | "--help")
+        echo "$USAGE"
+        ;;
+
+    "--sync")
+        rm -Rf "$STATE_COMPARISON_DIR"
+        echo "Syncing local dbt state with the remote cache..."
+        sync_local_cache
+        echo "Sync complete!"
+        ;;
+
+    "run-operation")
+        # shellcheck disable=SC2068
+        dbt $@
+        ;;
+
+    "docs")
+        shift
+        if [ -z "${1+x}" ]; then
+            echo "$USAGE"
+            echo
+            echo "Error: Missing required docs subcommand"
+            exit 1
+        else
+            subcommand="$1"
+            shift
+            if [[ "$subcommand" == "generate" ]]; then
+                mmdc_cmd=""
+                global_mmdc="mmdc"
+                local_mmdc="./node_modules/.bin/mmdc"
+                if command -v "$global_mmdc" &> /dev/null; then
+                    mmdc_cmd=$global_mmdc
+                elif [ -f "$local_mmdc" ]; then
+                    mmdc_cmd=$local_mmdc
+                else
+                    if ! command -v npm &> /dev/null; then
+                        echo "$USAGE"
+                        echo
+                        echo "Error: Missing required npm installation. Install"
+                        echo "npm with Node >= 16:"
+                        echo
+                        echo "https://docs.npmjs.com/downloading-and-installing-node-js-and-npm"
+                        exit 1
+                    else
+                        echo "mermaid-cli not found, installing using npm..."
+                        echo
+                        npm install @mermaid-js/mermaid-cli
+                        mmdc_cmd=$local_mmdc
+                    fi
+                fi
+
+                for file in assets/*.mmd; do
+                    $mmdc_cmd -i "$file" -o "${file/.mmd/.svg}"
+                done
+
+                echo "Using prod target for docs generation, since dbt does not"
+                echo "support state selectors for this command. If you'd like"
+                echo "to generate docs based on a development environment, use"
+                echo "the native 'dbt docs generate' command instead."
+                echo
+                # We don't need to double quote the array expansion since we
+                # want it to be re-split in order to parse the dbt arguments
+                # correctly.
+                # shellcheck disable=SC2068
+                dbt docs generate --target prod $@
+            elif [[ "$subcommand" == "serve" ]]; then
+                # shellcheck disable=SC2068
+                dbt docs serve $@
+            else
+                echo "$USAGE"
+                echo
+                echo "Error: Docs subcommand $subcommand not recognized"
+                exit 1
+            fi
+        fi
+        ;;
+
+    "run" | "test")
+        if [ ! -d "$STATE_COMPARISON_DIR" ]; then
+            echo "Local state cache not found, syncing with the remote"
+            sync_local_cache
+            echo "Sync complete!"
+        fi
+
+        extra_args=""
+        if [[ "$1" == "run" ]]; then
+            # We only care about selecting only modified/new resources in the
+            # case of the build step, where there is a penalty to building
+            # unmodified models. In the case of tests, this is unnecessary.
+            extra_args="-s state:modified state:new"
+        fi
+
+        # shellcheck disable=SC2068
+        dbt $@ --defer --state "$STATE_COMPARISON_DIR" "$extra_args"
+
+        # Keep the local state comparison dir in sync with the latest dbt state
+        rm -Rf "$STATE_COMPARISON_DIR"
+        cp -R "$TARGET_DIR" "$STATE_COMPARISON_DIR"
+        ;;
+
+    *)
+        echo "Error: Subcommand $1 is not supported, use dbt binary instead"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This PR adds a wrapper script around `dbt` that developers can use to leverage [deferral](https://docs.getdbt.com/reference/node-selection/defer) and [state selection techniques](https://docs.getdbt.com/reference/node-selection/methods#the-state-method) without having to understand how they work in detail.

Connects https://github.com/ccao-data/data-architecture/pull/111.