### PR TITLE
114 add condo units with negative predicted values to declared livable/non livable spaces tables

### DIFF
--- a/aws-athena/views/default-vw_pin_condo_char.sql
+++ b/aws-athena/views/default-vw_pin_condo_char.sql
@@ -339,7 +339,7 @@ SELECT DISTINCT
                 AND prior_values.oneyr_pri_board_tot BETWEEN 10 AND 5000
             )
             OR prior_values.oneyr_pri_board_tot BETWEEN 10 AND 1000
-            OR nonlivable.flag = "negative pred"
+            OR nonlivable.flag = 'negative pred'
         )
         AND nonlivable.flag != 'questionable'
             THEN 1

--- a/aws-athena/views/default-vw_pin_condo_char.sql
+++ b/aws-athena/views/default-vw_pin_condo_char.sql
@@ -198,7 +198,9 @@ chars AS (
         condo units received (unused) negative predicted values. These units
         were non-livable units incorrectly classified as livable. They received
         negative predicted values due to their very low % of ownership. This CTE
-        excludes them from the model going forward. */
+        excludes them from the model going forward. 3) Questionable garage units
+        are those that have been deemed nonlivable by some part of our
+        nonlivable detection, but upon human review have been deemed livable. */
         LEFT JOIN {{ source('ccao', 'pin_nonlivable') }} AS nonlivable
             ON par.parid = nonlivable.pin
     )

--- a/aws-athena/views/default-vw_pin_condo_char.sql
+++ b/aws-athena/views/default-vw_pin_condo_char.sql
@@ -27,10 +27,11 @@ questionable_gr AS (
     FROM {{ source('ccao', 'pin_questionable_garage_units') }}
 ),
 
--- In the process of QC'ing condo data, we discovered that some condo units
--- received (unused) negative predicted values. These units were non-livable units
--- incorrectly classified as livable. They received negative predicted values due to 
--- their very low % of ownership. This CTE excludes them from the model going forward.
+/* In the process of QC'ing condo data, we discovered that some condo units
+received (unused) negative predicted values. These units were non-livable units
+incorrectly classified as livable. They received negative predicted values due
+to their very low % of ownership. This CTE excludes them from the model going
+forward. */
 negative_preds AS (
     SELECT
         pin,

--- a/aws-athena/views/default-vw_pin_condo_char.sql
+++ b/aws-athena/views/default-vw_pin_condo_char.sql
@@ -339,7 +339,7 @@ SELECT DISTINCT
                 AND prior_values.oneyr_pri_board_tot BETWEEN 10 AND 5000
             )
             OR prior_values.oneyr_pri_board_tot BETWEEN 10 AND 1000
-            OR negative_preds.is_negative_pred = TRUE
+            OR nonlivable.flag = "negative pred"
         )
         AND nonlivable.flag != 'questionable'
             THEN 1

--- a/aws-athena/views/default-vw_pin_condo_char.sql
+++ b/aws-athena/views/default-vw_pin_condo_char.sql
@@ -409,8 +409,9 @@ SELECT DISTINCT
             THEN 'prior value'
     END AS parking_space_flag_reason,
     COALESCE(prior_values.oneyr_pri_board_tot < 10, FALSE) AS is_common_area,
-    questionable_gr.is_question_garage_unit,
-    negative_preds.is_negative_pred,
+    COALESCE(questionable_gr.is_question_garage_unit, FALSE)
+        AS is_question_garage_unit,
+    COALESCE(negative_preds.is_negative_pred, FALSE) AS is_negative_pred,
     aggregate_land.pin_is_multiland,
     aggregate_land.pin_num_landlines
 

--- a/aws-athena/views/default-vw_pin_condo_char.sql
+++ b/aws-athena/views/default-vw_pin_condo_char.sql
@@ -27,7 +27,10 @@ questionable_gr AS (
     FROM {{ source('ccao', 'pin_questionable_garage_units') }}
 ),
 
--- Some condo PINs have been detected as non-livable through modeling
+-- In the process of QC'ing condo data, we discovered that some condo units
+-- received (unused) negative predicted values. These units were non-livable units
+-- incorrectly classified as livable. They received negative predicted values due to 
+-- their very low % of ownership. This CTE excludes them from the model going forward.
 negative_preds AS (
     SELECT
         pin,

--- a/aws-s3/renv.lock
+++ b/aws-s3/renv.lock
@@ -283,6 +283,7 @@
       "RemoteRef": "HEAD",
       "RemoteSha": "01f385846ced9fc19bd551ec08a9cf154e27a414",
       "Remotes": "gitlab::ccao-data-science---modeling/packages/ccao",
+      "Remotes": "gitlab::ccao-data-science---modeling/packages/ccao",
       "Requirements": [
         "R",
         "clustMixType",
@@ -290,7 +291,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "9025e171da3556544e81992556d916dc"
+      "Hash": "9e2572c96446390ece824fbb8de8267e"
     },
     "aws.s3": {
       "Package": "aws.s3",
@@ -506,6 +507,7 @@
       "RemoteRef": "HEAD",
       "RemoteSha": "69de1ec95d7848b8b17fdc9bd65a32498f4b0b55",
       "Remotes": "gitlab::ccao-data-science---modeling/packages/assessr",
+      "Remotes": "gitlab::ccao-data-science---modeling/packages/assessr",
       "Requirements": [
         "R",
         "assessr",
@@ -514,7 +516,7 @@
         "rlang",
         "tidyr"
       ],
-      "Hash": "a62510ef048d2f789fbc79602ef204d1"
+      "Hash": "405edea17a17c9a42ec8676d4fc899cc"
     },
     "cellranger": {
       "Package": "cellranger",
@@ -999,19 +1001,20 @@
       "Package": "geoarrow",
       "Version": "0.0.0.9000",
       "Source": "GitHub",
-      "Remotes": "paleolimbot/narrow",
       "RemoteType": "github",
+      "Remotes": "paleolimbot/narrow",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "geoarrow",
       "RemoteUsername": "paleolimbot",
       "RemoteRef": "HEAD",
       "RemoteSha": "feebf9608b0cb3786a19e8a857479e0f50607c26",
+      "Remotes": "paleolimbot/narrow",
       "Requirements": [
         "R",
         "narrow",
         "wk"
       ],
-      "Hash": "41b0d41d7933333b5b7958f46c3e3a66"
+      "Hash": "49116e61e478f3823d7ba370c808f191"
     },
     "geodist": {
       "Package": "geodist",
@@ -2408,29 +2411,6 @@
       ],
       "Hash": "709d852d33178db54b17c722e5b1e594"
     },
-    "ptaxsim": {
-      "Package": "ptaxsim",
-      "Version": "0.6.0",
-      "Source": "GitLab",
-      "RemoteType": "gitlab",
-      "RemoteHost": "gitlab.com",
-      "RemoteUsername": "ccao-data-science---modeling",
-      "RemoteRepo": "packages/ptaxsim",
-      "RemoteSubdir": "",
-      "RemoteRef": "master",
-      "RemoteSha": "fa13e59cdbfa757e5249e95e6d23b3edc0a2f6af",
-      "Remotes": "github::paleolimbot/geoarrow",
-      "Remotes": "github::paleolimbot/geoarrow",
-      "Requirements": [
-        "DBI",
-        "R",
-        "RSQLite",
-        "data.table",
-        "glue",
-        "utils"
-      ],
-      "Hash": "bbfa004e647beccbf3caae1df42ef134"
-    },
     "purrr": {
       "Package": "purrr",
       "Version": "1.0.1",
@@ -3017,6 +2997,7 @@
       "RemoteRef": "HEAD",
       "RemoteSha": "08e3d763b7bb2becfe5fc95f800b3767ea704439",
       "Remotes": "ropensci/tabulizerjars",
+      "Remotes": "ropensci/tabulizerjars",
       "Requirements": [
         "png",
         "rJava",
@@ -3024,7 +3005,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "0e051c194cb6b13b71e16d65a91a0b2b"
+      "Hash": "cddbfb62f19f59e4aa8b420156ae14b9"
     },
     "tabulizerjars": {
       "Package": "tabulizerjars",

--- a/aws-s3/scripts-ccao-data-raw-us-east-1/ccao-condominium_parking.R
+++ b/aws-s3/scripts-ccao-data-raw-us-east-1/ccao-condominium_parking.R
@@ -1,9 +1,10 @@
 library(arrow)
 library(aws.s3)
 library(dplyr)
-library(purrr)
 library(openxlsx)
+library(purrr)
 library(readr)
+library(tools)
 
 # This script retrieves raw condominium characteristics from the CCAO's O Drive
 # compiled by the valuations department
@@ -23,9 +24,6 @@ openxlsx::read.xlsx(
       )
     )
   )
-
-# Apply function to foreclosure data
-walk(source_files, read_write_questionable)
 
 ##### 399 GARAGE UNITS & NEGATIVE PREDICTED VALUE #####
 

--- a/aws-s3/scripts-ccao-data-raw-us-east-1/ccao-condominium_parking.R
+++ b/aws-s3/scripts-ccao-data-raw-us-east-1/ccao-condominium_parking.R
@@ -33,7 +33,7 @@ openxlsx::read.xlsx(
 # Retrieve data and write to S3
 file_path <- "O:/CCAODATA/data/condos"
 source_files <- file_path_sans_ext(list.files(file_path))
-map(source_files, function(x) {
+walk(source_files, function(x) {
 
   if (!aws.s3::object_exists(file.path(output_bucket, x, "2023.parquet"))) {
 

--- a/aws-s3/scripts-ccao-data-warehouse-us-east-1/ccao-condominium_parking.R
+++ b/aws-s3/scripts-ccao-data-warehouse-us-east-1/ccao-condominium_parking.R
@@ -11,109 +11,63 @@ AWS_S3_RAW_BUCKET <- Sys.getenv("AWS_S3_RAW_BUCKET")
 AWS_S3_WAREHOUSE_BUCKET <- Sys.getenv("AWS_S3_WAREHOUSE_BUCKET")
 output_bucket <- file.path(
   AWS_S3_WAREHOUSE_BUCKET,
-  "ccao", "condominium"
+  "ccao", "condominium", "pin_nonlivable"
 )
+
+files <- aws.s3::get_bucket_df(
+  AWS_S3_RAW_BUCKET,
+  prefix = "ccao/condominium/"
+) %>%
+  filter(stringr::str_ends(Key, ".parquet") & !str_detect(Key, "char")) %>%
+  mutate(Key = file.path(AWS_S3_RAW_BUCKET, Key)) %>%
+  pull(Key)
+
+nonlivable <- list()
 
 ##### QUESTIONABLE GARAGE UNITS #####
 
-# Get S3 file addresses
-files <- grep(
-  ".parquet",
-  file.path(
-    AWS_S3_RAW_BUCKET,
-    aws.s3::get_bucket_df(
-      AWS_S3_RAW_BUCKET,
-      prefix = "ccao/condominium/pin_questionable_garage_units/")$Key
-  ),
-  value = TRUE
-)
-
-# Function to read and amend questionable parking spaces
-read_questionable <- function(x) {
-
-  read_parquet(x) %>%
-    filter(!str_detect(X3, "storage") | is.na(X3)) %>%
-    mutate(year = tools::file_path_sans_ext(basename(x))) %>%
-    select("pin" = 1, "year") %>%
-    filter(str_detect(pin, "^[:digit:]+$")) %>%
-    mutate(pin = str_pad(pin, 14, side = 'left', pad = '0'))
-
-}
-
-# Load raw files, cleanup, then write to warehouse S3
-map(files, read_questionable) %>%
-  bind_rows() %>%
-  group_by(year) %>%
-  arrow::write_dataset(
-    path = file.path(output_bucket, "pin_questionable_garage_units"),
-    format = "parquet",
-    hive_style = TRUE,
-    compression = "snappy"
+nonlivable[["questionable"]] <- read_parquet(
+  grep("questionable", files, value = TRUE)
+) %>%
+  filter(!str_detect(X3, "storage") | is.na(X3)) %>%
+  mutate(year = "2022") %>%
+  select("pin" = 1, "year") %>%
+  filter(str_detect(pin, "^[:digit:]+$")) %>%
+  mutate(
+    pin = str_pad(pin, 14, side = "left", pad = "0"),
+    flag = "questionable"
   )
 
 ##### 399 GARAGE UNITS #####
 
-# Get S3 file addresses
-files <- grep(
-  ".parquet",
-  file.path(
-    AWS_S3_RAW_BUCKET,
-    aws.s3::get_bucket_df(
-      AWS_S3_RAW_BUCKET,
-      prefix = "ccao/condominium/pin_399_garage_units/")$Key
-  ),
-  value = TRUE
-)
-
-# Function to read and amend questionable parking spaces
-read_399s <- function(x) {
-
-  read_parquet(x) %>%
-    mutate(across(.cols = everything(), ~ as.character(.x))) %>%
-    rename_with(tolower)
-
-}
-
-# Load raw files, cleanup, then write to warehouse S3
-map(files, read_399s) %>%
-  bind_rows() %>%
-  group_by(taxyr) %>%
-  arrow::write_dataset(
-    path = file.path(output_bucket, "pin_399_garage_units"),
-    format = "parquet",
-    hive_style = TRUE,
-    compression = "snappy"
+nonlivable[["gr_399s"]] <- read_parquet(grep("399", files, value = TRUE)) %>%
+  select("pin" = "PARID", "year" = "TAXYR") %>%
+  mutate(
+    across(.cols = everything(), ~ as.character(.x)),
+    flag = "399 GR"
   )
 
 ##### NEGATIVE PREDICTED VALUES #####
 
-# Get S3 file addresses
-files <- grep(
-  ".parquet",
-  file.path(
-    AWS_S3_RAW_BUCKET,
-    aws.s3::get_bucket_df(
-      AWS_S3_RAW_BUCKET,
-      prefix = "ccao/condominium/pin_negative_predicted_value/")$Key
-  ),
-  value = TRUE
-)
-
-map(files, function(x) {
-
-  read_parquet(x) %>%
-    mutate(across(.cols = everything(), ~ as.character(.x))) %>%
-    rename_with(tolower) %>%
-    mutate(
-      pin = str_remove_all(pin, "-"),
-      taxyr = str_extract(x, "[0-9]{4}")
+nonlivable[["neg_pred"]] <- map(
+  grep("negative", files, value = TRUE), function(x) {
+    read_parquet(x) %>%
+      mutate(across(.cols = everything(), ~ as.character(.x))) %>%
+      mutate(
+        pin = str_remove_all(pin, "-"),
+        year = str_extract(x, "[0-9]{4}"),
+        flag = "negative pred"
       )
+  }
+) %>%
+  bind_rows()
 
-}) %>%
+# Upload all nonlivable spaces to nonlivable table
+nonlivable %>%
   bind_rows() %>%
-  group_by(taxyr) %>%
+  group_by(year) %>%
   arrow::write_dataset(
-    path = file.path(output_bucket, "pin_negative_predicted_value"),
+    path = output_bucket,
     format = "parquet",
     hive_style = TRUE,
     compression = "snappy"

--- a/dbt/models/ccao/schema.yml
+++ b/dbt/models/ccao/schema.yml
@@ -9,8 +9,6 @@ sources:
       - name: hie
       - name: land_nbhd_rate
       - name: land_site_rate
-      - name: pin_399_garage_units
       - name: pin_condo_char
-      - name: pin_negative_predicted_value
-      - name: pin_questionable_garage_units
+      - name: pin_nonlivable
       - name: pin_weird

--- a/dbt/models/ccao/schema.yml
+++ b/dbt/models/ccao/schema.yml
@@ -11,5 +11,6 @@ sources:
       - name: land_site_rate
       - name: pin_399_garage_units
       - name: pin_condo_char
+      - name: pin_negative_predicted_value
       - name: pin_questionable_garage_units
       - name: pin_weird


### PR DESCRIPTION
@carolinedavidson discovered some condo units with negative predicted values in her condo report. We believe these units are likely non-livable and should be treated as such during modeling, reporting, etc.

This PR adds this data to ingest scripts (`ccao-condominium_parking.R`), generates an Athena table for the data, and adds it to the Athena condo characteristics view (`default.vw_pin_condo_char`).