### PR TITLE
Flesh out docs on how to develop our data catalog

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-dbt-model.md
+++ b/.github/ISSUE_TEMPLATE/new-dbt-model.md
@@ -1,12 +1,10 @@
 ---
 name: Add a new dbt model
-about: Request the addition of a new model to the dbt DAG.
-title: ''
-labels: ''
-assignees: ''
+description: Request the addition of a new model to the dbt DAG.
+title: Add a new dbt model
 ---
 
-_(Replace or delete anything in parentheses with your own issue.)_
+_(Replace or delete anything in parentheses with your own issue content.)_
 
 # New dbt model
 
@@ -25,12 +23,12 @@ _(Brief description of the task here.)_
 * **Description**: _(Provide a rich description for this model that will be
   displayed in documentation. Markdown is supported, and encouraged for more
   complex models. See [Model
-  description](/ccao-data/data-architecture#model-description) for guidance.)
+  description](/ccao-data/data-architecture#model-description) for guidance.)_
 
 ## Short checklist
 
 _(Use this checklist if the assignee already knows how to add a dbt model.
-Otherwise, delete it in favor of the long checklist below.)_
+Otherwise, delete it in favor of the long checklist in the following section.)_
 
 - [ ] Define the SQL query that creates the model in the `aws-athena/` directory
   - [ ] Optionally configure model materialization
@@ -56,10 +54,10 @@ Complete the following checklist to add the model:
   while tables should live in `aws-athena/ctas/`. When naming the file for the
   query, the period in the model name that separates the entity name from the
   database namespace should be changed to a hyphen (e.g. `default.new_model`
-  should become `default-new_model` for the purposes of the SQL file name).
+  should become `default-new_model` for the purpose of the SQL file name).
 
 
-```console
+```bash
 # View example
 touch aws-athena/views/default-vw_new_model.sql
 
@@ -114,6 +112,16 @@ using (pin10, year)
   `dbt_project.yml` to document the new directory under the `models.athena`
   key with a `+schema` attribute.
 
+```yaml
+# Table example (only the model name would change for a view)
+# schema.yml
+version: 2
+
+
+models:
+  - name: default.new_model
+```
+
 ```diff
 # View or table example
 --- a/dbt/dbt_project.yml
@@ -131,7 +139,7 @@ using (pin10, year)
 - [ ] Add a symlink from the appropriate subfolder of the `dbt/models/`
   directory to the SQL query you created in the `aws-athena/` directory.
 
-```console
+```bash
 # View example
 ln -s aws-athena/views/default-vw_new_model.sql dbt/models/default/default.vw_new_model.sql
 
@@ -144,7 +152,7 @@ ln -s aws-athena/ctas/default-new_model.sql dbt/models/default/default.new_model
 
 
 ```diff
-# example
+# Table example (only the model name would change for a view)
 --- a/dbt/models/default/docs.md
 +++ b/dbt/models/default/docs.md
 

--- a/.github/ISSUE_TEMPLATE/new-dbt-model.md
+++ b/.github/ISSUE_TEMPLATE/new-dbt-model.md
@@ -1,0 +1,216 @@
+---
+name: Add a new dbt model
+about: Request the addition of a new model to the dbt DAG.
+title: ''
+labels: ''
+assignees: ''
+---
+
+_(Replace or delete anything in parentheses with your own issue.)_
+
+# New dbt model
+
+_(Brief description of the task here.)_
+
+## Model attributes
+
+* **Name**: _(What should the model be called? See [Model
+ naming](/ccao-data/data-architecture#model-naming) for guidance.)_
+* **Materialization**: _(Should the model be a table or a view? See [Model
+  materialization](/ccao-data/data-architecture#model-materialization) for
+  guidance.)_
+* **Tests**:
+  * _(Add a bulleted list of tests here. See [Model
+  tests](/ccao-data/data-architecture#model-tests) for guidance.)_
+* **Description**: _(Provide a rich description for this model that will be
+  displayed in documentation. Markdown is supported, and encouraged for more
+  complex models. See [Model
+  description](/ccao-data/data-architecture#model-description) for guidance.)
+
+## Short checklist
+
+_(Use this checklist if the assignee already knows how to add a dbt model.
+Otherwise, delete it in favor of the long checklist below.)_
+
+- [ ] Define the SQL query that creates the model in the `aws-athena/` directory
+  - [ ] Optionally configure model materialization
+- [ ] Confirm that a subdirectory for this model's database exists in
+  the `dbt/models/` directory, and if not, create one, add a new `schema.yml`
+  file, and update `dbt_project.yml` to document the `+schema`
+- [ ] Add a symlink from the appropriate subfolder of the `dbt/models/`
+  directory to the new SQL query in the `aws-athena/` directory
+- [ ] Add docs for the model to the subdirectory `docs.md` file
+- [ ] Update the `schema.yml` file in the subfolder of `dbt/models/` where you
+  created your symlink to add a definition for your model
+- [ ] Add tests to your new model definition in `schema.yml`
+- [ ] If your model definition requires any new macros, make sure those macros
+  are tested in `dbt/macros/tests/test_all.sql`
+- [ ] Commit your changes to a branch and open a pull request
+
+## Checklist
+
+Complete the following checklist to add the model:
+
+- [ ] Define the SQL query that creates the model in the appropriate subfolder
+  of the `aws-athena/` directory. Views should live in `aws-athena/views/`
+  while tables should live in `aws-athena/ctas/`. When naming the file for the
+  query, the period in the model name that separates the entity name from the
+  database namespace should be changed to a hyphen (e.g. `default.new_model`
+  should become `default-new_model` for the purposes of the SQL file name).
+
+
+```console
+# View example
+touch aws-athena/views/default-vw_new_model.sql
+
+# Table example
+touch aws-athena/ctas/default-new_model.sql
+```
+
+- [ ] Use
+  [`source()`](https://docs.getdbt.com/reference/dbt-jinja-functions/source)
+  and [`ref()`](https://docs.getdbt.com/reference/dbt-jinja-functions/ref) to
+  reference other models where possible in your query.
+
+
+```sql
+-- View or table example
+-- Either aws-athena/views/default-vw_new_model.sql
+-- or aws-athena/ctas/default-new_model.sql
+select pin10, year
+from {{ source('raw', 'foobar') }}
+join {{ ref('default.vw_pin_universe') }}
+using (pin10, year)
+```
+
+- [ ] Optionally configure model materialization. If the output of the query
+  should be a view, no action is necessary, since the default for all models in
+  this repo is to materialize as views; but if the output should be a table,
+  with table data stored in S3, then you'll need to add a config block to the
+  top of the view to configure materialization.
+
+```sql
+-- Table example
+-- aws-athena/ctas/default-new_model.sql
+{{
+  config(
+    materialized='table',
+    partitioned_by=['year'],
+    bucketed_by=['pin10'],
+    bucket_count=1
+  )
+}}
+select pin10, year
+from {{ source('raw', 'foobar') }}
+join {{ ref('default.vw_pin_universe') }}
+using (pin10, year)
+```
+
+- [ ] Confirm that a subdirectory for this model's database exists in
+  the `dbt/models/` directory (e.g. `dbt/models/default/` for
+  the `default.new_model` model). If a subdirectory does not yet exist, create
+  one, add a `schema.yml` file to the directory to store [model
+  properties](https://docs.getdbt.com/reference/model-properties), and update
+  `dbt_project.yml` to document the new directory under the `models.athena`
+  key with a `+schema` attribute.
+
+```diff
+# View or table example
+--- a/dbt/dbt_project.yml
++++ b/dbt/dbt_project.yml
+
+ models:
+   athena:
+     +materialized: view
++    default:
++      +schema: default
+     census:
+       +schema: census
+```
+
+- [ ] Add a symlink from the appropriate subfolder of the `dbt/models/`
+  directory to the SQL query you created in the `aws-athena/` directory.
+
+```console
+# View example
+ln -s aws-athena/views/default-vw_new_model.sql dbt/models/default/default.vw_new_model.sql
+
+# Table example
+ln -s aws-athena/ctas/default-new_model.sql dbt/models/default/default.new_model.sql
+```
+
+- [ ] Add or edit the docs file for the `dbt/models/` subdirectory your symlink
+  is in to add docs for your model.
+
+
+```diff
+# example
+--- a/dbt/models/default/docs.md
++++ b/dbt/models/default/docs.md
+
+ `spatial.township` is not yearly.
+ {% enddocs %}
+
++{% docs new_model %}
++
++Your Markdown docs go here.
++
++{% enddocs %}
++
+ {% docs vw_pin_value %}
+ CCAO mailed total, CCAO final, and BOR final values for each PIN by year.
+```
+
+- [ ] Update the `schema.yml` file in the subfolder of `dbt/models/` where you
+  created your symlink to add a definition for your model.
+
+```diff
+# Table example (only the model name would change for a view)
+--- a/dbt/models/default/schema.yml
++++ b/dbt/models/default/schema.yml
+
+ models:
++  - name: default.new_model
++    description: '{{ doc("new_model") }}'
++    columns:
++      - name: pin10
++        description: 10-digit PIN
++      - name: year
++        description: Year
+   - name: default.vw_pin_history
+     description: '{{ doc("vw_pin_history") }}'
+     tests:
+```
+
+- [ ] Add tests to your new model definition in `schema.yml`.
+
+```diff
+# Table example (only the model name would change for a view)
+--- a/dbt/models/default/schema.yml
++++ b/dbt/models/default/schema.yml
+
+ models:
+   - name: default.new_model
+     description: '{{ doc("new_model") }}'
+     columns:
+       - name: pin10
+         description: 10-digit PIN
+       - name: year
+         description: Year
++    tests:
++      - unique_combination_of_columns:
++        name: new_model_unique_by_pin_and_year
++        combination_of_columns:
++          - pin
++          - year
+   - name: default.vw_pin_history
+     description: '{{ doc("vw_pin_history") }}'
+     tests:
+```
+
+- [ ] If your model definition requires any new macros, make sure those macros
+  are tested in `dbt/macros/tests/test_all.sql`. If any tests need implementing,
+  follow the pattern set by existing tests to implement them.
+
+- [ ] Commit your changes to a branch and open a pull request to build your
+  model and run tests in a CI environment.

--- a/.github/ISSUE_TEMPLATE/new-dbt-model.md
+++ b/.github/ISSUE_TEMPLATE/new-dbt-model.md
@@ -54,7 +54,7 @@ Complete the following checklist to add the model:
   while tables should live in `aws-athena/ctas/`. When naming the file for the
   query, the period in the model name that separates the entity name from the
   database namespace should be changed to a hyphen (e.g. `default.new_model`
-  should become `default-new_model` for the purpose of the SQL file name).
+  should become `default-new_model` for the purpose of the SQL filename).
 
 
 ```bash
@@ -83,9 +83,9 @@ using (pin10, year)
 
 - [ ] Optionally configure model materialization. If the output of the query
   should be a view, no action is necessary, since the default for all models in
-  this repo is to materialize as views; but if the output should be a table,
-  with table data stored in S3, then you'll need to add a config block to the
-  top of the view to configure materialization.
+  this repository is to materialize as views; but if the output should be a
+  table, with table data stored in S3, then you'll need to add a config block
+  to the top of the view to configure materialization.
 
 ```sql
 -- Table example

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -374,7 +374,7 @@ There are two ways to clean up a PR's resources manually:
    data source that matches the database pattern for your pull request
    (i.e. prefixed with `ci_` plus the name of your branch) and click the
    `Delete` button in the top right-hand corner of the table.
-2. **Using the command line**: If the workflow has failed, it most likely means
+2. **Using the command-line**: If the workflow has failed, it most likely means
    there is a bug in the `.github/scripts/cleanup_dbt_resources.sh` script
    ([source code](../.github/scripts/cleanup_dbt_resources.sh)). Once you've
    identified and fixed the bug, confirm it works by running the following

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -3,7 +3,79 @@
 This directory stores the configuration for building our data catalog using
 [dbt](https://docs.getdbt.com/docs/core).
 
-## Installation
+## Quick links
+
+* [Background: What does the data catalog
+  do?](#background-what-does-the-data-catalog-do)
+* [How to develop the catalog](#how-to-develop-the-catalog)
+* [How to add a new model](#how-to-add-a-new-model)
+* [Debugging tips](#debugging-tips)
+* [Data documentation](https://ccao-data.github.io/data-architecture)
+* [Design doc for our decision to develop our catalog with
+  dbt](../documentation/design-docs/data-catalog.md)
+
+## Background: What does the data catalog do?
+
+The data catalog accomplishes a few main goals:
+
+### 1. Store our data transformations as a directed acyclic graph (DAG)
+
+The models defined in [`models/`](./models/) represent the SQL operations that
+we run in order to transform raw data into output data for use in statistical
+modeling and reporting. These transformations comprise a DAG that we use for
+documenting our data and rebuilding it efficiently. We use the [`dbt
+run`](https://docs.getdbt.com/reference/commands/run) command to build these
+models into Athena views and tables.
+
+Note that when we talk about "models" in these docs, we generally mean to
+discuss [the resources that dbt calls
+"models"](https://docs.getdbt.com/docs/build/models), namely the definitions of
+the tables and views in our Athena warehouse. In contrast, we will use the
+phrase "statistical models" wherever we mean to discuss the algorithms that we
+use to predict property values.
+
+### 2. Define integrity checks that specify the correct format for our data
+
+The tests defined in the `schema.yml` files in the `models/` directory and in
+the [`tests/`](./tests/) directory set the specification for our source data
+and its transformations. These specs allow us to build confidence in the
+integrity of the data that we use and publish. We use the
+[`dbt test`](https://docs.getdbt.com/docs/build/tests) command to run these
+tests against our Athena warehouse.
+
+### 3. Generate documentation for our data
+
+The DAG definition is parsed by dbt and used to build our [data
+documentation](https://ccao-data.github.io/data-architecture). We use the
+[`dbt docs generate`](https://docs.getdbt.com/reference/commands/cmd-docs)
+command to generate these docs.
+
+### 4. Automation for all of the above using GitHub Actions
+
+The workflows, actions, and scripts defined in [the `.github/`
+directory](../.github/) work together to perform all of our dbt operations
+automatically, and to integrate with the development cycle such that new
+commits to the main branch of this repo automatically deploy changes to our
+tables, views, tests, and docs. Automated tasks include:
+
+* (Re)building any models that have been added or modified since the last commit
+  to the main branch (the `build-and-test-dbt` workflow)
+* Running tests for any models that have been added or modified since the last
+  commit, including tests that have themselves been added or modified (the
+  `build-and-test-dbt` workflow)
+* Running tests for all models once per day (the `test-dbt-models` workflow)
+* Checking [the freshness of our source
+  data](https://docs.getdbt.com/docs/deploy/source-freshness) once per day
+  (the `test-dbt-source-freshness` workflow)
+* Generating and deploying data documentation to our [docs
+  site](https://ccao-data.github.io/data-architecture) on every commit to the
+  main branch (the `deploy-dbt-docs` workflow)
+* Cleaning up temporary resources in our Athena warehouse whenever a pull
+  request is merged to the main branch (the `cleanup-dbt-resources` workflow)
+
+## How to develop the catalog
+
+### Installation
 
 These instructions are for Ubuntu, which is the only platform we've tested.
 
@@ -12,14 +84,16 @@ pip](https://docs.getdbt.com/docs/core/pip-install). (You don't need to
 follow these docs in order to install dbt; the steps that follow will take
 care of that for you.)
 
-### Requirements
+#### Requirements
 
 * Python3 with venv installed (`sudo apt install python3-venv`)
 * [AWS CLI installed
   locally](https://github.com/ccao-data/wiki/blob/master/How-To/Connect-to-AWS-Resources.md)
   * You'll also need permissions for Athena, Glue, and S3
 
-### Install dependencies
+#### Install dependencies
+
+Run the following commands in this repo:
 
 ```
 python3 -m venv venv
@@ -28,7 +102,7 @@ pip install -r requirements.txt
 dbt deps
 ```
 
-## Usage
+### Useful commands
 
 To run dbt commands, make sure you have the virtual environment activated:
 
@@ -42,9 +116,9 @@ You must also authenticate with AWS using MFA if you haven't already today:
 aws-mfa
 ```
 
-### Build tables and views
+#### Build tables and views
 
-Build the models to create tables and views in our Athena warehouse:
+Build all the tables and views in our Athena warehouse:
 
 ```
 dbt run
@@ -60,7 +134,42 @@ use the `--target` flag:
 dbt run --target prod
 ```
 
-### Generate documentation
+To build a subset of the models, use the `--select` option:
+
+```
+dbt run --select location.vw_pin10_location default.vw_pin_universe
+```
+
+Prefix a model's names with a plus sign (`+`) to instruct dbt to (re)build its
+parents as well:
+
+```
+dbt run --select +default.vw_pin_universe
+```
+
+Download the prod state and use the `--defer` and `--state` options in order to
+build a model without having to build its dependencies (for more details, see
+[the docs on deferral](https://docs.getdbt.com/reference/node-selection/defer)):
+
+```
+aws s3 cp s3://ccao-dbt-cache-us-east-1/master-cache/manifest.json state/manifest.json
+dbt run --select default.vw_pin_universe --defer --state state
+```
+
+After downloading the prod state, only build models that have been added or
+changed since the last prod run:
+
+```
+dbt run -s state:modified state:new --defer --state state
+```
+
+Delete all the resources created in your local environment:
+
+```
+../.github/scripts/cleanup_dbt_resources.sh dev
+```
+
+#### Generate documentation
 
 Note that we configure dbt's [`asset-paths`
 attribute](https://docs.getdbt.com/reference/project-configs/asset-paths) in
@@ -96,18 +205,30 @@ dbt docs serve
 
 Then, navigate to http://localhost:8080 to view the site.
 
-### Run tests
+#### Run tests
 
-Run the tests:
+Run tests for all models:
 
 ```
 dbt test
 ```
 
-Run tests for only one model:
+Run all tests for one model:
 
 ```
-dbt test --select <model_name>
+dbt test --select default.vw_pin_universe
+```
+
+Run only one test:
+
+```
+dbt test --select vw_pin_universe_unique_by_14_digit_pin_and_year
+```
+
+Run a test against the prod models:
+
+```
+dbt test --select vw_pin_universe_unique_by_14_digit_pin_and_year --target prod
 ```
 
 Run tests for dbt macros:
@@ -116,7 +237,88 @@ Run tests for dbt macros:
 dbt run-operation test_all
 ```
 
-#### Debugging dbt test failures
+### How to add a new model
+
+To request the addition of a new model, open an issue using the [Add a new dbt
+model](.github/ISSUE_TEMPLATE/new-dbt-model.md) issue template. The assignee
+should follow the checklist in the body of the issue in order to add the model
+to the DAG.
+
+There are a few subtleties to consider when requesting a new model, outlined
+below.
+
+#### Model materialization
+
+There are a number of different ways of materializing tables in Athena
+using dbt; see the [dbt
+docs](https://docs.getdbt.com/docs/build/materializations#overview) for more
+detail.
+
+So far our DAG only uses view and table materialization, although we are
+interested in eventually incorporating incremental materialization as well.
+
+The choice between view and table materialization depends on the runtime and
+downstream consumption of the model query. There is no hard and fast rule, but
+as a general guideline, consider materializing a model as a table if queries
+using the table take longer than 30s to execute, or if the model is consumed
+by another model that is itself computationally intensive.
+
+Our DAG is configured to materialize models as views by default, so
+extra configuration is only required for non-view materialization.
+
+#### Model naming
+
+Models should be namespaced according to the database that the model lives in
+(e.g. `location.tax` for the `tax` table in the `location` database.) Since
+dbt does not yet support namespacing for refs, we include the database as a
+prefix in the model name to simulate real namespacing, and we override the
+`generate_alias_name` macro to strip out this fake namespace when generating
+names of tables and views
+([docs](https://docs.getdbt.com/docs/build/custom-aliases)).
+
+In addition to database namespacing, views should be named with a `vw_` prefix
+(e.g. `location.vw_pin10_location`) to mark them as a view, while tables do not
+require any prefix (e.g. `location.tax`).
+
+#### Model description
+
+All new models should include, at minimum, a
+[description](https://docs.getdbt.com/reference/resource-properties/description)
+of the model itself. We generally store these descriptions as [docs
+blocks](https://docs.getdbt.com/reference/resource-properties/description#use-a-docs-block-in-a-description).
+
+Ideally, new models should also include descriptions for each column,
+implemented directly in the `schema.yml` model definition. However, our
+column descriptions are currently sparse, so it is not a strict requirement just
+yet.
+
+#### Model tests
+
+Any assumptions underlying the new model should be documented in the form of
+[dbt tests](https://docs.getdbt.com/docs/build/tests).
+
+Conceptually, there are two types of tests that we might consider for a new
+model:
+
+1. **Data tests** check that the assumptions that a model makes about the raw
+   data it is transforming are correct.
+    * For example: Test that the table is unique by `pin10` and `year`.
+2. **Unit tests** check that the transformation logic itself produces
+   the correct output on a hardcoded set of input data.
+    * For example: Test that an enum column computed by a `CASE... WHEN`
+      expression produces the correct enum output for a given input string.
+
+The dbt syntax does not distinguish between data and unit tests, but it has
+emerged as a valuable distinction that we make on our side. Data tests are
+generally much easier to define and to implement, since they operate directly on
+source data and do not require hardcoded input and output values to execute.
+Due to this complexity, we currently do not have a way of supporting unit
+tests, although we plan to revisit this in the future; as such, when proposing
+new tests, check to ensure that they are in fact data tests and not unit tests.
+
+## Debugging tips
+
+### How do I debug a failing test?
 
 Most of our dbt tests are simple SQL statements that we run against our
 models in order to confirm that models conform to spec. If a test is
@@ -144,6 +346,47 @@ to debug the test failure.
 
 To quickly rule out a failure related to a code change, you can switch to the
 main branch of this repository (or to an earlier commit where we know tests
-passed, if tests are failing on the main branch) and rerun the test. If the
-test continues to fail in the same fashion, then we can be confident that the
-root cause is the data and not the code change.
+passed, if tests are failing on the main branch) and rerun the test against prod
+using the `--target prod` option. If the test continues to fail in the same
+fashion, then we can be confident that the root cause is the data and not the
+code change.
+
+### What do I do if the `cleanup-dbt-resources` workflow fails?
+
+The `cleanup-dbt-resources` workflow removes all AWS resources that were created
+by GitHub Actions for a pull request once that pull request has been merged into
+the main branch of the repo. On rare occasions, this workflow might fail due to
+changes to our dbt setup that invalidate the assumptions of the workflow.
+
+There are two ways to clean up a PR's resources manually:
+
+1. **Using the AWS console**: Login to the AWS console and navigate to the
+   Athena homepage. Select `Data sources` in the sidebar. Click on the
+   `AwsDataCatalog` resource. In the `Associated databases` table, select each
+   data source that matches the database pattern for your pull request
+   (i.e. prefixed with `ci_` plus the name of your branch) and click the
+   `Delete` button in the top right-hand corner of the table.
+2. **Using the command line**: If the workflow has failed, it most likely means
+   there is a bug in the `.github/scripts/cleanup_dbt_resources.sh` script
+   ([source](../.github/scripts/cleanup_dbt_resources.sh)). Once you've
+   identified and fixed the bug, confirm it works by running the following
+   command to clean up the resources created by the pull request:
+
+```
+HEAD_REF=$(git branch --show-current) ../.github/scripts/cleanup_dbt_resources.sh ci
+```
+
+### What do I do if dbt found two schema.yml entries for the same resource?
+
+If you get this error:
+
+```
+Compilation Error
+  dbt found two schema.yml entries for the same resource named location.vw_pin10_location. Resources and their associated columns may only be described a single time. To fix this, remove one of the resource entries for location.vw_pin10_location in this file:
+   - models/location/schema.yml
+```
+
+It usually means that dbt's state has unresolvable conflicts with the current
+state of your working directory. To resolve this, run `dbt clean` to clear your
+dbt state, reinstall dbt dependencies with `dbt deps`, and then try rerunning
+the command that raised the error.

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -8,7 +8,7 @@ This directory stores the configuration for building our data catalog using
 ### In this document
 
 * [🖼️ Background: What does the data catalog
-  do?](background-what-does-the-data-catalog-do)
+  do?](#background-what-does-the-data-catalog-do)
 * [💻 How to develop the catalog](#how-to-develop-the-catalog)
 * [➕ How to add a new model](#how-to-add-a-new-model)
 * [🐛 Debugging tips](#debugging-tips)
@@ -96,6 +96,7 @@ care of that for you.)
 * [AWS CLI installed
   locally](https://github.com/ccao-data/wiki/blob/master/How-To/Connect-to-AWS-Resources.md)
   * You'll also need permissions for Athena, Glue, and S3
+* [`aws-mfa` installed locally](https://github.com/ccao-data/wiki/blob/master/How-To/Setup-the-AWS-Command-Line-Interface-and-Multi-factor-Authentication.md)
 
 #### Install dependencies
 
@@ -246,7 +247,7 @@ Then, navigate to http://localhost:8080 to view the site.
 <h3 id="how-to-add-a-new-model"> ➕ How to add a new model </h3>
 
 To request the addition of a new model, open an issue using the [Add a new dbt
-model](.github/ISSUE_TEMPLATE/new-dbt-model.md) issue template. The assignee
+model](../.github/ISSUE_TEMPLATE/new-dbt-model.md) issue template. The assignee
 should follow the checklist in the body of the issue in order to add the model
 to the DAG.
 
@@ -285,6 +286,7 @@ names of tables and views in Athena
 In addition to database namespacing, views should be named with a `vw_` prefix
 (e.g. `location.vw_pin10_location`) to mark them as a view, while tables do not
 require any prefix (e.g. `location.tax`).
+Finally, for the sake of consistency and ease of interpretation, all tables and views should be named using the singular case e.g. `location.tax` rather than `location.taxes`.
 
 #### Model description
 

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -5,16 +5,21 @@ This directory stores the configuration for building our data catalog using
 
 ## Quick links
 
-* [Background: What does the data catalog
-  do?](#background-what-does-the-data-catalog-do)
-* [How to develop the catalog](#how-to-develop-the-catalog)
-* [How to add a new model](#how-to-add-a-new-model)
-* [Debugging tips](#debugging-tips)
-* [Data documentation](https://ccao-data.github.io/data-architecture)
-* [Design doc for our decision to develop our catalog with
+### In this document
+
+* [🖼️ Background: What does the data catalog
+  do?](background-what-does-the-data-catalog-do)
+* [💻 How to develop the catalog](#how-to-develop-the-catalog)
+* [➕ How to add a new model](#how-to-add-a-new-model)
+* [🐛 Debugging tips](#debugging-tips)
+
+### Outside this document
+
+* [📖 Data documentation](https://ccao-data.github.io/data-architecture)
+* [📝 Design doc for our decision to develop our catalog with
   dbt](../documentation/design-docs/data-catalog.md)
 
-## Background: What does the data catalog do?
+<h2 id="background-what-does-the-data-catalog-do">🖼️ Background: What does the data catalog do?</h2>
 
 The data catalog accomplishes a few main goals:
 
@@ -25,10 +30,10 @@ we run in order to transform raw data into output data for use in statistical
 modeling and reporting. These transformations comprise a DAG that we use for
 documenting our data and rebuilding it efficiently. We use the [`dbt
 run`](https://docs.getdbt.com/reference/commands/run) command to build these
-models into Athena views and tables.
+models into views and tables in AWS Athena.
 
-Note that when we talk about "models" in these docs, we generally mean to
-discuss [the resources that dbt calls
+Note that when we talk about "models" in these docs, we generally mean [the
+resources that dbt calls
 "models"](https://docs.getdbt.com/docs/build/models), namely the definitions of
 the tables and views in our Athena warehouse. In contrast, we will use the
 phrase "statistical models" wherever we mean to discuss the algorithms that we
@@ -36,9 +41,10 @@ use to predict property values.
 
 ### 2. Define integrity checks that specify the correct format for our data
 
-The tests defined in the `schema.yml` files in the `models/` directory and in
-the [`tests/`](./tests/) directory set the specification for our source data
-and its transformations. These specs allow us to build confidence in the
+The tests defined in the `schema.yml` files in the `models/` directory,
+alongside some one-off tests defined in the [`tests/`](./tests/) directory,
+set the specification for our source data and its transformations. These
+specs allow us to build confidence in the
 integrity of the data that we use and publish. We use the
 [`dbt test`](https://docs.getdbt.com/docs/build/tests) command to run these
 tests against our Athena warehouse.
@@ -55,8 +61,8 @@ command to generate these docs.
 The workflows, actions, and scripts defined in [the `.github/`
 directory](../.github/) work together to perform all of our dbt operations
 automatically, and to integrate with the development cycle such that new
-commits to the main branch of this repo automatically deploy changes to our
-tables, views, tests, and docs. Automated tasks include:
+commits to the main branch of this repository automatically deploy changes to
+our tables, views, tests, and docs. Automated tasks include:
 
 * (Re)building any models that have been added or modified since the last commit
   to the main branch (the `build-and-test-dbt` workflow)
@@ -71,9 +77,9 @@ tables, views, tests, and docs. Automated tasks include:
   site](https://ccao-data.github.io/data-architecture) on every commit to the
   main branch (the `deploy-dbt-docs` workflow)
 * Cleaning up temporary resources in our Athena warehouse whenever a pull
-  request is merged to the main branch (the `cleanup-dbt-resources` workflow)
+  request is merged into the main branch (the `cleanup-dbt-resources` workflow)
 
-## How to develop the catalog
+<h2 id="how-to-develop-the-catalog"> 💻 How to develop the catalog </h2>
 
 ### Installation
 
@@ -93,7 +99,7 @@ care of that for you.)
 
 #### Install dependencies
 
-Run the following commands in this repo:
+Run the following commands in this directory:
 
 ```
 python3 -m venv venv
@@ -169,6 +175,38 @@ Delete all the resources created in your local environment:
 ../.github/scripts/cleanup_dbt_resources.sh dev
 ```
 
+#### Run tests
+
+Run tests for all models:
+
+```
+dbt test
+```
+
+Run all tests for one model:
+
+```
+dbt test --select default.vw_pin_universe
+```
+
+Run only one test:
+
+```
+dbt test --select vw_pin_universe_unique_by_14_digit_pin_and_year
+```
+
+Run a test against the prod models:
+
+```
+dbt test --select vw_pin_universe_unique_by_14_digit_pin_and_year --target prod
+```
+
+Run tests for dbt macros:
+
+```
+dbt run-operation test_all
+```
+
 #### Generate documentation
 
 Note that we configure dbt's [`asset-paths`
@@ -205,39 +243,7 @@ dbt docs serve
 
 Then, navigate to http://localhost:8080 to view the site.
 
-#### Run tests
-
-Run tests for all models:
-
-```
-dbt test
-```
-
-Run all tests for one model:
-
-```
-dbt test --select default.vw_pin_universe
-```
-
-Run only one test:
-
-```
-dbt test --select vw_pin_universe_unique_by_14_digit_pin_and_year
-```
-
-Run a test against the prod models:
-
-```
-dbt test --select vw_pin_universe_unique_by_14_digit_pin_and_year --target prod
-```
-
-Run tests for dbt macros:
-
-```
-dbt run-operation test_all
-```
-
-### How to add a new model
+<h3 id="how-to-add-a-new-model"> ➕ How to add a new model </h3>
 
 To request the addition of a new model, open an issue using the [Add a new dbt
 model](.github/ISSUE_TEMPLATE/new-dbt-model.md) issue template. The assignee
@@ -251,7 +257,7 @@ below.
 
 There are a number of different ways of materializing tables in Athena
 using dbt; see the [dbt
-docs](https://docs.getdbt.com/docs/build/materializations#overview) for more
+docs](https://docs.getdbt.com/docs/build/materializations) for more
 detail.
 
 So far our DAG only uses view and table materialization, although we are
@@ -273,7 +279,7 @@ Models should be namespaced according to the database that the model lives in
 dbt does not yet support namespacing for refs, we include the database as a
 prefix in the model name to simulate real namespacing, and we override the
 `generate_alias_name` macro to strip out this fake namespace when generating
-names of tables and views
+names of tables and views in Athena
 ([docs](https://docs.getdbt.com/docs/build/custom-aliases)).
 
 In addition to database namespacing, views should be named with a `vw_` prefix
@@ -295,7 +301,9 @@ yet.
 #### Model tests
 
 Any assumptions underlying the new model should be documented in the form of
-[dbt tests](https://docs.getdbt.com/docs/build/tests).
+[dbt tests](https://docs.getdbt.com/docs/build/tests). We prefer adding tests
+inline in `schema.yml` model properties files, as opposed to defining one-off
+tests in the `tests/` directory.
 
 Conceptually, there are two types of tests that we might consider for a new
 model:
@@ -316,7 +324,7 @@ Due to this complexity, we currently do not have a way of supporting unit
 tests, although we plan to revisit this in the future; as such, when proposing
 new tests, check to ensure that they are in fact data tests and not unit tests.
 
-## Debugging tips
+<h2 id="debugging-tips"> 🐛 Debugging tips </h2>
 
 ### How do I debug a failing test?
 
@@ -355,8 +363,8 @@ code change.
 
 The `cleanup-dbt-resources` workflow removes all AWS resources that were created
 by GitHub Actions for a pull request once that pull request has been merged into
-the main branch of the repo. On rare occasions, this workflow might fail due to
-changes to our dbt setup that invalidate the assumptions of the workflow.
+the main branch of the repository. On rare occasions, this workflow might fail
+due to changes to our dbt setup that invalidate the assumptions of the workflow.
 
 There are two ways to clean up a PR's resources manually:
 
@@ -368,7 +376,7 @@ There are two ways to clean up a PR's resources manually:
    `Delete` button in the top right-hand corner of the table.
 2. **Using the command line**: If the workflow has failed, it most likely means
    there is a bug in the `.github/scripts/cleanup_dbt_resources.sh` script
-   ([source](../.github/scripts/cleanup_dbt_resources.sh)). Once you've
+   ([source code](../.github/scripts/cleanup_dbt_resources.sh)). Once you've
    identified and fixed the bug, confirm it works by running the following
    command to clean up the resources created by the pull request:
 

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -295,10 +295,14 @@ All new models should include, at minimum, a
 of the model itself. We generally store these descriptions as [docs
 blocks](https://docs.getdbt.com/reference/resource-properties/description#use-a-docs-block-in-a-description).
 
-Ideally, new models should also include descriptions for each column,
-implemented directly in the `schema.yml` model definition. However, our
-column descriptions are currently sparse, so it is not a strict requirement just
-yet.
+New models should also include descriptions for each column,
+implemented directly in the `schema.yml` model definition. Docs blocks are
+generally not necessary for column descriptions, since column descriptions
+should be kept short and simple so that docs readers can scan them from the
+context of the "Columns" table.
+
+Any documentation for a column beyond its basic summary should be stored in
+a `meta.notes` attribute on the column.
 
 #### Model tests
 


### PR DESCRIPTION
This PR updates `dbt/README.md` to add more detailed docs on how to develop our dbt catalog. These docs represent my best attempt at a full set of information that other developers in this office will need to effectively contribute to the data catalog.

As part of these docs, this PR also adds a new `Add a new dbt model` issue template that provides detailed instructions for how to add a new model, assuming no context on how our dbt setup works.

Closes #67 and https://github.com/ccao-data/data-architecture/issues/108.