### PR TITLE
Always defer to master dbt state on CI to resolve intermittent build failures

### DIFF
--- a/.github/actions/configure_dbt_environment/action.yaml
+++ b/.github/actions/configure_dbt_environment/action.yaml
@@ -11,16 +11,12 @@ runs:
           echo "On pull request branch, setting dbt env to CI"
           {
             echo "TARGET=ci";
-            echo "CACHE_KEY=pr-caches/$GITHUB_HEAD_REF";
-            echo "CACHE_RESTORE_KEY=master-cache"
             echo "HEAD_REF=$GITHUB_HEAD_REF"
           } >> "$GITHUB_ENV"
         elif [[ $GITHUB_REF_NAME == 'master' ]]; then
           echo "On master branch, setting dbt env to prod"
           {
             echo "TARGET=prod";
-            echo "CACHE_KEY=master-cache";
-            echo "CACHE_RESTORE_KEY=master-cache"
           } >> "$GITHUB_ENV"
         else
           echo "CI context did not match any of the expected environments"

--- a/.github/actions/restore_dbt_cache/action.yaml
+++ b/.github/actions/restore_dbt_cache/action.yaml
@@ -8,8 +8,8 @@ inputs:
     description: The cache key to query for.
     required: true
   restore-key:
-    description: An additional key to use as a fallback for the cache.
-    required: true
+    description: An optional additional key to use as a fallback for the cache.
+    required: false
   bucket:
     description: The S3 bucket that should store the cache.
     required: false
@@ -41,16 +41,26 @@ runs:
             echo "cache-matched-key=$KEY"
           } >> $GITHUB_OUTPUT
         else
-          echo "Did not find exact match for cache key, checking fallback"
-          if aws s3api head-object --bucket "$BUCKET" --key "$RESTORE_KEY/manifest.json"; then
-            echo "Cache hit: Found fallback match"
-            {
-              echo "cache-hit=true";
-              echo "exact-match=false";
-              echo "cache-matched-key=$RESTORE_KEY"
-            } >> $GITHUB_OUTPUT
+          echo "Did not find exact match for cache key"
+          if [ ! -z "$RESTORE_KEY" ]; then
+            echo "Checking for fallback cache via restore-key"
+            if aws s3api head-object --bucket "$BUCKET" --key "$RESTORE_KEY/manifest.json"; then
+              echo "Cache hit: Found fallback match"
+              {
+                echo "cache-hit=true";
+                echo "exact-match=false";
+                echo "cache-matched-key=$RESTORE_KEY"
+              } >> $GITHUB_OUTPUT
+            else
+              echo "Cache miss: Did not find fallback match for cache key"
+              {
+                echo "cache-hit=false";
+                echo "exact-match=false";
+                echo "cache-matched-key=''";
+              } >> $GITHUB_OUTPUT
+            fi
           else
-            echo "Cache miss: Did not find fallback match for cache key"
+            echo "Cache miss: No exact match and no fallback cache key"
             {
               echo "cache-hit=false";
               echo "exact-match=false";

--- a/.github/variables/dbt.env
+++ b/.github/variables/dbt.env
@@ -1,4 +1,4 @@
-CACHE_KEY=foobar
+CACHE_KEY=master-cache
 PROJECT_DIR=dbt
 STATE_DIR=state
 TARGET_DIR=target

--- a/.github/variables/dbt.env
+++ b/.github/variables/dbt.env
@@ -1,3 +1,4 @@
 PROJECT_DIR=dbt
 STATE_DIR=state
 TARGET_DIR=target
+CACHE_KEY=master-cache

--- a/.github/variables/dbt.env
+++ b/.github/variables/dbt.env
@@ -1,4 +1,4 @@
+CACHE_KEY=master-cache
 PROJECT_DIR=dbt
 STATE_DIR=state
 TARGET_DIR=target
-CACHE_KEY=master-cache

--- a/.github/variables/dbt.env
+++ b/.github/variables/dbt.env
@@ -1,4 +1,4 @@
-CACHE_KEY=master-cache
+CACHE_KEY=foobar
 PROJECT_DIR=dbt
 STATE_DIR=state
 TARGET_DIR=target

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -29,7 +29,6 @@ jobs:
         with:
           path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
           key: ${{ env.CACHE_KEY }}
-          restore-key: foobar
 
       - if: steps.cache.outputs.cache-hit == 'true'
         name: Set command args to build/test modified resources

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -29,7 +29,6 @@ jobs:
         with:
           path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
           key: ${{ env.CACHE_KEY }}
-          restore-key: ${{ env.CACHE_RESTORE_KEY }}
 
       - if: steps.cache.outputs.cache-hit == 'true'
         name: Set command args to build/test modified resources
@@ -70,7 +69,8 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
 
-      - name: Update dbt state cache
+      - if: github.ref == 'refs/heads/master'
+        name: Update dbt state cache
         uses: ./.github/actions/save_dbt_cache
         with:
           path: ${{ env.PROJECT_DIR }}/${{ env.TARGET_DIR }}

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
           key: ${{ env.CACHE_KEY }}
+          restore-key: foobar
 
       - if: steps.cache.outputs.cache-hit == 'true'
         name: Set command args to build/test modified resources

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -1,7 +1,6 @@
 -- Source of truth view for PIN location
 SELECT
     -- Main PIN-level attribute data from iasWorld
-    1 AS foo,
     par.parid AS pin,
     SUBSTR(par.parid, 1, 10) AS pin10,
     par.taxyr AS year,

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -1,6 +1,7 @@
 -- Source of truth view for PIN location
 SELECT
     -- Main PIN-level attribute data from iasWorld
+    1 AS foo,
     par.parid AS pin,
     SUBSTR(par.parid, 1, 10) AS pin10,
     par.taxyr AS year,


### PR DESCRIPTION
We've been seeing some intermittent build failures on CI due to the fact that we're attempting to defer to branch-specific state rather than master state on CI in some cases. (More details in #129.) This PR simplifies that logic by always deferring to master branch state on CI, which means that we will run more builds and tests than we otherwise would, but we will also experience a more stable CI pipeline.

I tested these changes a few different ways via temporary commits:

* See [this workflow run](https://github.com/ccao-data/data-architecture/actions/runs/6191129053/job/16808775960#step:8:1) for a test confirming that this deferral behavior works in a simple case where we modify `default.vw_pin_universe` and want to build/test it without building/testing its dependencies.
* See [this workflow run](https://github.com/ccao-data/data-architecture/actions/runs/6191206527/job/16809028111#step:4:88) for a test confirming that the altered `restore-cache` action works when no exact match is found and no fallback is configured
* See [this workflow run](https://github.com/ccao-data/data-architecture/actions/runs/6191223729/job/16809080729#step:4:92) for a test confirming that `restore-cache` works when no exact match is found and no fallback match is found either

Closes https://github.com/ccao-data/data-architecture/issues/129.