### PR TITLE
Update dbt docs with more detail on handling table models and upgrade to dbt 1.6

### DIFF
--- a/dbt/.gitignore
+++ b/dbt/.gitignore
@@ -5,3 +5,4 @@ target/
 dbt_modules/
 dbt_packages/
 assets/*.svg
+master-cache/

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -12,6 +12,7 @@ athena:
       # "database" here corresponds to a Glue data catalog
       database: awsdatacatalog
       threads: 5
+      num_retries: 1
     ci:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-ci-us-east-1/results/
@@ -21,6 +22,7 @@ athena:
       schema: dbt-test
       database: awsdatacatalog
       threads: 5
+      num_retries: 1
     prod:
       type: athena
       s3_staging_dir: s3://ccao-athena-results-us-east-1/
@@ -30,3 +32,4 @@ athena:
       schema: default
       database: awsdatacatalog
       threads: 5
+      num_retries: 1

--- a/dbt/requirements.txt
+++ b/dbt/requirements.txt
@@ -1,1 +1,1 @@
-dbt-athena-community==1.5.1
+dbt-athena-community~=1.6.1


### PR DESCRIPTION
The introduction of our spatial queries as materialized tables into the dbt DAG in https://github.com/ccao-data/data-architecture/pull/111 creates an additional layer of complexity for local dbt development, since the time to build the full DAG has increased from a couple of minutes to a couple of hours.

This PR updates the dbt README to provide detailed instructions on how to avoid building compute-intensive tables using [`dbt clone`](https://docs.getdbt.com/reference/commands/clone) and [the `--exclude` option](https://docs.getdbt.com/reference/node-selection/exclude). In order to support this workflow, we upgrade to the v1.6.x lines of dbt Core and the dbt-athena adapter, which are the first versions to support `dbt clone` in addition to being the latest stable minor versions of both libraries.

We also take this opportunity to sneak in one small improvement to developer experience by reducing the number of times that dbt-athena will retry a failed query from 5 to 1; in my experience, intermittent Athena failures are very rare compared to SQL syntax and compilation failures, and eliminating the retry logic allows for faster debugging cycles when trying to resolve the latter class of failure.