### PR TITLE
Update build and test workflow with manual dispatch option

### DIFF
--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -45,8 +45,6 @@ jobs:
         run: |
           if [[ $CACHE_HIT == 'true' ]]; then
             echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"
-          else
-            echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
           fi
           if [[ $EVENT_NAME == 'workflow_dispatch' ]]; then
               echo "MANUALLY_DISPATCHED=true" >> "$GITHUB_ENV"

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -41,7 +41,7 @@ jobs:
           path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
           key: ${{ env.CACHE_KEY }}
 
-        name: Set command args for building/testing resources
+      - name: Set command args for building/testing resources
         run: |
           if [[ ${{ steps.cache.outputs.cache-hit == 'true' }} ]]; then
             echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -9,10 +9,11 @@ on:
   workflow_dispatch:
     inputs:
       models:
+        required: true
         description: >
           A space-separated list of dbt models to build.
           Prefix with the + sign to rebuild upstream models
-        default: default.vw_pin_sale default.vw_pin_universe
+        default: 'default.vw_pin_sale default.vw_pin_universe'
         type: string
 
 jobs:
@@ -40,19 +41,17 @@ jobs:
           path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
           key: ${{ env.CACHE_KEY }}
 
-      - if: steps.cache.outputs.cache-hit == 'true'
-        name: Set command args to build/test modified resources
-        run: echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"
-        shell: bash
+        name: Set command args for building/testing resources
+        run: |
+          if [[ ${{ steps.cache.outputs.cache-hit == 'true' }} ]]; then
+            echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"
+          else
+            echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
+          fi
 
-      - if: steps.cache.outputs.cache-hit != 'true'
-        name: Set command args to build/test all resources
-        run: echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
-        shell: bash
-
-      - if: inputs.models != '' && github.event_name == 'workflow_dispatch'
-        name: Set command args for manually dispatched workflow
-        run: echo "MANUALLY_DISPATCHED=true" >> "$GITHUB_ENV"
+          if [[ ${{ github.event_name == 'workflow_dispatch' }} ]]; then
+              echo "MANUALLY_DISPATCHED=true" >> "$GITHUB_ENV"
+          fi
         shell: bash
 
       - name: Test dbt macros

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -6,6 +6,15 @@ on:
   push:
     branches: [master]
 
+  workflow_dispatch:
+    inputs:
+      models:
+        description: >
+          A space-separated list of dbt models to build.
+          Prefix with the + sign to rebuild upstream models
+        default: default.vw_pin_sale default.vw_pin_universe
+        type: string
+
 jobs:
   build-and-test-dbt:
     runs-on: ubuntu-latest
@@ -41,6 +50,11 @@ jobs:
         run: echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
         shell: bash
 
+      - if: inputs.models != '' && github.event_name == 'workflow_dispatch'
+        name: Set command args for manually dispatched workflow
+        run: echo "MANUALLY_DISPATCHED=true" >> "$GITHUB_ENV"
+        shell: bash
+
       - name: Test dbt macros
         run: dbt run-operation test_all
         working-directory: ${{ env.PROJECT_DIR }}
@@ -49,8 +63,13 @@ jobs:
       - name: Build models
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
-            echo "Running build on modified/new resources only"
-            dbt run -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR"
+            if [[ $MANUALLY_DISPATCHED == 'true' ]]; then
+              echo "Running build on manually selected resources"
+              dbt run -t "$TARGET" -s ${{ inputs.models }} --defer --state "$STATE_DIR"
+            else
+              echo "Running build on modified/new resources only"
+              dbt run -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR"
+            fi
           else
             echo "Running build on all resources"
             dbt run -t "$TARGET"
@@ -61,8 +80,13 @@ jobs:
       - name: Test models
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
-            echo "Running tests on modified/new resources only"
-            dbt test -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR"
+            if [[ $MANUALLY_DISPATCHED == 'true' ]]; then
+              echo "Running tests on manually selected resources"
+              dbt test -t "$TARGET" -s ${{ inputs.models }} --defer --state "$STATE_DIR"
+            else
+              echo "Running tests on modified/new resources only"
+              dbt test -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR"
+            fi
           else
             echo "Running tests on all resources"
             dbt test -t "$TARGET"
@@ -70,7 +94,7 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
 
-      - if: github.ref == 'refs/heads/master'
+      - if: github.ref == 'refs/heads/master' && success()
         name: Update dbt state cache
         uses: ./.github/actions/save_dbt_cache
         with:

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -43,16 +43,18 @@ jobs:
 
       - name: Set command args for building/testing resources
         run: |
-          if [[ ${{ steps.cache.outputs.cache-hit == 'true' }} ]]; then
+          if [[ $CACHE_HIT == 'true' ]]; then
             echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"
           else
             echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
           fi
-
-          if [[ ${{ github.event_name == 'workflow_dispatch' }} ]]; then
+          if [[ $EVENT_NAME == 'workflow_dispatch' ]]; then
               echo "MANUALLY_DISPATCHED=true" >> "$GITHUB_ENV"
           fi
         shell: bash
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+          EVENT_NAME: ${{ github.event_name }}
 
       - name: Test dbt macros
         run: dbt run-operation test_all


### PR DESCRIPTION
This PR adds a manual dispatch option for the `build-and-test-dbt` workflow. It takes a space-separated list of model names as an input, pulls the `master` branch cache, builds and tests the specified models, then re-uploads the cache to S3.

Closes #128.