### PR TITLE
Add dbt manual workflow dispatch docs

### DIFF
--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -45,8 +45,6 @@ jobs:
         run: |
           if [[ $CACHE_HIT == 'true' ]]; then
             echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"
-          else
-            echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
           fi
           if [[ $EVENT_NAME == 'workflow_dispatch' ]]; then
               echo "MANUALLY_DISPATCHED=true" >> "$GITHUB_ENV"

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -41,7 +41,7 @@ jobs:
           path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
           key: ${{ env.CACHE_KEY }}
 
-        name: Set command args for building/testing resources
+      - name: Set command args for building/testing resources
         run: |
           if [[ ${{ steps.cache.outputs.cache-hit == 'true' }} ]]; then
             echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -9,10 +9,11 @@ on:
   workflow_dispatch:
     inputs:
       models:
+        required: true
         description: >
           A space-separated list of dbt models to build.
           Prefix with the + sign to rebuild upstream models
-        default: default.vw_pin_sale default.vw_pin_universe
+        default: 'default.vw_pin_sale default.vw_pin_universe'
         type: string
 
 jobs:
@@ -40,19 +41,17 @@ jobs:
           path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
           key: ${{ env.CACHE_KEY }}
 
-      - if: steps.cache.outputs.cache-hit == 'true'
-        name: Set command args to build/test modified resources
-        run: echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"
-        shell: bash
+        name: Set command args for building/testing resources
+        run: |
+          if [[ ${{ steps.cache.outputs.cache-hit == 'true' }} ]]; then
+            echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"
+          else
+            echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
+          fi
 
-      - if: steps.cache.outputs.cache-hit != 'true'
-        name: Set command args to build/test all resources
-        run: echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
-        shell: bash
-
-      - if: inputs.models != '' && github.event_name == 'workflow_dispatch'
-        name: Set command args for manually dispatched workflow
-        run: echo "MANUALLY_DISPATCHED=true" >> "$GITHUB_ENV"
+          if [[ ${{ github.event_name == 'workflow_dispatch' }} ]]; then
+              echo "MANUALLY_DISPATCHED=true" >> "$GITHUB_ENV"
+          fi
         shell: bash
 
       - name: Test dbt macros

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -6,6 +6,15 @@ on:
   push:
     branches: [master]
 
+  workflow_dispatch:
+    inputs:
+      models:
+        description: >
+          A space-separated list of dbt models to build.
+          Prefix with the + sign to rebuild upstream models
+        default: default.vw_pin_sale default.vw_pin_universe
+        type: string
+
 jobs:
   build-and-test-dbt:
     runs-on: ubuntu-latest
@@ -41,6 +50,11 @@ jobs:
         run: echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
         shell: bash
 
+      - if: inputs.models != '' && github.event_name == 'workflow_dispatch'
+        name: Set command args for manually dispatched workflow
+        run: echo "MANUALLY_DISPATCHED=true" >> "$GITHUB_ENV"
+        shell: bash
+
       - name: Test dbt macros
         run: dbt run-operation test_all
         working-directory: ${{ env.PROJECT_DIR }}
@@ -49,8 +63,13 @@ jobs:
       - name: Build models
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
-            echo "Running build on modified/new resources only"
-            dbt run -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR"
+            if [[ $MANUALLY_DISPATCHED == 'true' ]]; then
+              echo "Running build on manually selected resources"
+              dbt run -t "$TARGET" -s ${{ inputs.models }} --defer --state "$STATE_DIR"
+            else
+              echo "Running build on modified/new resources only"
+              dbt run -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR"
+            fi
           else
             echo "Running build on all resources"
             dbt run -t "$TARGET"
@@ -61,8 +80,13 @@ jobs:
       - name: Test models
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
-            echo "Running tests on modified/new resources only"
-            dbt test -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR"
+            if [[ $MANUALLY_DISPATCHED == 'true' ]]; then
+              echo "Running tests on manually selected resources"
+              dbt test -t "$TARGET" -s ${{ inputs.models }} --defer --state "$STATE_DIR"
+            else
+              echo "Running tests on modified/new resources only"
+              dbt test -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR"
+            fi
           else
             echo "Running tests on all resources"
             dbt test -t "$TARGET"
@@ -70,7 +94,7 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
 
-      - if: github.ref == 'refs/heads/master'
+      - if: github.ref == 'refs/heads/master' && success()
         name: Update dbt state cache
         uses: ./.github/actions/save_dbt_cache
         with:

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -43,16 +43,18 @@ jobs:
 
       - name: Set command args for building/testing resources
         run: |
-          if [[ ${{ steps.cache.outputs.cache-hit == 'true' }} ]]; then
+          if [[ $CACHE_HIT == 'true' ]]; then
             echo "MODIFIED_RESOURCES_ONLY=true" >> "$GITHUB_ENV"
           else
             echo "MODIFIED_RESOURCES_ONLY=false" >> "$GITHUB_ENV"
           fi
-
-          if [[ ${{ github.event_name == 'workflow_dispatch' }} ]]; then
+          if [[ $EVENT_NAME == 'workflow_dispatch' ]]; then
               echo "MANUALLY_DISPATCHED=true" >> "$GITHUB_ENV"
           fi
         shell: bash
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+          EVENT_NAME: ${{ github.event_name }}
 
       - name: Test dbt macros
         run: dbt run-operation test_all

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -10,9 +10,7 @@ on:
     inputs:
       models:
         required: true
-        description: >
-          A space-separated list of dbt models to build.
-          Prefix with the + sign to rebuild upstream models
+        description: A space-separated list of dbt models
         default: 'default.vw_pin_sale default.vw_pin_universe'
         type: string
 

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -7,8 +7,8 @@ This directory stores the configuration for building our data catalog using
 
 ### In this document
 
-* [🖼️ Background: What does the data catalog
-  do?](#background-what-does-the-data-catalog-do)
+* [🖼️ Background: What does the data catalog do?](#background-what-does-the-data-catalog-do)
+* [🔨 How to rebuild models using GitHub Actions](#how-to-rebuild-models-using-github-actions)
 * [💻 How to develop the catalog](#how-to-develop-the-catalog)
 * [➕ How to add a new model](#how-to-add-a-new-model)
 * [🐛 Debugging tips](#debugging-tips)
@@ -78,6 +78,28 @@ our tables, views, tests, and docs. Automated tasks include:
   main branch (the `deploy-dbt-docs` workflow)
 * Cleaning up temporary resources in our Athena warehouse whenever a pull
   request is merged into the main branch (the `cleanup-dbt-resources` workflow)
+
+<h2 id="how-to-rebuild-models-using-github-actions"> 🔨 How to rebuild models using GitHub Actions</h2>
+
+GitHub Actions can be used to manually rebuild part or all of our dbt DAG.
+To use this functionality:
+
+- Go to the `build-and-test-dbt` [workflow page](https://github.com/ccao-data/data-architecture/actions/workflows/build_and_test_dbt.yaml)
+- Click the **Run workflow** dropdown on the right-hand side of the screen
+- Populate the input box following the instructions below
+- Click **Run workflow**, then click the created workflow run to view progress
+
+The workflow input box expects a space-separated list of dbt model names or selectors.
+Multiple models can be passed at the same time, as the input box values are
+passed directly to `dbt run`. Model names _must include the database schema name_. Some possible inputs include:
+
+- `default.vw_pin_sale` - Rebuild a single view
+- `default.vw_pin_sale default.vw_pin_universe` - Rebuild two views at once
+- `+default.vw_pin_history` - Rebuild a view and all its upstream dependencies
+- `location.*` - Rebuild all views under the `location` schema
+- `path:models` - Rebuild the full DAG (:warning: takes a long time!)
+
+For more possible inputs using dbt node selection, see the [documentation site](https://docs.getdbt.com/reference/node-selection/syntax#examples).
 
 <h2 id="how-to-develop-the-catalog"> 💻 How to develop the catalog </h2>
 
@@ -284,7 +306,7 @@ dbt docs serve
 
 Then, navigate to http://localhost:8080 to view the site.
 
-<h3 id="how-to-add-a-new-model"> ➕ How to add a new model </h3>
+<h2 id="how-to-add-a-new-model"> ➕ How to add a new model </h2>
 
 To request the addition of a new model, open an issue using the [Add a new dbt
 model](../.github/ISSUE_TEMPLATE/new-dbt-model.md) issue template. The assignee
@@ -294,7 +316,7 @@ to the DAG.
 There are a few subtleties to consider when requesting a new model, outlined
 below.
 
-#### Model materialization
+### Model materialization
 
 There are a number of different ways of materializing tables in Athena
 using dbt; see the [dbt
@@ -313,7 +335,7 @@ by another model that is itself computationally intensive.
 Our DAG is configured to materialize models as views by default, so
 extra configuration is only required for non-view materialization.
 
-#### Model naming
+### Model naming
 
 Models should be namespaced according to the database that the model lives in
 (e.g. `location.tax` for the `tax` table in the `location` database.) Since
@@ -328,7 +350,7 @@ In addition to database namespacing, views should be named with a `vw_` prefix
 require any prefix (e.g. `location.tax`).
 Finally, for the sake of consistency and ease of interpretation, all tables and views should be named using the singular case e.g. `location.tax` rather than `location.taxes`.
 
-#### Model description
+### Model description
 
 All new models should include, at minimum, a
 [description](https://docs.getdbt.com/reference/resource-properties/description)
@@ -344,7 +366,7 @@ context of the "Columns" table.
 Any documentation for a column beyond its basic summary should be stored in
 a `meta.notes` attribute on the column.
 
-#### Model tests
+### Model tests
 
 Any assumptions underlying the new model should be documented in the form of
 [dbt tests](https://docs.getdbt.com/docs/build/tests). We prefer adding tests


### PR DESCRIPTION
This PR adds a short docs section describing how to use the manual workflow dispatch trigger to rebuild parts of our dbt DAG. It also slightly alters the text prompt for the workflow input.