### PR TITLE
Fix syntax error in `new-dbt-model` issue template so that it shows up in the New Issue view

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-dbt-model.md
+++ b/.github/ISSUE_TEMPLATE/new-dbt-model.md
@@ -2,6 +2,8 @@
 name: Add a new dbt model
 about: Request the addition of a new model to the dbt DAG.
 title: Add a new dbt model
+labels: ''
+assignees: ''
 ---
 
 _(Replace or delete anything in parentheses with your own issue content.)_

--- a/.github/ISSUE_TEMPLATE/new-dbt-model.md
+++ b/.github/ISSUE_TEMPLATE/new-dbt-model.md
@@ -1,6 +1,6 @@
 ---
 name: Add a new dbt model
-description: Request the addition of a new model to the dbt DAG.
+about: Request the addition of a new model to the dbt DAG.
 title: Add a new dbt model
 ---
 


### PR DESCRIPTION
The `new-dbt-model` issue template currently does not appear on the [New Issue page](https://github.com/ccao-data/data-architecture/issues/new/choose):

![Screenshot 2023-09-27 155134](https://github.com/ccao-data/data-architecture/assets/14170650/53729106-b1d5-43f3-a8c0-c424fbf1e9bf)

If you navigate to [the Markdown file](https://github.com/ccao-data/data-architecture/blob/master/.github/ISSUE_TEMPLATE/new-dbt-model.md), you'll notice GitHub displaying an error message saying `About can't be blank`:

![Screenshot 2023-09-27 155329](https://github.com/ccao-data/data-architecture/assets/14170650/d4a65603-ff2d-420a-8e44-7b1b62c9f8ab)

This error message is not super clear, but comparing the template to a template that is successfully rendering in the New Issue view (`data-onboarding`) reveals the latter is using `about` instead of `description`, which seems related to the error message in question:

https://github.com/ccao-data/data-architecture/blob/4beab06c70d40c19c5932bfe8a4d6a7aeefe7001/.github/ISSUE_TEMPLATE/new-dbt-model.md?plain=1#L1-L5

https://github.com/ccao-data/data-architecture/blob/4beab06c70d40c19c5932bfe8a4d6a7aeefe7001/.github/ISSUE_TEMPLATE/data-onboarding.md?plain=1#L1-L8

The weird thing is that the [documentation for issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax) (which GitHub seems to now call "issue forms") says that `description` is a required field:

> All issue form configuration files must begin with `name`, `description`, and `body` key-value pairs.

But given that the page indicates issue form syntax is "currently in beta and subject to change", my suspicion is that this is a newer syntax, and the old syntax (which `data-onboarding` must use) requires `about` instead of `description`. Another clue here is that the syntax described in the issue form docs requires a `body` key, which is not used by the `data-onboarding` issue template.

Hence, this PR tweaks the markup for the `new-dbt-model` issue template such that its attributes match the attributes in `data-onboarding`.