### PR TITLE
Add script and GitHub workflow to test open data assets on a schedule

### DIFF
--- a/.github/actions/publish_sns_topic/action.yaml
+++ b/.github/actions/publish_sns_topic/action.yaml
@@ -26,4 +26,3 @@ runs:
           --subject "${{ inputs.subject }}" \
           --message "${{ inputs.body }}"
       shell: bash
-

--- a/.github/actions/publish_sns_topic/action.yaml
+++ b/.github/actions/publish_sns_topic/action.yaml
@@ -17,6 +17,7 @@ runs:
   steps:
     - name: Mask topic ARN
       run: echo "::add-mask::${{ inputs.sns_topic_arn }}"
+      shell: bash
 
     - name: Publish SNS topic
       run: >

--- a/.github/actions/publish_sns_topic/action.yaml
+++ b/.github/actions/publish_sns_topic/action.yaml
@@ -1,0 +1,28 @@
+name: Publish SNS topic
+description: |
+  Publish a notification to an AWS SNS topic. Requires that AWS authentication
+  already be configured.
+inputs:
+  sns_topic_arn:
+    description: ARN of the SNS topic to publish to.
+    required: true
+  subject:
+    description: Subject for the SNS notification.
+    required: true
+  body:
+    description: Text body for the SNS notification.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Mask topic ARN
+      run: echo "::add-mask::${{ inputs.sns_topic_arn }}"
+
+    - name: Publish SNS topic
+      run: >
+        aws sns publish \
+          --topic-arn "${{ inputs.sns_topic_arn }}" \
+          --subject "${{ inputs.subject }}" \
+          --message "${{ inputs.body }}"
+      shell: bash
+

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -28,7 +28,9 @@ ASSET_API_QUERY_PARAMS = {"$query": "SELECT COUNT(*),year GROUP BY year"}
 DBT = dbtRunner()
 
 # Data for the most recent two years are permitted to be slightly different,
-# according to this buffer value
+# according to this buffer value. This is because we expect some level of
+# change in the Athena data (which is updated daily) compared to the Open Data
+# portal (which is updated bi-weekly or monthly).
 BUFFER = 0.02
 
 

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -18,7 +18,7 @@ DBT = dbtRunner()
 
 # Data for the most recent two years are permitted to be slightly different,
 # according to this buffer value
-BUFFER = 0.2
+BUFFER = 0.02
 
 
 def main() -> None:
@@ -93,7 +93,9 @@ def main() -> None:
             # they're strings (as in our data). This is super annoying but
             # it's still the fastest way we know to print a clean table
             # in Python :\
-            diff_table.print_table(max_rows=None)
+            diff_table.print_table(
+                max_rows=None, max_columns=None, max_column_width=None
+            )
         print()
         raise ValueError("Open data asset test failed")
 

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -6,7 +6,11 @@
 # used to parse exposure data representing open data assets and their
 # dependency graph.
 #
-# Example:
+# Exposures that should be tested are required to have a `meta.test_row_count`
+# attribute set to `true`. Exposures that do not have this attribute set to
+# `true` will not be tested.
+#
+# Example usage:
 #
 #   cd dbt
 #   python3 ../.github/scripts/test_open_data_assets.py target/manifest.json
@@ -43,6 +47,13 @@ def main() -> None:
     diffs: typing.List[typing.List[typing.Dict]] = []
 
     for exposure in dbt_manifest_json["exposures"].values():
+        if not exposure.get("meta", {}).get("test_row_count", False):
+            print(
+                f"Skipping row count test for exposure `{exposure['name']}` "
+                "because it does not have an enabled `meta.test_row_count` attr"
+            )
+            continue
+
         asset_name = exposure["label"]
         asset_url = exposure["url"]
         asset_id = asset_url.split("/")[-1]

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# Run tests on our open data assets
+import contextlib
+import datetime
+import io
+import json
+import pprint
+import sys
+import typing
+
+import requests
+from dbt.cli.main import dbtRunner
+
+# API URL and params that we can use to grab counts by year for each asset
+ASSET_API_URL = "https://datacatalog.cookcountyil.gov/resource/{asset_id}.json"
+ASSET_API_QUERY_PARAMS = {"$query": "SELECT COUNT(*),year GROUP BY year"}
+DBT = dbtRunner()
+
+# Data for the most recent two years are permitted to be slightly different,
+# according to this buffer value
+BUFFER = 0.2
+
+
+def main() -> None:
+    """Entrypoint for the script."""
+    dbt_manifest_path = sys.argv[1]
+    with open(dbt_manifest_path) as dbt_manifest_file:
+        dbt_manifest_json = json.loads(dbt_manifest_file.read())
+
+    errors: typing.List[typing.Dict] = []
+
+    for exposure in dbt_manifest_json["exposures"].values():
+        asset_name = exposure["label"]
+        asset_url = exposure["url"]
+        asset_id = asset_url.split("/")[-1]
+
+        # For now, assume just one dependency table, since all of our open
+        # data assets currently have a 1:1 relationship with a view.
+        fq_source_model_name = exposure["depends_on"]["nodes"][0]
+
+        # Dependency tables in the DAG are fully qualified, so we have to
+        # strip the prefix to get the schema and tablename.
+        source_model_name = ".".join(fq_source_model_name.split(".")[2:])
+
+        print(f"Comparing asset '{asset_name}' to model '{source_model_name}'")
+
+        asset_api_url = ASSET_API_URL.format(asset_id=asset_id)
+        response = requests.get(asset_api_url, params=ASSET_API_QUERY_PARAMS)
+        if not response.ok:
+            print("Encountered error in request to asset endpoint")
+            response.raise_for_status()
+
+        asset_row_counts_by_year = response.json()
+
+        dbt_output = io.StringIO()
+        with contextlib.redirect_stdout(dbt_output):
+            dbt_result = DBT.invoke(
+                [
+                    "--quiet",
+                    "run-operation",
+                    "row_count_by_year",
+                    "--args",
+                    f"{{model: '{source_model_name}', print: true}}",
+                    "--target",
+                    "prod"
+                ]
+            )
+
+        if not dbt_result.success:
+            print("Encountered error in dbt call")
+            raise ValueError(dbt_result.exception)
+
+        source_model_row_counts_by_year = json.loads(dbt_output.getvalue())
+
+        if row_counts_differ(
+            source_model_row_counts_by_year, asset_row_counts_by_year
+        ):
+            errors.append(
+                {
+                    source_model_name: source_model_row_counts_by_year,
+                    asset_name: asset_row_counts_by_year,
+                }
+            )
+
+    if errors:
+        print()
+        print(
+            "The following view/asset pairs did not have matching row "
+            "counts by year:"
+        )
+        print()
+        for error in errors:
+            pprint.pprint(error)
+        print()
+        raise ValueError("Open data asset test failed")
+
+    print("All open data assets have the expected row counts by year!")
+
+
+def row_counts_differ(
+    athena_model_row_counts: typing.List[typing.Dict],
+    open_data_asset_row_counts: typing.List[typing.Dict],
+    current_year_buffer: float = BUFFER,
+) -> bool:
+    """Check whether two lists of row count dicts are the same. Applies a
+    buffer to the current year of data to account for the fact that more
+    recent years may have incomplete data.
+
+    Row count dicts are expected to have a "COUNT" key and a "year" key.
+    The "COUNT" key should represent an integer, but it can be a string
+    representation of an int in the case of open_data_asset_row_counts,
+    where that is the format returned by the Socrata API.
+    """
+    # We expect these lists to already be sorted, but double-check anyway
+    athena_model_row_counts = sorted(
+        athena_model_row_counts, key=lambda x: x["year"]
+    )
+    open_data_asset_row_counts = sorted(
+        open_data_asset_row_counts, key=lambda x: x["year"]
+    )
+
+    # Extract the current and last year since we want to apply different
+    # matching rules to them
+    current_year = datetime.datetime.now().year
+    last_year = current_year - 1
+    current_year, last_year = str(current_year), str(last_year)
+
+    for model_row_count_dict in athena_model_row_counts:
+        model_year = model_row_count_dict["year"]
+        model_count = model_row_count_dict["COUNT"]
+
+        asset_count: int = 0
+        for asset_row_count_dict in open_data_asset_row_counts:
+            if asset_row_count_dict["year"] == model_year:
+                asset_count = int(asset_row_count_dict["COUNT"])
+                break
+        else:
+            # No matching year found, so these two datasets must be different
+            return True
+
+        counts_match = (
+            (
+                model_count * (1 - current_year_buffer)
+                < asset_count
+                < model_count * (1 + current_year_buffer)
+            )
+            if model_year in [current_year, last_year]
+            else asset_count == model_count
+        )
+        if not counts_match:
+            return True
+
+    return False
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -50,7 +50,8 @@ def main() -> None:
         if not exposure.get("meta", {}).get("test_row_count", False):
             print(
                 f"Skipping row count test for exposure `{exposure['name']}` "
-                "because it does not have an enabled `meta.test_row_count` attr"
+                "because it does not have an enabled `meta.test_row_count` "
+                "attribute"
             )
             continue
 
@@ -86,9 +87,9 @@ def main() -> None:
                     "--args",
                     (
                         "{"
-                            f"model: '{source_model_name}', "
-                            "group_by: 'year', "
-                            "print: true"
+                        f"model: '{source_model_name}', "
+                        "group_by: 'year', "
+                        "print: true"
                         "}"
                     ),
                     "--target",

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
-# Run tests on our open data assets
+# Run tests on our open data assets to confirm that their row counts match
+# the row counts of the underlying Athena tables when grouped by year.
+#
+# Requires one positional argument, the path to a dbt manifest that can be
+# used to parse exposure data representing open data assets and their
+# dependency graph.
+#
+# Example:
+#
+#   cd dbt
+#   python3 ../.github/scripts/test_open_data_assets.py target/manifest.json
+
 import contextlib
 import datetime
 import io
@@ -119,7 +130,7 @@ def diff_row_counts(
     Row count dicts are expected to have a "COUNT" key and a "year" key.
     The "COUNT" key should represent an integer, but it can be a string
     representation of an int in the case of open_data_asset_row_counts,
-    where that is the format returned by the Socrata API.
+    since that is the format returned by the Socrata API.
     """
     # We expect these lists to already be sorted, but double-check anyway
     athena_model_row_counts = sorted(

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -82,9 +82,15 @@ def main() -> None:
                 [
                     "--quiet",
                     "run-operation",
-                    "row_count_by_year",
+                    "row_count_by_group",
                     "--args",
-                    f"{{model: '{source_model_name}', print: true}}",
+                    (
+                        "{"
+                            f"model: '{source_model_name}', "
+                            "group_by: 'year', "
+                            "print: true"
+                        "}"
+                    ),
                     "--target",
                     "prod",
                 ]

--- a/.github/workflows/test_dbt_models.yaml
+++ b/.github/workflows/test_dbt_models.yaml
@@ -24,28 +24,19 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
 
-      - name: Create failure notification body
-        id: create-message
+      - name: Get current time
         if: failure()
-        run: |
-          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S")
-          {
-            echo "notification_subject=dbt tests failed for workflow run: $GITHUB_RUN_ID UTC"
-            echo "notification_body<<EOF"
-            echo "dbt tests failed for workflow $GITHUB_RUN_ID, run on $TIMESTAMP"
-            echo ""
-            echo "Link to failing workflow: \
-          https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
+        run: echo "TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S")" >> "$GITHUB_ENV"
         shell: bash
 
-      - name: Send SNS failure notification
+      - name: Send failure notification
         if: failure()
-        id: send-message
-        run: >
-          aws sns publish \
-            --topic-arn ${{ secrets.AWS_SNS_NOTIFICATION_TOPIC_ARN }} \
-            --subject "${{ steps.create-message.outputs.notification_subject }}" \
-            --message "${{ steps.create-message.outputs.notification_body }}"
-        shell: bash
+        uses: ./.github/actions/publish_sns_topic
+        with:
+          sns_topic_arn: ${{ secrets.AWS_SNS_NOTIFICATION_TOPIC_ARN }}
+          subject: "dbt tests failed for workflow run: ${{ github.run_id }} UTC"
+          body: |
+            dbt tests failed for workflow ${{ github.run_id }}, run on ${{ env.TIMESTAMP }}
+
+            Link to failing workflow:
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/test_open_data_assets.yaml
+++ b/.github/workflows/test_open_data_assets.yaml
@@ -1,15 +1,22 @@
-name: test-dbt-models
+name: test-open-data-assets
 
-on: workflow_dispatch
+on:
+  # TODO: Remove this once we've finished testing
+  pull_request:
+    branches: [master]
+  schedule:
+    # Every Monday at 9am CST (3pm UTC)
+    - cron: '0 15 * * 1'
 
 jobs:
-  test-dbt-models:
+  test-open-data-assets:
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint
     # so that we can authenticate with AWS
     permissions:
       id-token: write
       contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -19,8 +26,17 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
 
-      - name: Test models
-        run: dbt test --target "$TARGET"
+      - name: Install Python requirements
+        run: pip install requests
+        shell: bash
+
+      - name: Compile dbt manifest
+        run: dbt compile
+        working-directory: ${{ env.PROJECT_DIR }}
+        shell: bash
+
+      - name: Test that open data row counts match Athena views
+        run: python3 ../.github/scripts/test_open_data_assets.py target/manifest.json
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
 
@@ -34,9 +50,9 @@ jobs:
         uses: ./.github/actions/publish_sns_topic
         with:
           sns_topic_arn: ${{ secrets.AWS_SNS_NOTIFICATION_TOPIC_ARN }}
-          subject: "dbt tests failed for workflow run: ${{ github.run_id }}"
+          subject: "Open data asset tests failed for workflow run: ${{ github.run_id }}"
           body: |
-            dbt tests failed for workflow ${{ github.run_id }}, run on ${{ env.TIMESTAMP }} UTC
+            Open data asset tests failed for workflow ${{ github.run_id }}, run on ${{ env.TIMESTAMP }} UTC
 
             Link to failing workflow:
             https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/test_open_data_assets.yaml
+++ b/.github/workflows/test_open_data_assets.yaml
@@ -1,12 +1,13 @@
 name: test-open-data-assets
 
 on:
-  # TODO: Remove this once we've finished testing
-  pull_request:
-    branches: [master]
   schedule:
-    # Every Monday at 9am CST (3pm UTC)
-    - cron: '0 15 * * 1'
+    # Every third day of the month at 9am CST (3pm UTC). This schedule
+    # makes sense since most of our assets are configured to refresh on the
+    # first day of the month. Some assets have a biweekly schedule such
+    # that they also refresh in the middle of the month, but we ignore that
+    # in order to make scheduling simpler.
+    - cron: '0 15 3 * *'
 
 jobs:
   test-open-data-assets:
@@ -16,7 +17,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test_open_data_assets.yaml
+++ b/.github/workflows/test_open_data_assets.yaml
@@ -1,8 +1,6 @@
 name: test-open-data-assets
 
 on:
-  # TODO: Remove this after testing
-  pull_request:
   schedule:
     # Every third day of the month at 9am CST (3pm UTC). This schedule
     # makes sense since most of our assets are configured to refresh on the

--- a/.github/workflows/test_open_data_assets.yaml
+++ b/.github/workflows/test_open_data_assets.yaml
@@ -26,10 +26,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
 
-      - name: Install Python requirements
-        run: pip install requests
-        shell: bash
-
       - name: Compile dbt manifest
         run: dbt compile
         working-directory: ${{ env.PROJECT_DIR }}

--- a/.github/workflows/test_open_data_assets.yaml
+++ b/.github/workflows/test_open_data_assets.yaml
@@ -1,6 +1,8 @@
 name: test-open-data-assets
 
 on:
+  # TODO: Remove this after testing
+  pull_request:
   schedule:
     # Every third day of the month at 9am CST (3pm UTC). This schedule
     # makes sense since most of our assets are configured to refresh on the

--- a/.github/workflows/test_open_data_assets.yaml
+++ b/.github/workflows/test_open_data_assets.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup dbt
         uses: ./.github/actions/setup_dbt

--- a/dbt/macros/row_count_by_group.sql
+++ b/dbt/macros/row_count_by_group.sql
@@ -1,19 +1,16 @@
 -- Macro that takes a model and returns its row count grouped and
--- sorted by year.
---
--- The name of the column containing year data can be specified with
--- the `year_column` argument, defaulting to "year". The sort order
--- can be specified with the `ordering` argument, defaulting to "asc".
+-- sorted by a given column. The sort order for the results can be specified
+-- with the `ordering` argument, defaulting to "asc".
 --
 -- If the `print` argument is set to True (default is False), the macro will
 -- print the results of the query to stdout, which allows this macro to be used
 -- by scripts to return data.
-{% macro row_count_by_year(model, year_column="year", ordering="asc", print=False) %}
+{% macro row_count_by_group(model, group_by, ordering="asc", print=False) %}
     {% set query %}
-        select count(*) as COUNT, {{ year_column }}
+        select count(*) as COUNT, {{ group_by }}
         from {{ model }}
-        group by {{ year_column }}
-        order by {{ year_column }} {{ ordering }}
+        group by {{ group_by }}
+        order by {{ group_by }} {{ ordering }}
     {% endset %}
 
     {% if print %}

--- a/dbt/macros/row_count_by_year.sql
+++ b/dbt/macros/row_count_by_year.sql
@@ -1,0 +1,24 @@
+-- Macro that takes a model and returns its row count grouped and
+-- sorted by year.
+--
+-- The name of the column containing year data can be specified with
+-- the `year_column` argument, defaulting to "year". The sort order
+-- can be specified with the `ordering` argument, defaulting to "asc".
+--
+-- If the `print` argument is set to True (default is False), the macro will
+-- print the results of the query to stdout, which allows this macro to be used
+-- by scripts to return data.
+{% macro row_count_by_year(model, year_column="year", ordering="asc", print=False) %}
+    {% set query %}
+        select count(*) as COUNT, {{ year_column }}
+        from {{ model }}
+        group by {{ year_column }}
+        order by {{ year_column }} {{ ordering }}
+    {% endset %}
+
+    {% if print %}
+        {% set results = run_query(query) %} {{ results.print_json() }}
+    {% endif %}
+
+    {{ return(query) }}
+{% endmacro %}

--- a/dbt/models/default/schema.yml
+++ b/dbt/models/default/schema.yml
@@ -716,6 +716,8 @@ exposures:
       - ref('default.vw_pin_universe')
     owner:
       name: Data Department
+    meta:
+      test_row_count: true
     description: |
       A complete, historic universe of Cook County parcels with attached geographic, governmental, and spatial data.
 
@@ -731,6 +733,8 @@ exposures:
       - ref('default.vw_card_res_char')
     owner:
       name: Data Department
+    meta:
+      test_row_count: true
     description: |
       Single and multi-family (less than 7 units) property characteristics collected and maintained by the Assessor's Office for all of Cook County, from 1999 to present.
 
@@ -750,6 +754,8 @@ exposures:
       - ref('default.vw_pin_condo_char')
     owner:
       name: Data Department
+    meta:
+      test_row_count: true
     description: |
       Residential condominium unit characteristics collected and maintained by the Assessor's office for all of Cook County, from 1999 to present.
 
@@ -767,6 +773,8 @@ exposures:
       - ref('default.vw_pin_sale')
     owner:
       name: Data Department
+    meta:
+      test_row_count: true
     description: |
       Parcel sales for real property in Cook County, from 1999 to present.
 
@@ -782,6 +790,8 @@ exposures:
       - ref('default.vw_pin_history')
     owner:
       name: Data Department
+    meta:
+      test_row_count: true
     description: |
       Land, building, and total assessed values for all Cook County parcels, from 1999 to present.
 
@@ -797,6 +807,8 @@ exposures:
       - ref('default.vw_pin_appeal')
     owner:
       name: Data Department
+    meta:
+      test_row_count: true
     description: |
       Land, building, and total assessed values, pre and post-appeal with the Cook County Assessor’s office, for all Cook County parcels, from 1999 to present.
 
@@ -812,6 +824,8 @@ exposures:
       - ref('default.vw_pin_address')
     owner:
       name: Data Department
+    meta:
+      test_row_count: true
     description: |
       Situs and mailing addresses of Cook County parcels.
 
@@ -827,6 +841,8 @@ exposures:
       - ref('default.vw_pin_exempt')
     owner:
       name: Data Department
+    meta:
+      test_row_count: true
     description: |
       Parcels with property tax-exempt status across all of Cook County per tax year, from Tax Year 2022 on, with geographic coordinates and addresses.
 

--- a/dbt/models/default/schema.yml
+++ b/dbt/models/default/schema.yml
@@ -706,3 +706,130 @@ models:
       # TODO: Data completeness correlates with availability of spatial data
       # by year
   - name: default.vw_pin_exempt
+
+exposures:
+  - name: parcel_universe
+    label: Parcel Universe
+    type: dashboard
+    url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Parcel-Universe/nj4t-kc8j
+    depends_on:
+      - ref('default.vw_pin_universe')
+    owner:
+      name: Data Department
+    description: |
+      A complete, historic universe of Cook County parcels with attached geographic, governmental, and spatial data.
+
+      Notes: Contains a cornucopia of locational and spatial data for all parcels in Cook County.
+
+      Use cases: Joining parcel-level data to this dataset allows analysis and reporting across a number of different political, tax, Census, and other boundaries.
+
+  - name: single_and_multi_family_improvement_characteristics
+    label: Single and Multi-Family Improvement Characteristics
+    type: dashboard
+    url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Single-and-Multi-Family-Improvement-Chara/x54s-btds
+    depends_on:
+      - ref('default.vw_card_res_char')
+    owner:
+      name: Data Department
+    description: |
+      Single and multi-family (less than 7 units) property characteristics collected and maintained by the Assessor's Office for all of Cook County, from 1999 to present.
+
+      Notes: Residential PINs with multiple improvements (living structures) will have one card for each improvement.
+
+      Use cases: This data describes the location and physical characteristics of all single and multi-family improvements in the county. It can be:
+
+        * Used on its own to characterize the housing stock in a specific location
+        * Joined to assessments for analysis of assessments across geographies and housing types
+        * Joined to sales for the construction of hedonic home value estimates
+
+  - name: residential_condominium_unit_characteristics
+    label: Residential Condominium Unit Characteristics
+    type: dashboard
+    url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Residential-Condominium-Unit-Characteri/3r7i-mrz4
+    depends_on:
+      - ref('default.vw_pin_condo_char')
+    owner:
+      name: Data Department
+    description: |
+      Residential condominium unit characteristics collected and maintained by the Assessor's office for all of Cook County, from 1999 to present.
+
+      Use cases: This data describes the location and physical characteristics of all condominium units in the county. Condominium units are associated with substantially less characteristic data than single and multi-family improvements. It can be:
+
+        * Used on its own to characterize the housing stock in a specific location
+        * Joined to assessments for analysis of assessments across geographies and housing types
+        * Joined to sales for the construction of hedonic home value estimates
+
+  - name: parcel_sales
+    label: Parcel Sales
+    type: dashboard
+    url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Parcel-Sales/wvhk-k5uv
+    depends_on:
+      - ref('default.vw_pin_sale')
+    owner:
+      name: Data Department
+    description: |
+      Parcel sales for real property in Cook County, from 1999 to present.
+
+      Notes: Refreshed monthly, though data may only change roughly quarterly depending on how often new sales are added to iasWorld.
+
+      Use cases: Alone, sales data can be used to characterize real estate markets. Sales paired with characteristics can be used to find comparable properties or as an input to an automated modeling application. Sales paired with assessments can be used to calculate sales ratio statistics. Outliers can be easily removed using filters constructed from class, township, and year variables.
+
+  - name: assessed_values
+    label: Assessed Values
+    type: dashboard
+    url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Assessed-Values/uzyt-m557
+    depends_on:
+      - ref('default.vw_pin_history')
+    owner:
+      name: Data Department
+    description: |
+      Land, building, and total assessed values for all Cook County parcels, from 1999 to present.
+
+      Notes: Refreshed monthly, data is updated as towns are mailed/certified by Valuations and the Board of Review.
+
+      Use cases: Alone, can characterize assessments in a given area. Can be combined with characteristic data to make more nuanced generalizations about assessments. Can be combined with sales data to conduct ratio studies.
+
+  - name: appeals
+    label: Appeals
+    type: dashboard
+    url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Appeals/y282-6ig3
+    depends_on:
+      - ref('default.vw_pin_appeal')
+    owner:
+      name: Data Department
+    description: |
+      Land, building, and total assessed values, pre and post-appeal with the Cook County Assessor’s office, for all Cook County parcels, from 1999 to present.
+
+      Notes: Refreshed monthly, data is updated as towns are mailed/certified by Valuations.
+
+      Use cases: Alone, can be used to investigate appeal trends. Can be combined with geographies to see how AV shifts around the county between mailing and assessor certified stages.
+
+  - name: parcel_addresses
+    label: Parcel Addresses
+    type: dashboard
+    url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Parcel-Addresses/3723-97qp
+    depends_on:
+      - ref('default.vw_pin_address')
+    owner:
+      name: Data Department
+    description: |
+      Situs and mailing addresses of Cook County parcels.
+
+      Notes: Refreshed monthly, data is updated as towns are mailed/certified by Valuations.
+
+      Use cases: Can be used for geocoding or joining address-level data to other datasets.
+
+  - name: property_tax_exempt_parcels
+    label: Property Tax-Exempt Parcels
+    type: dashboard
+    url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Property-Tax-Exempt-Parcels/vgzx-68gb
+    depends_on:
+      - ref('default.vw_pin_exempt')
+    owner:
+      name: Data Department
+    description: |
+      Parcels with property tax-exempt status across all of Cook County per tax year, from Tax Year 2022 on, with geographic coordinates and addresses.
+
+      Notes: Refreshed monthly, data is updated when necessary as PINs are re-classified.
+
+      Use cases: Can be used to study parcels that are exempted from paying property taxes.

--- a/dbt/models/proximity/schema.yml
+++ b/dbt/models/proximity/schema.yml
@@ -27,3 +27,19 @@ models:
   - name: proximity.dist_pin_to_water
   - name: proximity.vw_pin10_proximity
   - name: proximity.vw_pin10_proximity_fill
+
+exposures:
+  - name: parcel_proximity
+    label: Parcel Proximity
+    type: dashboard
+    url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Parcel-Proximity/ydue-e5u3
+    depends_on:
+      - ref('proximity.vw_pin10_proximity')
+    owner:
+      name: Data Department
+    description: |
+      Cook County 10-digit parcels with attached distances to various spatial features.
+
+      Notes: Refreshed monthly, data is updated yearly as spatial files are made available.
+
+      Use cases: Can be used to isolate parcels by distance to specific spatial features.

--- a/dbt/models/proximity/schema.yml
+++ b/dbt/models/proximity/schema.yml
@@ -37,6 +37,8 @@ exposures:
       - ref('proximity.vw_pin10_proximity')
     owner:
       name: Data Department
+    meta:
+      test_row_count: true
     description: |
       Cook County 10-digit parcels with attached distances to various spatial features.
 


### PR DESCRIPTION
This PR adds a new scheduled workflow `test-open-data-assets` that runs a Python script once a month to confirm that the row counts of our open data assets match the row counts of the views that produce them. The goal here is to create a system that can alert us if the Socrata agent is silently failing to publish rows for some data sets, which is behavior we've experienced in the past.

In order to implement this alerting system, this PR makes two major refactors:

* The logic that the `test-dbt-models` workflow uses to push failure notifications to SNS is factored out into a composite action, `publish_sns_topic`, so that it can be reused by the new workflow that runs open data tests.
* [Exposures](https://docs.getdbt.com/docs/build/exposures) are added to the dbt DAG for all of our open data assets except for [Neighborhood Boundaries](https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Neighborhood-Boundaries/pcdw-pxtg) (which doesn't have a `year` field, so I'm unsure if it should be tested). These exposure configurations allow the Python script to programmatically parse the metadata for our open data assets and compare it to the dbt models that produced it.

Note that my [test workflow run](https://github.com/ccao-data/data-architecture/actions/runs/6487851859/job/17619059598) did not actually pass, but we agreed in an out-of-band discussion that the failures are most likely due to the fact that data was last refreshed nearly two weeks ago, so we're going to wait till these tests run on 11/3 to see if we need to make any further adjustments.

Closes https://github.com/ccao-data/data-architecture/issues/115.