### PR TITLE
Update guidance on defining model descriptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-dbt-model.md
+++ b/.github/ISSUE_TEMPLATE/new-dbt-model.md
@@ -39,7 +39,6 @@ Otherwise, delete it in favor of the long checklist in the following section.)_
   file, and update `dbt_project.yml` to document the `+schema`
 - [ ] Add a symlink from the appropriate subfolder of the `dbt/models/`
   directory to the new SQL query in the `aws-athena/` directory
-- [ ] Add docs for the model to the subdirectory `docs.md` file
 - [ ] Update the `schema.yml` file in the subfolder of `dbt/models/` where you
   created your symlink to add a definition for your model
 - [ ] Add tests to your new model definition in `schema.yml`
@@ -166,30 +165,9 @@ cat dbt/models/default/default.vw_new_model.sql
 cat dbt/models/default/default.new_model.sql
 ```
 
-- [ ] Add or edit the docs file for the `dbt/models/` subdirectory your symlink
-  is in to add docs for your model.
-
-
-```diff
-# Table example (only the model name would change for a view)
---- a/dbt/models/default/docs.md
-+++ b/dbt/models/default/docs.md
-
- `spatial.township` is not yearly.
- {% enddocs %}
-
-+{% docs new_model %}
-+
-+Your Markdown docs go here.
-+
-+{% enddocs %}
-+
- {% docs vw_pin_value %}
- CCAO mailed total, CCAO final, and BOR final values for each PIN by year.
-```
-
 - [ ] Update the `schema.yml` file in the subfolder of `dbt/models/` where you
-  created your symlink to add a definition for your model.
+  created your symlink to add a definition for your model. Make sure to add
+  descriptions for new entities (models, sources, columns, etc).
 
 ```diff
 # Table example (only the model name would change for a view)
@@ -198,14 +176,14 @@ cat dbt/models/default/default.new_model.sql
 
  models:
 +  - name: default.new_model
-+    description: '{{ doc("new_model") }}'
++    description: New model
 +    columns:
 +      - name: pin10
 +        description: 10-digit PIN
 +      - name: year
 +        description: Year
    - name: default.vw_pin_history
-     description: '{{ doc("vw_pin_history") }}'
+     description: PIN history
      tests:
 ```
 
@@ -218,7 +196,7 @@ cat dbt/models/default/default.new_model.sql
 
  models:
    - name: default.new_model
-     description: '{{ doc("new_model") }}'
+     description: New model
      columns:
        - name: pin10
          description: 10-digit PIN
@@ -231,7 +209,7 @@ cat dbt/models/default/default.new_model.sql
 +          - pin
 +          - year
    - name: default.vw_pin_history
-     description: '{{ doc("vw_pin_history") }}'
+     description: PIN history
      tests:
 ```
 

--- a/.github/ISSUE_TEMPLATE/new-dbt-model.md
+++ b/.github/ISSUE_TEMPLATE/new-dbt-model.md
@@ -15,17 +15,17 @@ _(Brief description of the task here.)_
 ## Model attributes
 
 * **Name**: _(What should the model be called? See [Model
- naming](/ccao-data/data-architecture#model-naming) for guidance.)_
+ naming](/ccao-data/data-architecture/tree/master/dbt#model-naming) for guidance.)_
 * **Materialization**: _(Should the model be a table or a view? See [Model
-  materialization](/ccao-data/data-architecture#model-materialization) for
+  materialization](/ccao-data/data-architecture/tree/master/dbt#model-materialization) for
   guidance.)_
 * **Tests**:
   * _(Add a bulleted list of tests here. See [Model
-  tests](/ccao-data/data-architecture#model-tests) for guidance.)_
+  tests](/ccao-data/data-architecture/tree/master/dbt#model-tests) for guidance.)_
 * **Description**: _(Provide a rich description for this model that will be
   displayed in documentation. Markdown is supported, and encouraged for more
   complex models. See [Model
-  description](/ccao-data/data-architecture#model-description) for guidance.)_
+  description](/ccao-data/data-architecture/tree/master/dbt#model-description) for guidance.)_
 
 ## Short checklist
 
@@ -116,9 +116,6 @@ using (pin10, year)
 ```yaml
 # Table example (only the model name would change for a view)
 # schema.yml
-version: 2
-
-
 models:
   - name: default.new_model
 ```
@@ -167,7 +164,10 @@ cat dbt/models/default/default.new_model.sql
 
 - [ ] Update the `schema.yml` file in the subfolder of `dbt/models/` where you
   created your symlink to add a definition for your model. Make sure to add
-  descriptions for new entities (models, sources, columns, etc).
+  descriptions for new entities (models, sources, columns, etc). See
+  [Model description](ccao-data/data-architecture/tree/master/dbt#model-description)
+  and [Column descriptions](ccao-data/data-architecture/tree/master/dbt#column-descriptions)
+  for specific guidance on doc locations and using docs blocks
 
 ```diff
 # Table example (only the model name would change for a view)

--- a/.github/ISSUE_TEMPLATE/new-dbt-model.md
+++ b/.github/ISSUE_TEMPLATE/new-dbt-model.md
@@ -165,8 +165,8 @@ cat dbt/models/default/default.new_model.sql
 - [ ] Update the `schema.yml` file in the subfolder of `dbt/models/` where you
   created your symlink to add a definition for your model. Make sure to add
   descriptions for new entities (models, sources, columns, etc). See
-  [Model description](ccao-data/data-architecture/tree/master/dbt#model-description)
-  and [Column descriptions](ccao-data/data-architecture/tree/master/dbt#column-descriptions)
+  [Model description](/ccao-data/data-architecture/tree/master/dbt#model-description)
+  and [Column descriptions](/ccao-data/data-architecture/tree/master/dbt#column-descriptions)
   for specific guidance on doc locations and using docs blocks
 
 ```diff

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -354,17 +354,21 @@ Finally, for the sake of consistency and ease of interpretation, all tables and 
 
 All new models should include, at minimum, a
 [description](https://docs.getdbt.com/reference/resource-properties/description)
-of the model itself. We generally store these descriptions as [docs
-blocks](https://docs.getdbt.com/reference/resource-properties/description#use-a-docs-block-in-a-description).
+of the model itself. We use the following pattern to determine where to
+define the Markdown text that comprises these descriptions:
 
-New models should also include descriptions for each column,
-implemented directly in the `schema.yml` model definition. Docs blocks are
-generally not necessary for column descriptions, since column descriptions
-should be kept short and simple so that docs readers can scan them from the
-context of the "Columns" table.
+* If a description is shared between two or fewer resources (models, sources,
+  columns, etc.), its text should be defined inline in the `schema.yml` file
+  under the `description` key for the resource
+* If a description is shared between three or more resources, its text should
+  be defined as a [docs block](https://docs.getdbt.com/reference/resource-properties/description#use-a-docs-block-in-a-description).
 
-Any documentation for a column beyond its basic summary should be stored in
-a `meta.notes` attribute on the column.
+New models should also include descriptions for each column. Since the first
+few characters of a column description will be shown in the documentation in
+a dedicated column on the "Columns" table, column descriptions should always
+start with a sentence that is short and simple enough that docs readers can
+scan it from the context of the "Columns" table and understand what the column
+represents at a high level.
 
 ### Model tests
 

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -362,6 +362,8 @@ define the Markdown text that comprises these descriptions:
   under the `description` key for the resource
 * If a description is shared between three or more resources, its text should
   be defined as a [docs block](https://docs.getdbt.com/reference/resource-properties/description#use-a-docs-block-in-a-description).
+  If the docs block represents text that will be used by columns, its identifier
+  should have a `column_` prefix.
 
 New models should also include descriptions for each column. Since the first
 few characters of a column description will be shown in the documentation in

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -348,29 +348,59 @@ names of tables and views in Athena
 In addition to database namespacing, views should be named with a `vw_` prefix
 (e.g. `location.vw_pin10_location`) to mark them as a view, while tables do not
 require any prefix (e.g. `location.tax`).
+
 Finally, for the sake of consistency and ease of interpretation, all tables and views should be named using the singular case e.g. `location.tax` rather than `location.taxes`.
+
+### Model location
+
+Models are generally defined in the `schema.yml` file within each database
+subdirectory. Resources related to each model should be defined inline (with
+the exception of columns, see [Column descriptions](#column-descriptions).
+
+For complicated models with *many* columns or tests, we split `schema.yml`
+files into individual files per model. These files should be contained in a
+`schema/` subdirectory within each database directory, and should be named
+using the fully namespaced model name. For example, the model definition
+for `iasworld.sales` lives in `models/iasworld/schema/iasworld.sales.yml`.
 
 ### Model description
 
 All new models should include, at minimum, a
 [description](https://docs.getdbt.com/reference/resource-properties/description)
-of the model itself. We use the following pattern to determine where to
-define the Markdown text that comprises these descriptions:
+of the model itself. We store these model-level descriptions as [docs
+blocks](https://docs.getdbt.com/reference/resource-properties/description#use-a-docs-block-in-a-description)
+within the `docs.md` file of each schema subdirectory.
 
-* If a description is shared between two or fewer resources (models, sources,
-  columns, etc.), its text should be defined inline in the `schema.yml` file
-  under the `description` key for the resource
-* If a description is shared between three or more resources, its text should
-  be defined as a [docs block](https://docs.getdbt.com/reference/resource-properties/description#use-a-docs-block-in-a-description).
-  If the docs block represents text that will be used by columns, its identifier
-  should have a `column_` prefix.
+Descriptions related to models in a `schema/` subdirectory should still live
+in `docs.md`. For example, the description for `default.vw_pin_universe` lives
+in `models/default/docs.md`.
+
+#### Column descriptions
 
 New models should also include descriptions for each column. Since the first
 few characters of a column description will be shown in the documentation in
 a dedicated column on the "Columns" table, column descriptions should always
-start with a sentence that is short and simple enough that docs readers can
-scan it from the context of the "Columns" table and understand what the column
-represents at a high level.
+start with a sentence that is short and simple. This allows docs readers to
+scan the "Columns" table and understand what the column represents at a high level.
+
+Column descriptions can live in three separate places with the following hierarchy:
+
+1. `models/shared_columns.md` - Definitions shared across all databases and models
+2. `models/$DATEBASE/columns.md` - Definitions shared across a single database
+3. `models/$DATEBASE/schema.yml` OR `models/$DATABASE/schema/$DATABASE-$MODEL.yml` - Definitions specific to a single model
+
+We use the following pattern to determine where to define each column description:
+
+1. If a description is shared by three or more resources *across multiple
+  databases*, its text should be defined as a [docs block](https://docs.getdbt.com/reference/resource-properties/description#use-a-docs-block-in-a-description) in `models/shared_columns.md`.
+  The docs block identifier for each column should have a `shared_column_` prefix.
+2. If a description is shared by three or more resources *across multiple
+  models in the same database*, its text should be defined as a
+  [docs block](https://docs.getdbt.com/reference/resource-properties/description#use-a-docs-block-in-a-description) in `models/$DATABASE/columns.md`.
+  The docs block identifier for each column should have a `column_` prefix.
+3. If a description is shared between two or fewer columns, its text should
+  be defined inline in the `schema.yml` file under the `description` key for
+  the column.
 
 ### Model tests
 

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -386,8 +386,8 @@ scan the "Columns" table and understand what the column represents at a high lev
 Column descriptions can live in three separate places with the following hierarchy:
 
 1. `models/shared_columns.md` - Definitions shared across all databases and models
-2. `models/$DATEBASE/columns.md` - Definitions shared across a single database
-3. `models/$DATEBASE/schema.yml` OR `models/$DATABASE/schema/$DATABASE-$MODEL.yml` - Definitions specific to a single model
+2. `models/$DATABASE/columns.md` - Definitions shared across a single database
+3. `models/$DATABASE/schema.yml` OR `models/$DATABASE/schema/$DATABASE-$MODEL.yml` - Definitions specific to a single model
 
 We use the following pattern to determine where to define each column description:
 


### PR DESCRIPTION
In https://github.com/ccao-data/data-architecture/pull/164, we're moving to a new pattern where we only use doc blocks for descriptions if they're reused by >2 entities. This PR updates our guidance to ensure that this pattern is documented.