### PR TITLE
Update view to contain sales val characteristics

### DIFF
--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -207,7 +207,7 @@ mydec_sales AS (
 ),
 
 sales_val AS (
-    SELECT 
+    SELECT
         meta_sale_document_num,
         sv_is_outlier,
         sv_is_ptax_outlier,
@@ -216,7 +216,7 @@ sales_val AS (
         run_id,
         version
     FROM (
-        SELECT 
+        SELECT
             meta_sale_document_num,
             sv_is_outlier,
             sv_is_ptax_outlier,
@@ -224,9 +224,11 @@ sales_val AS (
             sv_outlier_type,
             run_id,
             version,
-            ROW_NUMBER() OVER (PARTITION BY meta_sale_document_num ORDER BY version DESC) AS rn
+            ROW_NUMBER()
+                OVER (PARTITION BY meta_sale_document_num ORDER BY version DESC)
+                AS rn
         FROM {{ source('sale', 'flag') }}
-    ) tmp
+    ) AS tmp
     WHERE rn = 1
 )
 

--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -305,7 +305,7 @@ SELECT
     sales_val.sv_is_heuristic_outlier,
     sales_val.sv_outlier_type,
     sales_val.sv_run_id,
-    sales_val.sv_version AS 
+    sales_val.sv_version
 FROM unique_sales
 LEFT JOIN sale_filter
     ON unique_sales.township_code = sale_filter.township_code

--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -216,17 +216,17 @@ max_version_flag AS (
 
 sales_val AS (
     SELECT
-        f.meta_sale_document_num,
-        f.sv_is_outlier,
-        f.sv_is_ptax_outlier,
-        f.sv_is_heuristic_outlier,
-        f.sv_outlier_type,
-        f.run_id AS sv_run_id,
-        f.version AS sv_version
-    FROM {{ source('sale', 'flag') }} AS f
+        sf.meta_sale_document_num,
+        sf.sv_is_outlier,
+        sf.sv_is_ptax_outlier,
+        sf.sv_is_heuristic_outlier,
+        sf.sv_outlier_type,
+        sf.run_id AS sv_run_id,
+        sf.version AS sv_version
+    FROM {{ source('sale', 'flag') }} AS sf
     JOIN max_version_flag AS mv
-        ON f.meta_sale_document_num = mv.meta_sale_document_num
-        AND f.version = mv.max_version
+        ON sf.meta_sale_document_num = mv.meta_sale_document_num
+        AND sf.version = mv.max_version
 )
 
 SELECT

--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -220,7 +220,7 @@ mydec_sales AS (
 max_version_flag AS (
     SELECT
         meta_sale_document_num,
-        MAX(version) as max_version
+        MAX(version) AS max_version
     FROM {{ source('sale', 'flag') }}
     GROUP BY meta_sale_document_num
 ),
@@ -235,7 +235,7 @@ sales_val AS (
         sf.run_id AS sv_run_id,
         sf.version AS sv_version
     FROM {{ source('sale', 'flag') }} AS sf
-    JOIN max_version_flag AS mv
+    INNER JOIN max_version_flag AS mv
         ON sf.meta_sale_document_num = mv.meta_sale_document_num
         AND sf.version = mv.max_version
 )

--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -221,8 +221,8 @@ sales_val AS (
         f.sv_is_ptax_outlier,
         f.sv_is_heuristic_outlier,
         f.sv_outlier_type,
-        f.run_id,
-        f.version
+        f.run_id AS sv_run_id,
+        f.version AS sv_version
     FROM {{ source('sale', 'flag') }} AS f
     JOIN max_version_flag AS mv
         ON f.meta_sale_document_num = mv.meta_sale_document_num
@@ -304,8 +304,8 @@ SELECT
     sales_val.sv_is_ptax_outlier,
     sales_val.sv_is_heuristic_outlier,
     sales_val.sv_outlier_type,
-    sales_val.run_id,
-    sales_val.version
+    sales_val.sv_run_id,
+    sales_val.sv_version AS 
 FROM unique_sales
 LEFT JOIN sale_filter
     ON unique_sales.township_code = sale_filter.township_code

--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -311,12 +311,7 @@ SELECT
     mydec_sales.homestead_exemption_general_alternative,
     mydec_sales.homestead_exemption_senior_citizens,
     mydec_sales.homestead_exemption_senior_citizens_assessment_freeze,
-    sales_val.sv_is_outlier,
-    sales_val.sv_is_ptax_outlier,
-    sales_val.sv_is_heuristic_outlier,
-    sales_val.sv_outlier_type,
-    sales_val.sv_run_id,
-    sales_val.sv_version
+    sales_val.*
 FROM unique_sales
 LEFT JOIN sale_filter
     ON unique_sales.township_code = sale_filter.township_code


### PR DESCRIPTION
This PR successfully joins (tested in dbt, view is on my dev database) the sales val data into `default.vw_pin_sale`. 

Outstanding questions:
- Column order
- What do we do with prior sale filter data
- Correct columns included
- Column names

Closes #97 