### PR TITLE
Address randomness caused by athena tiebreak in bad_doc_no

### DIFF
--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -83,7 +83,7 @@ unique_sales AS (
             -- duplicate document number.
             ROW_NUMBER() OVER (
                 PARTITION BY NULLIF(REPLACE(sales.instruno, 'D', ''), '')
-                ORDER BY sales.saledt
+                ORDER BY sales.saledt, sales.salekey ASC
             ) AS bad_doc_no,
             -- Some pins sell for the exact same price a few months after
             -- they're sold. These sales are unecessary for modeling and may be

--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -83,7 +83,7 @@ unique_sales AS (
             -- duplicate document number.
             ROW_NUMBER() OVER (
                 PARTITION BY NULLIF(REPLACE(sales.instruno, 'D', ''), '')
-                ORDER BY sales.saledt, sales.salekey ASC
+                ORDER BY sales.saledt ASC, sales.salekey ASC
             ) AS bad_doc_no,
             -- Some pins sell for the exact same price a few months after
             -- they're sold. These sales are unecessary for modeling and may be


### PR DESCRIPTION
The new `bad_doc_no` column was not sorted enough to avoid tiebreakers and was causing different row counts each time the view was queried.