### PR TITLE
Drop sales val outputs from legacy sale view

### DIFF
--- a/aws-athena/views/default-legacy_vw_pin_sale.sql
+++ b/aws-athena/views/default-legacy_vw_pin_sale.sql
@@ -224,14 +224,6 @@ mydec_sales AS (
     not, so we'll exclude them to avoid afore mentioned duplicates. */
     WHERE num_cards_sale = 1
         OR (YEAR(mydec_date) > 2020)
-),
-
-max_version_flag AS (
-    SELECT
-        meta_sale_document_num,
-        MAX(version) AS max_version
-    FROM {{ source('sale', 'flag') }}
-    GROUP BY meta_sale_document_num
 )
 
 SELECT

--- a/aws-athena/views/default-legacy_vw_pin_sale.sql
+++ b/aws-athena/views/default-legacy_vw_pin_sale.sql
@@ -232,21 +232,6 @@ max_version_flag AS (
         MAX(version) AS max_version
     FROM {{ source('sale', 'flag') }}
     GROUP BY meta_sale_document_num
-),
-
-sales_val AS (
-    SELECT
-        sf.meta_sale_document_num,
-        sf.sv_is_outlier,
-        sf.sv_is_ptax_outlier,
-        sf.sv_is_heuristic_outlier,
-        sf.sv_outlier_type,
-        sf.run_id AS sv_run_id,
-        sf.version AS sv_version
-    FROM {{ source('sale', 'flag') }} AS sf
-    INNER JOIN max_version_flag AS mv
-        ON sf.meta_sale_document_num = mv.meta_sale_document_num
-        AND sf.version = mv.max_version
 )
 
 SELECT
@@ -319,8 +304,7 @@ SELECT
     mydec_sales.is_homestead_exemption,
     mydec_sales.homestead_exemption_general_alternative,
     mydec_sales.homestead_exemption_senior_citizens,
-    mydec_sales.homestead_exemption_senior_citizens_assessment_freeze,
-    sales_val.*
+    mydec_sales.homestead_exemption_senior_citizens_assessment_freeze
 FROM unique_sales
 LEFT JOIN sale_filter
     ON unique_sales.township_code = sale_filter.township_code
@@ -330,5 +314,3 @@ LEFT JOIN sale_filter
 LEFT JOIN mydec_sales
     ON unique_sales.doc_no = mydec_sales.doc_no
     AND unique_sales.pin = mydec_sales.pin
-LEFT JOIN sales_val
-    ON unique_sales.doc_no = sales_val.meta_sale_document_num;


### PR DESCRIPTION
This PR drops the (unused) sales val model outputs from the temporary legacy sales view. The view is currently throwing the following error due to a change in the underlying datatype of the sales val output:

```
Failed analyzing stored view 'awsdatacatalog.reporting.vw_ratio_stats': line 79:8: View 
'awsdatacatalog.default.legacy_vw_pin_sale' is stale or in invalid state: column 
[sv_is_outlier] of type boolean projected from query view at position 45 cannot be coerced 
to column [sv_is_outlier] of type bigint stored in view definition
```

This error is blocking reporting jobs from running. Removing the sales val outputs and redefining the view should be a quick fix. Pinging @wrridgeway for awareness.