### PR TITLE
Update CTAS write compression

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -27,8 +27,8 @@ clean-targets:
 models:
   athena:
     +materialized: view
-    +write_compression: SNAPPY
-    +format: PARQUET
+    +write_compression: zstd
+    +format: parquet
     census:
       +schema: census
     default:


### PR DESCRIPTION
This PR updates the Parquet write compression used by all dbt materialized models. Swapping from the default `snappy` compression to `zstd` reduces data queried by Athena by 30-40%  with basically no loss in query performance.

> [!NOTE]
Let's merge this after working hours since it will temporarily bork critical tables.