### PR TITLE
Update osmdata package

### DIFF
--- a/aws-s3/renv.lock
+++ b/aws-s3/renv.lock
@@ -2030,7 +2030,7 @@
     },
     "osmdata": {
       "Package": "osmdata",
-      "Version": "0.2.2",
+      "Version": "0.2.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [

--- a/aws-s3/renv.lock
+++ b/aws-s3/renv.lock
@@ -2047,7 +2047,7 @@
         "utils",
         "xml2"
       ],
-      "Hash": "393e194d2abaa6d10d6a2ae528494f2f"
+      "Hash": "484fb25b6267ae0a885511dbac53f193"
     },
     "paws": {
       "Package": "paws",


### PR DESCRIPTION
During the exploratory analysis in #195, we discovered that the `osmdata` package was out of date. The package update fixes the following error:

```
> osm_roads <- opq(bbox = "Cook County, IL") %>%
+   add_osm_feature(
+     key = "highway",
+     value = c("motorway", "trunk", "primary")
+   ) %>%
+   osmdata_sf() %>%
+   .$osm_lines %>%
+   select(osm_id, name) %>%
+   st_transform(4326) %>%
+   mutate(geometry_3435 = st_transform(geometry, 3435))
Error in `httr2::req_perform()`:
! HTTP 405 Method Not Allowed.
Run `rlang::last_trace()` to see where the error occurred.
```