### PR TITLE
Add sales view lineage to docs

### DIFF
--- a/dbt/assets/sales-lineage.mmd
+++ b/dbt/assets/sales-lineage.mmd
@@ -1,0 +1,7 @@
+flowchart LR
+    A[(MyDec)] -->|Via DS + SP| B[AS/400 + Mainframe]
+    A --> |Sales after Feb. 2021<br>via DS + MV| C[(iasworld.sales)]
+    B --> |Sales before<br>Feb. 2021| C
+    A --> |Via Data. Dept.<br> direct import| D[(sale.mydec)]
+    D --> |Used to fill<br>missing data| E[default.vw_pin_sale]
+    C --> |Default source| E

--- a/dbt/models/default/docs.md
+++ b/dbt/models/default/docs.md
@@ -127,7 +127,8 @@ View containing aggregate land square footage for all PINs.
 {% docs view_vw_pin_sale %}
 View containing cleaned and deduplicated PIN-level sales.
 
-Sourced from `iasworld.sales`, which is sourced from MyDec.
+Sourced from `iasworld.sales`, which is sourced from
+[MyDec](https://mytax.illinois.gov/MyDec/_/). See below for lineage details.
 
 ### Assumptions
 
@@ -144,6 +145,24 @@ Sourced from `iasworld.sales`, which is sourced from MyDec.
 - `sale.mydec` data is given precedence over `iasworld.sales` prior to 2021
 - Multicard sales are excluded from `mydec` data because they can't be joined
   to `iasworld.sales` (which is only parcel-level) without creating duplicates
+
+### Lineage
+
+This view is constructed from [MyDec](https://mytax.illinois.gov/MyDec/_/) data
+gathered and filtered by numerous parties. It uses the `iasworld.sales` table
+as a base, which is itself constructed from two separate sources of MyDec data.
+Current MyDec records are ingested into `iasworld.sales` using a manual import
+process. The full data lineage looks something like:
+
+```mermaid
+flowchart LR
+    A[(MyDec)] -->|Via DS + SP| B[AS/400 + Mainframe]
+    A --> |Sales after Feb. 2021<br>via DS + MV| C[(iasworld.sales)]
+    B --> |Sales before<br>Feb. 2021| C
+    A --> |Via Data. Dept.<br> direct import| D[(sale.mydec)]
+    D --> |Used to fill<br>missing data| E[default.vw_pin_sale]
+    C --> |Default source| E
+```
 
 **Primary Key**: `year`, `pin`
 {% enddocs %}

--- a/dbt/models/default/docs.md
+++ b/dbt/models/default/docs.md
@@ -154,15 +154,7 @@ as a base, which is itself constructed from two separate sources of MyDec data.
 Current MyDec records are ingested into `iasworld.sales` using a manual import
 process. The full data lineage looks something like:
 
-```mermaid
-flowchart LR
-    A[(MyDec)] -->|Via DS + SP| B[AS/400 + Mainframe]
-    A --> |Sales after Feb. 2021<br>via DS + MV| C[(iasworld.sales)]
-    B --> |Sales before<br>Feb. 2021| C
-    A --> |Via Data. Dept.<br> direct import| D[(sale.mydec)]
-    D --> |Used to fill<br>missing data| E[default.vw_pin_sale]
-    C --> |Default source| E
-```
+![Data Flow Diagram](./assets/sales-lineage.svg)
 
 **Primary Key**: `year`, `pin`
 {% enddocs %}


### PR DESCRIPTION
Got some additional notes on how sales data is imported into the various systems of record. I'm adding those notes to `default.vw_pin_sale` for posterity. 