### PR TITLE
Add `workflow_dispatch` fix for CI dbt builds

### DIFF
--- a/.github/actions/configure_dbt_environment/action.yaml
+++ b/.github/actions/configure_dbt_environment/action.yaml
@@ -9,11 +9,17 @@ runs:
         # present, we must be in a PR context. Occasionally, we need to
         # manually rebuild assets generated during a PR. In that case, we
         # detect the PR context using the branch name and event
-        if [[ -n "$GITHUB_HEAD_REF" ]] || [[ "$GITHUB_REF_NAME" != 'master' && "$GITHUB_EVENT_NAME" == 'workflow_dispatch' ]]; then
+        if [[ -n "$GITHUB_HEAD_REF" ]]; then
           echo "On pull request branch, setting dbt env to CI"
           {
             echo "TARGET=ci";
             echo "HEAD_REF=$GITHUB_HEAD_REF"
+          } >> "$GITHUB_ENV"
+        elif [[ "$GITHUB_REF_NAME" != 'master' && "$GITHUB_EVENT_NAME" == 'workflow_dispatch' ]]; then
+          echo "Manually dispatched from pull request branch, setting dbt env to CI"
+          {
+            echo "TARGET=ci";
+            echo "HEAD_REF=$GITHUB_REF_NAME"
           } >> "$GITHUB_ENV"
         elif [[ "$GITHUB_REF_NAME" == 'master' ]]; then
           echo "On master branch, setting dbt env to prod"

--- a/.github/actions/configure_dbt_environment/action.yaml
+++ b/.github/actions/configure_dbt_environment/action.yaml
@@ -6,14 +6,16 @@ runs:
     - name: Configure dbt environment
       run: |
         # GITHUB_HEAD_REF is only set on pull_request events, so if it's
-        # present, we must be in a PR context
-        if [ -n "$GITHUB_HEAD_REF" ]; then
+        # present, we must be in a PR context. Occasionally, we need to
+        # manually rebuild assets generated during a PR. In that case, we
+        # detect the PR context using the branch name and event
+        if [[ -n "$GITHUB_HEAD_REF" ]] || [[ "$GITHUB_REF_NAME" != 'master' && "$GITHUB_EVENT_NAME" == 'workflow_dispatch' ]]; then
           echo "On pull request branch, setting dbt env to CI"
           {
             echo "TARGET=ci";
             echo "HEAD_REF=$GITHUB_HEAD_REF"
           } >> "$GITHUB_ENV"
-        elif [[ $GITHUB_REF_NAME == 'master' ]]; then
+        elif [[ "$GITHUB_REF_NAME" == 'master' ]]; then
           echo "On master branch, setting dbt env to prod"
           {
             echo "TARGET=prod";


### PR DESCRIPTION
This PR adds a small tweak to detect and use PR context for dbt when using the `workflow_dispatch` option. The fix is needed because using `GITHUB_HEAD_REF` to detect PR context (and thus to set the dbt target to `ci`) doesn't work for manually dispatched workflows. The issue was discovered during these workflow runs:

- https://github.com/ccao-data/data-architecture/actions/runs/6804924433/job/18503445904
- https://github.com/ccao-data/data-architecture/actions/runs/6804785306/job/18503010735