### PR TITLE
Update multisale detection

### DIFF
--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -15,6 +15,8 @@ models:
         description: '{{ doc("shared_column_sale_is_multisale") }}'
       - name: is_mydec_date
         description: Indicator for whether or not the observation uses the MyDec sale date
+      - name: mydec_deed_type
+        description: Deed types from MyDec, much more granular than deed types from iasWorld
       - name: nbhd
         description: '{{ doc("shared_column_nbhd_code") }}'
       - name: num_parcels_sale


### PR DESCRIPTION
 - update multisale detection to remove the letter 'D' from document number when tallying how many parcels are associated with a sale
 - remove language about cards in mydec sales
 - add mydec deed type to vw_pin_sale
 - use mydec's number of parcels per sale column to exclude multisales before joining mydec data to iasworld.sales