### PR TITLE
Mitigate incorrect values in htpar.user104

### DIFF
--- a/aws-athena/views/default-vw_pin_appeal.sql
+++ b/aws-athena/views/default-vw_pin_appeal.sql
@@ -33,7 +33,10 @@ SELECT
     CASE
         WHEN htpar.taxyr < '2020' AND htpar.resact = 'C' THEN 'change'
         WHEN htpar.taxyr < '2020' AND htpar.resact = 'NC' THEN 'no change'
-        WHEN htpar.taxyr >= '2020' THEN LOWER(htpar.user104)
+        WHEN
+            htpar.taxyr >= '2020' AND TRIM(LOWER(htpar.user104)) = 'decrease'
+            THEN 'change'
+        WHEN htpar.taxyr >= '2020' THEN TRIM(LOWER(htpar.user104))
     END AS change,
     CASE
         WHEN htpar.taxyr < '2020'

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -101,5 +101,3 @@ models:
             - year
             - case_no
             - change
-          config:
-            error_if: ">43"


### PR DESCRIPTION
Assuming this (`htpar.user104`) data won't get fixed anytime soon, addressing it in `default.vw_pin_appeal` seems to be our best bet for now.