### PR TITLE
Fix where clause logic to deactivate PINs

### DIFF
--- a/aws-athena/views/default-vw_card_res_char.sql
+++ b/aws-athena/views/default-vw_card_res_char.sql
@@ -135,6 +135,8 @@ FROM {{ source('iasworld', 'dweldat') }} AS dwel
 LEFT JOIN {{ source('iasworld', 'pardat') }} AS pardat
     ON dwel.parid = pardat.parid
     AND dwel.taxyr = pardat.taxyr
+    AND pardat.cur = 'Y'
+    AND pardat.deactivat IS NULL
 LEFT JOIN multicodes
     ON dwel.parid = multicodes.parid
     AND dwel.taxyr = multicodes.taxyr
@@ -146,5 +148,3 @@ LEFT JOIN townships
     AND dwel.taxyr = townships.taxyr
 WHERE dwel.cur = 'Y'
     AND dwel.deactivat IS NULL
-    AND pardat.cur = 'Y'
-    AND pardat.deactivat IS NULL

--- a/aws-athena/views/default-vw_pin_address.sql
+++ b/aws-athena/views/default-vw_pin_address.sql
@@ -52,12 +52,12 @@ FROM {{ source('iasworld', 'pardat') }} AS par
 LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg
     ON par.parid = leg.parid
     AND par.taxyr = leg.taxyr
+    AND leg.cur = 'Y'
+    AND leg.deactivat IS NULL
 LEFT JOIN {{ source('iasworld', 'owndat') }} AS own
     ON par.parid = own.parid
     AND par.taxyr = own.taxyr
-WHERE par.cur = 'Y'
-    AND par.deactivat IS NULL
-    AND leg.cur = 'Y'
-    AND leg.deactivat IS NULL
     AND own.cur = 'Y'
     AND own.deactivat IS NULL
+WHERE par.cur = 'Y'
+    AND par.deactivat IS NULL

--- a/aws-athena/views/default-vw_pin_appeal.sql
+++ b/aws-athena/views/default-vw_pin_appeal.sql
@@ -1,32 +1,4 @@
 -- View containing appeals by PIN
-WITH htpar AS (
-    SELECT *
-    FROM {{ source('iasworld', 'htpar') }}
-    WHERE cur = 'Y'
-        AND deactivat IS NULL
-),
-
-pardat AS (
-    SELECT *
-    FROM {{ source('iasworld', 'pardat') }}
-    WHERE cur = 'Y'
-        AND deactivat IS NULL
-),
-
-legdat AS (
-    SELECT *
-    FROM {{ source('iasworld', 'legdat') }}
-    WHERE cur = 'Y'
-        AND deactivat IS NULL
-),
-
-htagnt AS (
-    SELECT *
-    FROM {{ source('iasworld', 'htagnt') }}
-    WHERE cur = 'Y'
-        AND deactivat IS NULL
-)
-
 SELECT
     htpar.parid AS pin,
     pardat.class AS class,
@@ -92,16 +64,24 @@ SELECT
         WHEN htpar.hrstatus = 'P' THEN 'pending'
         WHEN htpar.hrstatus = 'X' THEN 'closed pending c of e'
     END AS status
-FROM htpar
-LEFT JOIN pardat
+FROM {{ source('iasworld', 'htpar') }} AS htpar
+LEFT JOIN {{ source('iasworld', 'pardat') }} AS pardat
     ON htpar.parid = pardat.parid
     AND htpar.taxyr = pardat.taxyr
-LEFT JOIN legdat
+LEFT JOIN {{ source('iasworld', 'legdat') }} AS legdat
     ON htpar.parid = legdat.parid
     AND htpar.taxyr = legdat.taxyr
-LEFT JOIN htagnt
-    ON htpar.cpatty = htagnt.agent
 LEFT JOIN {{ ref('default.vw_pin_value') }} AS vwpv
     ON htpar.parid = vwpv.pin
     AND htpar.taxyr = vwpv.year
-WHERE htpar.caseno IS NOT NULL
+LEFT JOIN {{ source('iasworld', 'htagnt') }} AS htagnt
+    ON htpar.cpatty = htagnt.agent
+WHERE htpar.cur = 'Y'
+    AND htpar.caseno IS NOT NULL
+    AND htpar.deactivat IS NULL
+    AND pardat.cur = 'Y'
+    AND pardat.deactivat IS NULL
+    AND legdat.cur = 'Y'
+    AND legdat.deactivat IS NULL
+    AND htagnt.cur = 'Y'
+    AND htagnt.deactivat IS NULL

--- a/aws-athena/views/default-vw_pin_appeal.sql
+++ b/aws-athena/views/default-vw_pin_appeal.sql
@@ -68,20 +68,20 @@ FROM {{ source('iasworld', 'htpar') }} AS htpar
 LEFT JOIN {{ source('iasworld', 'pardat') }} AS pardat
     ON htpar.parid = pardat.parid
     AND htpar.taxyr = pardat.taxyr
+    AND pardat.cur = 'Y'
+    AND pardat.deactivat IS NULL
 LEFT JOIN {{ source('iasworld', 'legdat') }} AS legdat
     ON htpar.parid = legdat.parid
     AND htpar.taxyr = legdat.taxyr
+    AND legdat.cur = 'Y'
+    AND legdat.deactivat IS NULL
 LEFT JOIN {{ ref('default.vw_pin_value') }} AS vwpv
     ON htpar.parid = vwpv.pin
     AND htpar.taxyr = vwpv.year
 LEFT JOIN {{ source('iasworld', 'htagnt') }} AS htagnt
     ON htpar.cpatty = htagnt.agent
+    AND htagnt.cur = 'Y'
+    AND htagnt.deactivat IS NULL
 WHERE htpar.cur = 'Y'
     AND htpar.caseno IS NOT NULL
     AND htpar.deactivat IS NULL
-    AND pardat.cur = 'Y'
-    AND pardat.deactivat IS NULL
-    AND legdat.cur = 'Y'
-    AND legdat.deactivat IS NULL
-    AND htagnt.cur = 'Y'
-    AND htagnt.deactivat IS NULL

--- a/aws-athena/views/default-vw_pin_history.sql
+++ b/aws-athena/views/default-vw_pin_history.sql
@@ -92,12 +92,12 @@ FROM {{ ref('default.vw_pin_value') }} AS vwpv
 LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg
     ON vwpv.pin = leg.parid
     AND vwpv.year = leg.taxyr
+    AND leg.cur = 'Y'
+    AND leg.deactivat IS NULL
 LEFT JOIN {{ source('iasworld', 'pardat') }} AS par
     ON vwpv.pin = par.parid
     AND vwpv.year = par.taxyr
-LEFT JOIN {{ source('spatial', 'township') }} AS town
-    ON leg.user1 = town.township_code
-WHERE leg.cur = 'Y'
-    AND leg.deactivat IS NULL
     AND par.cur = 'Y'
     AND par.deactivat IS NULL
+LEFT JOIN {{ source('spatial', 'township') }} AS town
+    ON leg.user1 = town.township_code

--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -11,10 +11,10 @@ WITH town_class AS (
     LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg
         ON par.parid = leg.parid
         AND par.taxyr = leg.taxyr
-    WHERE par.cur = 'Y'
-        AND par.deactivat IS NULL
         AND leg.cur = 'Y'
         AND leg.deactivat IS NULL
+    WHERE par.cur = 'Y'
+        AND par.deactivat IS NULL
 ),
 
 -- "nopar" isn't entirely accurate for sales associated with only one parcel,

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -122,6 +122,8 @@ FROM {{ source('iasworld', 'pardat') }} AS par
 LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg
     ON par.parid = leg.parid
     AND par.taxyr = leg.taxyr
+    AND leg.cur = 'Y'
+    AND leg.deactivat IS NULL
 LEFT JOIN {{ source('spatial', 'parcel') }} AS sp
     ON SUBSTR(par.parid, 1, 10) = sp.pin10
     AND par.taxyr = sp.year
@@ -132,5 +134,3 @@ LEFT JOIN {{ source('spatial', 'township') }} AS twn
     ON leg.user1 = CAST(twn.township_code AS VARCHAR)
 WHERE par.cur = 'Y'
     AND par.deactivat IS NULL
-    AND leg.cur = 'Y'
-    AND leg.deactivat IS NULL

--- a/aws-athena/views/model-vw_card_res_input.sql
+++ b/aws-athena/views/model-vw_card_res_input.sql
@@ -31,8 +31,9 @@ sqft_percentiles AS (
             AS char_land_sf_95_percentile
     FROM {{ ref('default.vw_card_res_char') }} AS ch
     LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg
-        ON ch.pin = leg.parid AND ch.year = leg.taxyr
-    WHERE leg.cur = 'Y'
+        ON ch.pin = leg.parid
+        AND ch.year = leg.taxyr
+        AND leg.cur = 'Y'
         AND leg.deactivat IS NULL
     GROUP BY ch.year, leg.user1
 ),

--- a/aws-athena/views/model-vw_pin_condo_input.sql
+++ b/aws-athena/views/model-vw_pin_condo_input.sql
@@ -23,8 +23,9 @@ sqft_percentiles AS (
             AS char_land_sf_95_percentile
     FROM {{ ref('default.vw_pin_condo_char') }} AS ch
     LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg
-        ON ch.pin = leg.parid AND ch.year = leg.taxyr
-    WHERE leg.cur = 'Y'
+        ON ch.pin = leg.parid
+        AND ch.year = leg.taxyr
+        AND leg.cur = 'Y'
         AND leg.deactivat IS NULL
     GROUP BY ch.year, leg.user1
 )

--- a/aws-athena/views/model-vw_pin_shared_input.sql
+++ b/aws-athena/views/model-vw_pin_shared_input.sql
@@ -38,6 +38,8 @@ WITH uni AS (
     LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg
         ON par.parid = leg.parid
         AND par.taxyr = leg.taxyr
+        AND leg.cur = 'Y'
+        AND leg.deactivat IS NULL
     LEFT JOIN {{ source('spatial', 'parcel') }} AS sp
         ON SUBSTR(par.parid, 1, 10) = sp.pin10
         AND par.taxyr = sp.year
@@ -45,8 +47,6 @@ WITH uni AS (
         ON leg.user1 = CAST(twn.township_code AS VARCHAR)
     WHERE par.cur = 'Y'
         AND par.deactivat IS NULL
-        AND leg.cur = 'Y'
-        AND leg.deactivat IS NULL
 ),
 
 acs5 AS (

--- a/dbt/models/default/schema/default.vw_card_res_char.yml
+++ b/dbt/models/default/schema/default.vw_card_res_char.yml
@@ -114,3 +114,6 @@ models:
             - pin
             - year
             - card
+      - row_count:
+          name: default_vw_card_res_char_row_count
+          above: 27347262 # as of 2023-11-22

--- a/dbt/models/default/schema/default.vw_pin_address.yml
+++ b/dbt/models/default/schema/default.vw_pin_address.yml
@@ -70,5 +70,8 @@ models:
           combination_of_columns:
             - pin
             - year
+      - row_count:
+          name: default_vw_pin_address_row_count
+          above: 45079937 # as of 2023-11-22
       # TODO: Mailing address changes after validated sale(?)
       # TODO: Site addresses are all in Cook County

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -101,3 +101,6 @@ models:
             - year
             - case_no
             - change
+      - row_count:
+          name: default_vw_pin_appeal_row_count
+          above: 8407667 # as of 2023-11-22

--- a/dbt/models/default/schema/default.vw_pin_exempt.yml
+++ b/dbt/models/default/schema/default.vw_pin_exempt.yml
@@ -25,3 +25,7 @@ models:
         description: '{{ doc("shared_column_township_name") }}'
       - name: year
         description: '{{ doc("shared_column_year") }}'
+    tests:
+      - row_count:
+          name: default_vw_pin_exempt_row_count
+          above: 184845 # as of 2023-11-22

--- a/dbt/models/default/schema/default.vw_pin_history.yml
+++ b/dbt/models/default/schema/default.vw_pin_history.yml
@@ -74,3 +74,6 @@ models:
           combination_of_columns:
             - pin
             - year
+      - row_count:
+          name: default_vw_pin_history_row_count
+          above: 45079095 # as of 2023-11-22

--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -74,6 +74,9 @@ models:
             - sale_filter_same_sale_within_365
           config:
             error_if: ">2079"
+      - row_count:
+          name: default_vw_pin_sale_row_count
+          above: 2477674 # as of 2023-11-22
       # TODO: Sale is validated (after sales validation has been added to
       # iasworld)
       # TODO: Validation is catching obvious outliers

--- a/dbt/models/default/schema/default.vw_pin_universe.yml
+++ b/dbt/models/default/schema/default.vw_pin_universe.yml
@@ -248,5 +248,8 @@ models:
           combination_of_columns:
             - pin
             - year
+      - row_count:
+          name: default_vw_pin_universe_row_count
+          above: 45079937 # as of 2023-11-22
       # TODO: Data completeness correlates with availability of spatial data
       # by year

--- a/dbt/tests/generic/test_row_count.sql
+++ b/dbt/tests/generic/test_row_count.sql
@@ -1,0 +1,10 @@
+-- Test that row counts are above a certain value
+{% test row_count(model, column_name, above) %}
+    {%- if column_name is defined %} {%- set count_col = column_name %}
+    {%- else %} {%- set count_col = "*" %}
+    {%- endif %}
+
+    select row_count
+    from (select count({{ count_col }}) as row_count from {{ model }})
+    where row_count < {{ above }}
+{% endtest %}


### PR DESCRIPTION
PR #141 introduced a significant regression that resulted in incorrect row counts for important views. The regression primarily affected the experimental `default.vw_pin_appeal` view and resulted in over 90% of its values being missing. Other models break down like so:

| Database | Model               | Cur. Count | PR Count |   Diff. | Pct. Missing |
|----------|---------------------|-----------:|---------:|--------:|-------------:|
| default  | vw_card_res_char    |   27347262 | 27347262 |       0 |        0.00% |
| default  | vw_pin_address      |   45071159 | 45079937 |    8778 |        0.02% |
| default  | vw_pin_appeal       |     743601 |  8407667 | 7664066 |       91.16% |
| default  | vw_pin_exempt       |     184845 |   184845 |       0 |        0.00% |
| default  | vw_pin_history      |   45079082 | 45079095 |      13 |        0.00% |
| default  | vw_pin_sale         |    2477674 |  2477674 |       0 |        0.00% |
| default  | vw_pin_universe     |   45079937 | 45079937 |       0 |        0.00% |
| model    | vw_card_res_input   |   27306493 | 27306493 |       0 |        0.00% |
| model    | vw_pin_condo_input  |   10075360 | 10075360 |       0 |        0.00% |
| model    | vw_pin_shared_input |   45094310 | 45094310 |       0 |        0.00% |

## Cause

The regression is the result of some slightly tricky conditional logic. Basically, by using a column from a joined table in a `WHERE` clause _after a join_, you implicitly require that the joined table have a non-NULL record. `default.vw_pin_appeal` is the best example of this. Here's a reprex:

```sql
SELECT *
FROM iasworld.htpar AS htpar
LEFT JOIN iasworld.htagnt AS htagnt
    ON htpar.cpatty = htagnt.agent
WHERE htpar.cur = 'Y'
    AND htpar.caseno IS NOT NULL
    AND htpar.deactivat IS NULL
    AND htagnt.cur = 'Y' -- REQUIRES that htagnt have a corresponding record, basically making this an INNER JOIN
    AND htagnt.deactivat IS NULL
```

## Solution

- By moving the conditionals for `cur` and `deactivat` into each join, the conditionals are applied _before_ the join rather than after. This is also how Tyler's Inquire constructs queries, according to the [Inquire Manual (p. 34)](https://www.tylertech.com/CLT/IASProductUsers/Enterprise-Assessment-Tax-Documentation/Inquire.pdf).
- I added a note to the [Appeals Open Data asset](https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Appeals/y282-6ig3) to let users know that rows were missing within a certain time window. We should update the note once this PR is merged.
- I added dbt tests for fixed row counts on each major view. Row counts should really never go _down_, so this should help prevent similar logic mistakes in the future.

## Follow-ups

- Update all affected Open Data assets + update the appeals asset note
- Add row count tests to model views in #232