### PR TITLE
Update dbt docs with warnings about mailing address staleness

### DIFF
--- a/dbt/models/default/docs.md
+++ b/dbt/models/default/docs.md
@@ -21,12 +21,9 @@ and reporting.
 Source of truth view for PIN address, both legal (property address)
 and mailing (owner/taxpayer address).
 
-### Assumptions
-
-- Mailing addresses are updated when properties transfer ownership.
-
 ### Nuance
 
+- Mailing addresses and owner names have not been regularly updated since 2017.
 - Newer properties may be missing a mailing or property address, as they
   need to be assigned one by the postal service.
 
@@ -94,6 +91,7 @@ institutions, or local governments.
 
 ### Nuance
 
+- Mailing addresses and owner names have not been regularly updated since 2017.
 - Newer properties may be missing a mailing or property address, as they
   need to be assigned one by the postal service.
 {% enddocs %}

--- a/dbt/models/iasworld/docs.md
+++ b/dbt/models/iasworld/docs.md
@@ -240,6 +240,11 @@ It also stores other miscellaneous sub-PIN information like HIEs.
 {% docs table_owndat %}
 Property owner information such as name and mailing address.
 
+### Nuance
+
+- This table currently feeds all mailing address columns but mailing addresses
+have not been regularly updated since 2017.
+
 **Primary Key**: `jur`, `taxyr`, `parid`
 {% enddocs %}
 

--- a/dbt/models/iasworld/docs.md
+++ b/dbt/models/iasworld/docs.md
@@ -242,8 +242,7 @@ Property owner information such as name and mailing address.
 
 ### Nuance
 
-- This table currently feeds all mailing address columns but mailing addresses
-have not been regularly updated since 2017.
+- Mailing addresses and owner names have not been regularly updated since 2017.
 
 **Primary Key**: `jur`, `taxyr`, `parid`
 {% enddocs %}

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -4,6 +4,11 @@
 
 {% docs shared_column_mail_address_city_name %}
 City name of owner/taxpayer mailing address
+:::caution
+
+Stale since 2017
+
+:::
 {% enddocs %}
 
 ## mail_address_full
@@ -14,42 +19,77 @@ First line (no city, state, ZIP) of owner/taxpayer mailing address.
 Concatenated from other columns in the following order: `street_prefix`
 `street_number` `street_direction` `street_name` `street_suffix`
 `unit_prefix` `unit_number`
+:::caution
+
+Stale since 2017
+
+:::
 {% enddocs %}
 
 ## mail_address_name
 
 {% docs shared_column_mail_address_name %}
 Full name (single unsplit string) of owner/taxpayer mailing address
+:::caution
+
+Stale since 2017
+
+:::
 {% enddocs %}
 
 ## mail_address_state
 
 {% docs shared_column_mail_address_state %}
 State abbreviation of owner/taxpayer mailing address
+:::caution
+
+Stale since 2017
+
+:::
 {% enddocs %}
 
 ## mail_address_zipcode_1
 
 {% docs shared_column_mail_address_zipcode_1 %}
 ZIP code (first 5 digits) of owner/taxpayer mailing address
+:::caution
+
+Stale since 2017
+
+:::
 {% enddocs %}
 
 ## mail_address_zipcode_2
 
 {% docs shared_column_mail_address_zipcode_2 %}
 ZIP code (last 4 digits) of owner/taxpayer mailing address
+:::caution
+
+Stale since 2017
+
+:::
 {% enddocs %}
 
 ## owner_name
 
 {% docs shared_column_owner_name %}
 Property owner name
+:::caution
+
+Stale since 2017
+
+:::
 {% enddocs %}
 
 ## owner_num
 
 {% docs shared_column_owner_num %}
 Property owner internal iasWorld number
+:::caution
+
+Stale since 2017
+
+:::
 {% enddocs %}
 
 ## prop_address_city_name

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -4,11 +4,6 @@
 
 {% docs shared_column_mail_address_city_name %}
 City name of owner/taxpayer mailing address
-:::caution
-
-Stale since 2017
-
-:::
 {% enddocs %}
 
 ## mail_address_full
@@ -19,77 +14,42 @@ First line (no city, state, ZIP) of owner/taxpayer mailing address.
 Concatenated from other columns in the following order: `street_prefix`
 `street_number` `street_direction` `street_name` `street_suffix`
 `unit_prefix` `unit_number`
-:::caution
-
-Stale since 2017
-
-:::
 {% enddocs %}
 
 ## mail_address_name
 
 {% docs shared_column_mail_address_name %}
 Full name (single unsplit string) of owner/taxpayer mailing address
-:::caution
-
-Stale since 2017
-
-:::
 {% enddocs %}
 
 ## mail_address_state
 
 {% docs shared_column_mail_address_state %}
 State abbreviation of owner/taxpayer mailing address
-:::caution
-
-Stale since 2017
-
-:::
 {% enddocs %}
 
 ## mail_address_zipcode_1
 
 {% docs shared_column_mail_address_zipcode_1 %}
 ZIP code (first 5 digits) of owner/taxpayer mailing address
-:::caution
-
-Stale since 2017
-
-:::
 {% enddocs %}
 
 ## mail_address_zipcode_2
 
 {% docs shared_column_mail_address_zipcode_2 %}
 ZIP code (last 4 digits) of owner/taxpayer mailing address
-:::caution
-
-Stale since 2017
-
-:::
 {% enddocs %}
 
 ## owner_name
 
 {% docs shared_column_owner_name %}
 Property owner name
-:::caution
-
-Stale since 2017
-
-:::
 {% enddocs %}
 
 ## owner_num
 
 {% docs shared_column_owner_num %}
 Property owner internal iasWorld number
-:::caution
-
-Stale since 2017
-
-:::
 {% enddocs %}
 
 ## prop_address_city_name


### PR DESCRIPTION
We have learned that owner information has _not been regularly updated_ in owndat since 2017. This PR makes note of that in the dbt docs for `iasworld.owndat`, `default.vw_pin_address`, and `default.vw_pin_exempt`.