### PR TITLE
Add time filter to QC tests

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -22,6 +22,18 @@ clean-targets:
   - "target"
   - "dbt_packages"
 
+vars:
+  # Start year for testing data using test_qc_* tagged dbt tests. Typically
+  # this should be the current year, since errors in past data cannot usually
+  # be amended once records are closed. Set as an integer for compatibility
+  # with comparison operators and SQL's BETWEEN
+  test_qc_year_start: 2023
+
+  # End year for testing data using test_qc_* tagged dbt tests. Typically set
+  # to a date in the future, but can also be use to select specific time
+  # frames for testing
+  test_qc_year_end: 2030
+
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 models:

--- a/dbt/models/default/schema/default.vw_card_res_char.yml
+++ b/dbt/models/default/schema/default.vw_card_res_char.yml
@@ -116,4 +116,4 @@ models:
             - card
       - row_count:
           name: default_vw_card_res_char_row_count
-          above: 27347262 # as of 2023-11-22
+          above: 27347200 # as of 2023-11-29

--- a/dbt/models/default/schema/default.vw_pin_address.yml
+++ b/dbt/models/default/schema/default.vw_pin_address.yml
@@ -64,7 +64,7 @@ models:
             - mail_address_zipcode_1
             - mail_address_zipcode_2
           config:
-            where: CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+            where: CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
             error_if: ">900000"
       - unique_combination_of_columns:
           name: default_vw_pin_address_unique_by_14_digit_pin_and_year

--- a/dbt/models/default/schema/default.vw_pin_address.yml
+++ b/dbt/models/default/schema/default.vw_pin_address.yml
@@ -64,7 +64,7 @@ models:
             - mail_address_zipcode_1
             - mail_address_zipcode_2
           config:
-            where: year >= '2023'
+            where: CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
             error_if: ">900000"
       - unique_combination_of_columns:
           name: default_vw_pin_address_unique_by_14_digit_pin_and_year

--- a/dbt/models/default/schema/default.vw_pin_address.yml
+++ b/dbt/models/default/schema/default.vw_pin_address.yml
@@ -64,6 +64,7 @@ models:
             - mail_address_zipcode_1
             - mail_address_zipcode_2
           config:
+            where: year >= '2023'
             error_if: ">900000"
       - unique_combination_of_columns:
           name: default_vw_pin_address_unique_by_14_digit_pin_and_year
@@ -73,5 +74,4 @@ models:
       - row_count:
           name: default_vw_pin_address_row_count
           above: 45079937 # as of 2023-11-22
-      # TODO: Mailing address changes after validated sale(?)
       # TODO: Site addresses are all in Cook County

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -91,7 +91,7 @@ models:
             - mailed_tot
             - certified_tot
           config:
-            where: CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+            where: CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
             error_if: ">266719"
       # `change` should be an enum
       - expression_is_true:
@@ -103,7 +103,7 @@ models:
             - case_no
             - change
           config:
-            where: CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+            where: CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
       - row_count:
           name: default_vw_pin_appeal_row_count
           above: 8407667 # as of 2023-11-22

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -91,6 +91,7 @@ models:
             - mailed_tot
             - certified_tot
           config:
+            where: year >= '2023'
             error_if: ">266719"
       # `change` should be an enum
       - expression_is_true:
@@ -101,6 +102,8 @@ models:
             - year
             - case_no
             - change
+          config:
+            where: year >= '2023'
       - row_count:
           name: default_vw_pin_appeal_row_count
           above: 8407667 # as of 2023-11-22

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -91,7 +91,7 @@ models:
             - mailed_tot
             - certified_tot
           config:
-            where: year >= '2023'
+            where: CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
             error_if: ">266719"
       # `change` should be an enum
       - expression_is_true:
@@ -103,7 +103,7 @@ models:
             - case_no
             - change
           config:
-            where: year >= '2023'
+            where: CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
       - row_count:
           name: default_vw_pin_appeal_row_count
           above: 8407667 # as of 2023-11-22

--- a/dbt/models/iasworld/schema/iasworld.addn.yml
+++ b/dbt/models/iasworld/schema/iasworld.addn.yml
@@ -18,8 +18,11 @@ sources:
                   name: iasworld_addn_area_between_0_and_1.5M
                   min_value: 0
                   max_value: 1500000
-                  config:
-                    where: cur = 'Y' AND deactivat IS NULL
+                  config: &unique-conditions
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
           - name: area_sqm
             description: Area of this line in meters
           - name: areaid
@@ -31,9 +34,11 @@ sources:
             tests:
               - not_null:
                   name: iasworld_addn_card_not_null
+                  config: *unique-conditions
               - dbt_utils.accepted_range:
                   name: iasworld_addn_card_gte_1
                   min_value: 1
+                  config: *unique-conditions
           - name: cdu
             description: '{{ doc("column_cdu") }}'
           - name: chgrsn
@@ -47,7 +52,7 @@ sources:
                   field: class_code
                   config:
                     where: |
-                      taxyr >= '2022'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND class != 'EX'
                       AND cur = 'Y'
                       AND deactivat IS NULL
@@ -59,6 +64,7 @@ sources:
               - accepted_values:
                   name: iasworld_addn_cur_in_accepted_values
                   values: ['Y', 'D']
+                  config: *unique-conditions
           - name: deactivat
             description: '{{ doc("column_deactivat") }}'
           - name: depr
@@ -68,8 +74,7 @@ sources:
                   name: iasworld_addn_depr_between_0_and_100
                   min_value: 0
                   max_value: 100
-                  config:
-                    where: cur = 'Y' AND deactivat IS NULL
+                  config: *unique-conditions
           - name: eff_area
             description: Support value per line
           - name: effageovr
@@ -103,6 +108,7 @@ sources:
             tests:
               - not_null:
                   name: iasworld_addn_lline_not_null
+                  config: *unique-conditions
           - name: lower
             description: Lower level addition code
           - name: mktadj
@@ -124,10 +130,12 @@ sources:
             tests:
               - not_null:
                   name: iasworld_addn_parid_not_null
+                  config: *unique-conditions
               - relationships:
                   name: iasworld_addn_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  config: *unique-conditions
           - name: pctcomp
             description: '{{ doc("column_pctcomp") }}'
           - name: prodamage
@@ -187,6 +195,7 @@ sources:
             tests:
               - not_null:
                   name: iasworld_addn_taxyr_not_null
+                  config: *unique-conditions
           - name: third
             description: Third floor addition code
           - name: trans_id

--- a/dbt/models/iasworld/schema/iasworld.aprval.yml
+++ b/dbt/models/iasworld/schema/iasworld.aprval.yml
@@ -23,9 +23,9 @@ sources:
                   name: iasworld_aprval_aprbldg_between_0_and_1B
                   min_value: 0
                   max_value: 1000000000
-                  config:
+                  config: &unique-conditions
                     where: |
-                      taxyr >= '2021'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND cur = 'Y'
                       AND deactivat IS NULL
           - name: aprdate
@@ -37,8 +37,7 @@ sources:
                   name: iasworld_aprval_aprland_between_0_and_1B
                   min_value: 0
                   max_value: 1000000000
-                  config: &unique-conditions
-                    where: cur = 'Y' AND deactivat IS NULL
+                  config: *unique-conditions
           - name: aprtot
             description: '{{ doc("column_aprtot") }}'
             tests:
@@ -178,10 +177,12 @@ sources:
             tests:
               - not_null:
                   name: iasworld_aprval_parid_not_null
+                  config: *unique-conditions
               - relationships:
                   name: iasworld_aprval_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  config: *unique-conditions
           - name: posttype
             description: Assessment posting type
           - name: ppcomval
@@ -245,6 +246,7 @@ sources:
             tests:
               - not_null:
                   name: iasworld_aprval_taxyr_not_null
+                  config: *unique-conditions
           - name: tiebackbldg
             description: Sum of building value for all children in the income tieback group
           - name: tiebackland

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -23,7 +23,7 @@ sources:
                   field: class_code
                   config:
                     where: |
-                      taxyr >= '2022'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND class NOT IN ('EX', 'RR', '999')
                       AND NOT REGEXP_LIKE(class, '[0-9]{3}[A|B]')
                       AND rolltype != 'RR'
@@ -56,10 +56,18 @@ sources:
             tests:
               - not_null:
                   name: iasworld_asmt_all_parid_not_null
+                  config: &unique-conditions
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND rolltype != 'RR'
+                      AND procname IN ('CCAOVALUE', 'CCAOFINAL', 'BORVALUE')
+                      AND deactivat IS NULL
+                      AND valclass IS NULL
               - relationships:
                   name: iasworld_asmt_all_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  config: *unique-conditions
           - name: procdate
             description: '{{ doc("column_procdate") }}'
           - name: procname
@@ -82,11 +90,7 @@ sources:
                     - taxyr
                     - procname
                   config:
-                    where: &unique-conditions |
-                      rolltype != 'RR'
-                      AND procname IN ('CCAOVALUE', 'CCAOFINAL', 'BORVALUE')
-                      AND deactivat IS NULL 
-                      AND valclass IS NULL
+                    <<: *unique-conditions
                     error_if: ">15300"
           - name: splitno
             description: '{{ doc("column_splitno") }}'
@@ -99,6 +103,7 @@ sources:
             tests:
               - not_null:
                   name: iasworld_asmt_all_taxyr_not_null
+                  config: *unique-conditions
           - name: tottax
             description: Total tax
           - name: trans_id
@@ -143,7 +148,7 @@ sources:
                 - procname
                 - taxyr
               config:
-                where: *unique-conditions
+                <<: *unique-conditions
                 error_if: ">15300"
           - row_values_match_after_join:
               name: iasworld_asmt_all_class_matches_pardat_class
@@ -153,5 +158,4 @@ sources:
               join_columns:
                 - parid
                 - taxyr
-              config:
-                where: *unique-conditions
+              config: *unique-conditions

--- a/dbt/models/iasworld/schema/iasworld.comdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.comdat.yml
@@ -18,8 +18,11 @@ sources:
                   name: iasworld_comdat_adjfact_between_0_and_1
                   min_value: 0
                   max_value: 1
-                  config:
-                    where: cur = 'Y' AND deactivat IS NULL
+                  config: &unique-conditions
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
           - name: areasum
             description: '{{ doc("column_areasum") }}'
           - name: bld_modelid
@@ -35,8 +38,7 @@ sources:
                   name: iasworld_comdat_bldgval_between_0_and_1B
                   min_value: 0
                   max_value: 1000000000
-                  config:
-                    where: cur = 'Y' AND deactivat IS NULL
+                  config: *unique-conditions
           - name: bldnum
             description: Building number
           - name: busla
@@ -48,9 +50,11 @@ sources:
             tests:
               - not_null:
                   name: iasworld_comdat_card_not_null
+                  config: *unique-conditions
               - dbt_utils.accepted_range:
                   name: iasworld_comdat_card_gte_1
                   min_value: 1
+                  config: *unique-conditions
           - name: cdu
             description: '{{ doc("column_cdu") }}'
           - name: chgrsn
@@ -60,10 +64,7 @@ sources:
                   name: iasworld_comdat_chgrsn_eq_5_mktadj_not_null
                   expression: |
                     != '5' OR mktadj IS NOT NULL
-                  config:
-                    where: |
-                      cur = 'Y'
-                      AND taxyr >= '2022'
+                  config: *unique-conditions
           - name: class
             description: '{{ doc("shared_column_class") }}'
             tests:
@@ -73,10 +74,10 @@ sources:
                   field: class_code
                   config:
                     where: |
-                      taxyr >= '2022'
-                      AND cur = 'Y'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND NOT REGEXP_LIKE(class, '[0-9]{3}[A|B]')
                       AND class NOT IN ('EX', 'RR')
+                      AND cur = 'Y'
                       AND deactivat IS NULL
           - name: convbldg
             description: '{{ doc("column_convbldg") }}'
@@ -85,8 +86,7 @@ sources:
                   name: iasworld_comdat_convbldg_between_0_and_1B
                   min_value: 0
                   max_value: 1000000000
-                  config:
-                    where: cur = 'Y' AND deactivat IS NULL
+                  config: *unique-conditions
           - name: cubicft
             description: Cubic feet
           - name: cur
@@ -104,8 +104,7 @@ sources:
                   name: iasworld_comdat_depr_between_0_and_1
                   min_value: 0
                   max_value: 1
-                  config:
-                    where: cur = 'Y' AND deactivat IS NULL
+                  config: *unique-conditions
           - name: deprt
             description: '{{ doc("column_deprt") }}'
           - name: effageovr
@@ -121,8 +120,7 @@ sources:
                   name: iasworld_comdat_exmppct_between_0_and_100
                   min_value: 0
                   max_value: 100
-                  config:
-                    where: cur = 'Y' AND deactivat IS NULL
+                  config: *unique-conditions
           - name: exmpval
             description: '{{ doc("column_exmpval") }}'
           - name: gfact
@@ -235,12 +233,12 @@ sources:
             tests:
               - not_null:
                   name: iasworld_comdat_yrblt_not_null
+                  config: *unique-conditions
               - dbt_utils.accepted_range:
                   name: iasworld_comdat_yrblt_between_1850_and_now
                   min_value: 1850
                   max_value: cast(year(current_date) as decimal)
-                  config:
-                    where: cur = 'Y' AND deactivat IS NULL
+                  config: *unique-conditions
 
         tests:
           - unique_combination_of_columns:
@@ -257,8 +255,4 @@ sources:
               join_columns:
                 - parid
                 - taxyr
-              config:
-                where: |
-                  taxyr >= '2023'
-                  AND cur = 'Y'
-                  AND deactivat IS NULL
+              config: *unique-conditions

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -50,7 +50,8 @@ sources:
                   # online PDF of all class definitions
                   config: &unique-conditions
                     where: | 
-                      cur = 'Y'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
                       AND deactivat IS NULL
                       AND class NOT IN ('201', '213', '218', '219', '220', '221', '224', '225', '236', '240', '241', '290', '294', '297')
               - accepted_values:
@@ -96,9 +97,11 @@ sources:
             tests:
               - not_null:
                   name: iasworld_dweldat_card_not_null
+                  config: *unique-conditions
               - dbt_utils.accepted_range:
                   name: iasworld_dweldat_card_gte_1
                   min_value: 1
+                  config: *unique-conditions
           - name: catharea
             description: Cathedral ceiling area
           - name: cathval
@@ -122,7 +125,7 @@ sources:
                   field: class_code
                   config:
                     where: |
-                      taxyr >= '2022'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND class NOT IN ('EX', 'RR')
                       AND cur = 'Y'
                       AND deactivat IS NULL
@@ -389,8 +392,9 @@ sources:
                     != '5' OR mktadj IS NOT NULL
                   config:
                     where: |
-                      cur = 'Y'
-                      AND taxyr >= '2022'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
           - name: modover
             description: Residential override model
           - name: mvpattic
@@ -438,6 +442,7 @@ sources:
                   name: iasworld_dweldat_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  config: *unique-conditions
           - name: pctcomplete
             description: Percent of construction completed
           - name: plumbgrade
@@ -506,7 +511,8 @@ sources:
                   max_value: 15
                   config:
                     where: |
-                      class NOT IN ('211', '212')
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND class NOT IN ('211', '212')
                       AND cur = 'Y'
                       AND deactivat IS NULL
               - dbt_utils.accepted_range:
@@ -515,7 +521,8 @@ sources:
                   max_value: 24
                   config:
                     where: |
-                      class IN ('211', '212')
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND class IN ('211', '212')
                       AND cur = 'Y'
                       AND deactivat IS NULL
               - expression_is_true:
@@ -598,7 +605,8 @@ sources:
                   max_value: 40
                   config:
                     where: |
-                      class NOT IN ('211', '212')
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND class NOT IN ('211', '212')
                       AND cur = 'Y'
                       AND deactivat IS NULL
               - dbt_utils.accepted_range:
@@ -607,7 +615,8 @@ sources:
                   max_value: 50
                   config:
                     where: |
-                      class IN ('211', '212')
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND class IN ('211', '212')
                       AND cur = 'Y'
                       AND deactivat IS NULL
           - name: salekey
@@ -633,7 +642,8 @@ sources:
                   max_value: 10000
                   config:
                     where: |
-                      class NOT IN ('208', '209', '211', '212', '236', '297')
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND class NOT IN ('208', '209', '211', '212', '236', '297')
                       AND cur = 'Y'
                       AND deactivat IS NULL
               - dbt_utils.accepted_range:
@@ -642,7 +652,8 @@ sources:
                   max_value: 20000
                   config:
                     where: |
-                      class IN ('208', '209', '211', '212')
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND class IN ('208', '209', '211', '212')
                       AND cur = 'Y'
                       AND deactivat IS NULL
           - name: shfact
@@ -789,7 +800,8 @@ sources:
                   name: iasworld_dweldat_char_apts_not_null
                   config:
                     where: |
-                      class IN ('211', '212')
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND class IN ('211', '212')
                       AND cur = 'Y'
                       AND deactivat IS NULL
               - accepted_values:
@@ -797,7 +809,8 @@ sources:
                   values: ['1', '2', '3', '4', '5', '6']
                   config:
                     where: |
-                      class IN ('211', '212')
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND class IN ('211', '212')
                       AND cur = 'Y'
                       AND deactivat IS NULL
           - name: user15
@@ -946,11 +959,7 @@ sources:
               join_columns:
                 - parid
                 - taxyr
-              config:
-                where: |
-                  taxyr >= '2023'
-                  AND cur = 'Y'
-                  AND deactivat IS NULL
+              config: *unique-conditions
           - expression_is_true:
               name: iasworld_dweldat_card_proration_rate_between_0_and_100
               expression: 'CAST(user24 AS decimal) BETWEEN 0.00 AND 100.00'

--- a/dbt/models/iasworld/schema/iasworld.htpar.yml
+++ b/dbt/models/iasworld/schema/iasworld.htpar.yml
@@ -106,7 +106,8 @@ sources:
                   values: ['C', 'O', 'P', 'X']
                   config: &unique-conditions
                     where: |
-                      cur = 'Y'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
                       AND deactivat IS NULL
           - name: httimejur
             description: Schedule jurisdiction
@@ -165,10 +166,12 @@ sources:
             tests:
               - not_null:
                   name: iasworld_htpar_parid_not_null
+                  config: *unique-conditions
               - relationships:
                   name: iasworld_htpar_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  config: *unique-conditions
           - name: petemail
             description: Petitioner email address
           - name: petfax
@@ -309,3 +312,4 @@ sources:
                 - parid
                 - taxyr
                 - cpaddr3
+              config: *unique-conditions

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -17,6 +17,11 @@ sources:
               - dbt_utils.expression_is_true:
                   name: iasworld_land_acres_is_sf_transformed
                   expression: '* 43560 BETWEEN sf - 5 AND sf + 5'
+                  config: &unique-conditions
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
           - name: adjfact
             description: '{{ doc("column_adjfact") }}'
           - name: agflg
@@ -48,9 +53,10 @@ sources:
                   field: class_code
                   config:
                     where: |
-                      cur = 'Y'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND class NOT IN ('EX', 'RR', '999')
                       AND NOT REGEXP_LIKE(class, '[0-9]{3}[A|B]')
+                      AND cur = 'Y'
                       AND deactivat IS NULL
           - name: code
             description: Code
@@ -101,10 +107,7 @@ sources:
                   name: iasworld_land_influ_between_neg_100_and_pos_100
                   min_value: -100
                   max_value: 100
-                  config:
-                    where:
-                      cur = 'Y'
-                      AND deactivat IS NULL 
+                  config: *unique-conditions
           - name: influ2
             description: Influence percent (+/-)
           - name: jur
@@ -121,10 +124,6 @@ sources:
                   group_by_columns:
                     - parid
                     - taxyr
-                  config:
-                    where:
-                      cur = 'Y'
-                      AND deactivat IS NULL 
           - name: lmod
             description: Land location model number
           - name: locfact
@@ -178,6 +177,7 @@ sources:
                   name: iasworld_land_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  config: *unique-conditions
           - name: price
             description: Price
             tests:
@@ -186,9 +186,9 @@ sources:
                   min_value: 1
                   config:
                     where:
-                      cur = 'Y'
-                      AND taxyr >= '2023'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND class NOT IN ('EX', 'RR', '999')
+                      AND cur = 'Y'
                       AND deactivat IS NULL 
           - name: recnr
             description: '{{ doc("column_recnr") }}'
@@ -215,10 +215,7 @@ sources:
               - dbt_utils.accepted_range:
                   name: iasworld_land_sf_gte_1
                   min_value: 1
-                  config:
-                    where:
-                      cur = 'Y'
-                      AND deactivat IS NULL 
+                  config: *unique-conditions
           - name: sfact
             description: S factor
           - name: sizefact
@@ -282,7 +279,7 @@ sources:
                 - taxyr
               config:
                 where: |
-                  taxyr >= '2022'
+                  CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                   AND class NOT IN ('EX', 'RR')
                   AND cur = 'Y'
                   AND deactivat IS NULL

--- a/dbt/models/iasworld/schema/iasworld.legdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.legdat.yml
@@ -26,7 +26,8 @@ sources:
                   values: ['N', 'S', 'E', 'W', 'NE', 'NW', 'SE', 'SW']
                   config: &unique-conditions
                     where: 
-                      cur = 'Y'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
                       AND deactivat IS NULL 
           - name: adrid
             description: '{{ doc("column_adrid") }}'
@@ -101,6 +102,7 @@ sources:
                   name: iasworld_legdat_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  config: *unique-conditions
           - name: postalcode
             description: '{{ doc("column_postalcode") }}'
           - name: procdate
@@ -195,10 +197,12 @@ sources:
             tests:
               - not_null:
                   name: iasworld_legdat_user1_not_null
+                  config: *unique-conditions
               - relationships:
                   name: iasworld_legdat_user1_in_spatial_township_township_code
                   to: source('spatial', 'township')
                   field: township_code
+                  config: *unique-conditions
           - name: wen
             description: '{{ doc("shared_column_updated_at") }}'
           - name: wencalc
@@ -253,6 +257,7 @@ sources:
               additional_select_columns:
                 - parid
                 - taxyr
+              config: *unique-conditions
           - no_extra_whitespace:
               name: iasworld_legdat_address_columns_no_extra_whitespace
               column_names:

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -27,7 +27,8 @@ sources:
                   min_value: 1
                   config: &unique-conditions
                     where: |
-                      cur = 'Y'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
                       AND deactivat IS NULL
           - name: areaid
             description: '{{ doc("column_areaid") }}'
@@ -52,10 +53,7 @@ sources:
                   name: iasworld_oby_chgrsn_eq_5_mktadj_not_null
                   expression: |
                     != '5' OR mktadj IS NOT NULL
-                  config:
-                    where: |
-                      cur = 'Y'
-                      AND taxyr >= '2022'
+                  config: *unique-conditions
           - name: class
             description: '{{ doc("shared_column_class") }}'
           - name: cline
@@ -293,8 +291,4 @@ sources:
               join_columns:
                 - parid
                 - taxyr
-              config:
-                where: |
-                  taxyr >= '2022'
-                  AND cur = 'Y'
-                  AND deactivat IS NULL
+              config: *unique-conditions

--- a/dbt/models/iasworld/schema/iasworld.owndat.yml
+++ b/dbt/models/iasworld/schema/iasworld.owndat.yml
@@ -149,6 +149,11 @@ sources:
                   name: iasworld_owndat_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  config: &unique-conditions
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
           - name: partial
             description: '{{ doc("column_partial") }}'
           - name: pctown
@@ -171,10 +176,6 @@ sources:
                   group_by_columns:
                     - parid
                     - taxyr
-                  config: &unique-conditions
-                    where: |
-                      cur = 'Y'
-                      AND deactivat IS NULL
           - name: site
             description: '{{ doc("column_site") }}'
           - name: skip_addr_validation
@@ -264,6 +265,7 @@ sources:
                 - addr1
               config:
                 where: |
-                  cur = 'Y'
+                  CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                  AND cur = 'Y'
                   AND deactivat IS NULL
                   AND addr1 IS NOT NULL

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -77,7 +77,7 @@ sources:
                   field: class_code
                   config:
                     where: |
-                      taxyr >= '2022'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND class NOT IN ('EX', 'RR')
                       AND NOT REGEXP_LIKE(class, '[0-9]{3}[A|B]')
                       AND cur = 'Y'
@@ -196,7 +196,8 @@ sources:
                     - taxyr
                   config: &unique-conditions
                     where: |
-                      cur = 'Y'
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
                       AND deactivat IS NULL
           - name: skip_addr_validation
             description: '{{ doc("column_skip_addr_validation") }}'

--- a/dbt/models/qc/schema.yml
+++ b/dbt/models/qc/schema.yml
@@ -10,20 +10,19 @@ models:
       - expression_is_true:
           name: qc_vw_class_mismatch_no_289s
           expression: oby_class != '289'
-          config:
-            where: taxyr >= '2022'
+          config: &time-filter
+            where: |
+              CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
       - expression_is_true:
           name: qc_vw_class_mismatch_comdat_class_eq_pardat_class
           expression: comdat_class = pardat_class
-          config:
-            where: taxyr >= '2022'
+          config: *time-filter
       - expression_is_true:
           # Only match on major class code, since
           # most of these are minor improvements
           name: qc_vw_class_mismatch_oby_class_eq_pardat_class
           expression: substr(oby_class, 1, 1) = substr(pardat_class, 1, 1)
-          config:
-            where: taxyr >= '2022'
+          config: *time-filter
 
   - name: qc.vw_incorrect_asmt_value
     description: '{{ doc("view_vw_incorrect_asmt_value") }}'
@@ -40,7 +39,7 @@ models:
               inclusive: false
               config:
                 where: |
-                  taxyr >= '2023'
+                  CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                   AND class NOT IN ('EX', 'RR')
       - name: cur_year_bav
         tests:
@@ -57,7 +56,7 @@ models:
                 - cur_year_fav
               config:
                 where: |
-                  taxyr >= '2023'
+                  CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                   AND class IN (
                     '100', '200', '239', '240', '241', '300', '400', '500',
                     '535', '550', '637', '637A', '637B', '650', '651', '651A',
@@ -78,7 +77,7 @@ models:
                 - cur_year_fav
               config:
                 where: |
-                  taxyr >= '2023'
+                  CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                   AND class NOT IN (
                     '100', '200', '239', '240', '241', '300', '400', '500',
                     '535', '550', '637', '637A', '637B', '650', '651', '651A',
@@ -95,7 +94,7 @@ models:
               inclusive: false
               config:
                 where: |
-                  taxyr >= '2023'
+                  CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                   AND class NOT IN ('EX', 'RR')
       - name: class
         tests:
@@ -103,19 +102,16 @@ models:
           - dbt_utils.expression_is_true:
               name: qc_vw_incorrect_asmt_value_class_equals_luc
               expression: '= luc'
-              config:
-                where: taxyr >= '2023'
+              config: *time-filter
     tests:
       - dbt_utils.expression_is_true:
           name: qc_vw_incorrect_asmt_value_no_yoy_inc_gt_500K
           expression: (cur_year_fmv - pri_year_fmv) <= 500000
-          config:
-            where: taxyr >= '2023'
+          config: *time-filter
       - dbt_utils.expression_is_true:
           name: qc_vw_incorrect_asmt_value_no_yoy_dec_gt_1M
           expression: (cur_year_fmv - pri_year_fmv) >= -1000000
-          config:
-            where: taxyr >= '2023'
+          config: *time-filter
 
   - name: qc.vw_incorrect_val_method
     description: '{{ doc("view_vw_incorrect_val_method") }}'
@@ -131,7 +127,7 @@ models:
               expression: IN ('1') AND revcode IS NOT NULL
               config:
                 where: |
-                  taxyr >= '2023'
+                  CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                   AND class LIKE '2%'
 
   - name: qc.vw_neg_asmt_value
@@ -145,8 +141,7 @@ models:
           - dbt_utils.accepted_range: &test-non-negative
               name: qc_vw_neg_asmt_value_val01_gte_0
               min_value: 0
-              config:
-                where: taxyr >= '2023'
+              config: *time-filter
       - name: val02
         tests:
           - dbt_utils.accepted_range:


### PR DESCRIPTION
This PR adds a time filter to most `tag:test_qc*` dbt tests related to testing raw iasWorld data. Currently, it limits all tests to only the current year, as set in `dbt_project.yml`. This is because we can't actually correct errors from prior years in most cases, so they aren't worth actually testing.