### PR TITLE
Prefix non-prod databases with `z_` for better sorting

### DIFF
--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -20,7 +20,6 @@ SELECT
     sp.y_3435,
 
     -- PIN locations from spatial joins
-    vwl.census_block_group_geoid,
     vwl.census_block_geoid,
     vwl.census_congressional_district_geoid,
     vwl.census_county_subdivision_geoid,

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -20,6 +20,7 @@ SELECT
     sp.y_3435,
 
     -- PIN locations from spatial joins
+    vwl.census_block_group_geoid,
     vwl.census_block_geoid,
     vwl.census_congressional_district_geoid,
     vwl.census_county_subdivision_geoid,

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -178,7 +178,7 @@ dbt clone --state master-cache
 ```
 
 This will copy all production views and tables into a new set of Athena schemas
-prefixed with your Unix `$USER` name (e.g. `dev_jecochr_default` for the
+prefixed with your Unix `$USER` name (e.g. `z_dev_jecochr_default` for the
 `default` schema when `dbt` is run on Jean's machine).
 
 Once you've copied prod tables and views into your development schemas, you can
@@ -203,7 +203,7 @@ dbt run --select default.*
 By default, all `dbt` commands will run against the `dev` environment (called
 a [target](https://docs.getdbt.com/reference/dbt-jinja-functions/target) in
 dbt jargon), which namespaces the resources it creates by prefixing database
-names with `dev_` and your Unix `$USER` name.
+names with `z_dev_` and your Unix `$USER` name.
 
 You should almost never have to manually build tables and views in our
 production environment, since this repository is configured to automatically
@@ -222,7 +222,7 @@ data sources tidy, you have two options: Delete all of your development Athena
 databases, or delete a selection of Athena databases.
 
 To delete all the resources in your local environment (i.e. every Athena
-database with a name matching the pattern `dev_$USER_$SCHEMA`):
+database with a name matching the pattern `z_dev_$USER_$SCHEMA`):
 
 ```
 ../.github/scripts/cleanup_dbt_resources.sh dev
@@ -232,7 +232,7 @@ To instead delete a selected database, use the [`aws glue delete-database`
 command](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/glue/delete-database.html):
 
 ```
-aws glue delete-database dev_jecochr_default
+aws glue delete-database z_dev_jecochr_default
 ```
 
 Note that these two operations will only delete Athena databases, and will leave
@@ -478,7 +478,7 @@ There are two ways to clean up a PR's resources manually:
    Athena homepage. Select `Data sources` in the sidebar. Click on the
    `AwsDataCatalog` resource. In the `Associated databases` table, select each
    data source that matches the database pattern for your pull request
-   (i.e. prefixed with `ci_` plus the name of your branch) and click the
+   (i.e. prefixed with `z_ci_` plus the name of your branch) and click the
    `Delete` button in the top right-hand corner of the table.
 2. **Using the command-line**: If the workflow has failed, it most likely means
    there is a bug in the `.github/scripts/cleanup_dbt_resources.sh` script
@@ -513,14 +513,14 @@ exist:
 
 ```
 Runtime Error in model default.vw_card_res_char (models/default/default.vw_card_res_char.sql)
-  line 24:10: Table 'awsdatacatalog.dev_jecochr_default.vw_pin_land' does not exist
+  line 24:10: Table 'awsdatacatalog.z_dev_jecochr_default.vw_pin_land' does not exist
 ```
 
 The error may look like this if an entire schema is missing:
 
 ```
 Runtime Error in model default.vw_pin_universe (models/default/default.vw_pin_universe.sql)
-  line 130:11: Schema 'dev_jecochr_location' does not exist
+  line 130:11: Schema 'z_dev_jecochr_location' does not exist
 ```
 
 To resolve this error, you can prefix your selected model's names with a plus

--- a/dbt/macros/generate_schema_name.sql
+++ b/dbt/macros/generate_schema_name.sql
@@ -27,10 +27,10 @@
     {%- set default_schema = target.schema -%}
 
     {%- if target.name == "dev" -%}
-        {%- set schema_prefix = "dev_" ~ env_var_func("USER") ~ "_" -%}
+        {%- set schema_prefix = "z_dev_" ~ env_var_func("USER") ~ "_" -%}
     {%- elif target.name == "ci" -%}
         {%- set github_head_ref = kebab_slugify(env_var_func("HEAD_REF")) -%}
-        {%- set schema_prefix = "ci_" ~ github_head_ref ~ "_" -%}
+        {%- set schema_prefix = "z_ci_" ~ github_head_ref ~ "_" -%}
     {%- else -%} {%- set schema_prefix = "" -%}
     {%- endif -%}
 

--- a/dbt/macros/tests/test_generate_schema_name.sql
+++ b/dbt/macros/tests/test_generate_schema_name.sql
@@ -26,7 +26,7 @@
             mock_env_var,
             exceptions.raise_compiler_error,
         ),
-        "dev_testuser_test",
+        "z_dev_testuser_test",
     ) %}
 {% endmacro %}
 
@@ -40,7 +40,7 @@
             mock_env_var,
             exceptions.raise_compiler_error,
         ),
-        "ci_testuser-feature-branch-1_test",
+        "z_ci_testuser-feature-branch-1_test",
     ) %}
 {% endmacro %}
 


### PR DESCRIPTION
This PR amends changes the prefixes used to identify non-prod databases in Athena. It changes:

- `dev_` -> `z_dev_`
- `ci_` -> `z_ci_`

This sorts all the non-prod databases to the bottom of the Athena dropdown menu (where they belong).

Successful run to create a prefixed DB here: https://github.com/ccao-data/data-architecture/actions/runs/7052325320/job/19197128258?pr=256

I also created a local `z_dev_` environment.