### PR TITLE
Re-add `meta_year` column to `model.vw_card_res_input`

### DIFF
--- a/aws-athena/views/model-vw_card_res_input.sql
+++ b/aws-athena/views/model-vw_card_res_input.sql
@@ -144,6 +144,7 @@ forward_fill AS (
 SELECT
     f1.meta_pin,
     f1.meta_pin10,
+    f1.meta_year,
     f1.meta_class,
     f1.meta_modeling_group,
     f1.meta_triad_name,


### PR DESCRIPTION
I accidentally removed/moved this column when I needed to use it as a partition key in #232. This PR re-adds it to its proper place.