### PR TITLE
Change `dbt-test` database schema name

### DIFF
--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -8,7 +8,7 @@ athena:
       s3_data_naming: schema_table
       region_name: us-east-1
       # "schema" here corresponds to a Glue database
-      schema: dbt-test
+      schema: z_static_unused-dbt-stub-database
       # "database" here corresponds to a Glue data catalog
       database: awsdatacatalog
       threads: 5
@@ -19,7 +19,7 @@ athena:
       s3_data_dir: s3://ccao-dbt-athena-ci-us-east-1/data/
       s3_data_naming: schema_table
       region_name: us-east-1
-      schema: dbt-test
+      schema: z_static_unused-dbt-stub-database
       database: awsdatacatalog
       threads: 5
       num_retries: 1


### PR DESCRIPTION
This PR changes the `dbt-test` test database name to `z_static_unused-dbt-stub-database` to make it more descriptive and aligned with the new sorting added in #256.