### PR TITLE
 Add APRVAL.reascd field to default.vw_pin_value and dbt docs

### DIFF
--- a/aws-athena/views/default-vw_pin_history.sql
+++ b/aws-athena/views/default-vw_pin_history.sql
@@ -14,6 +14,7 @@ SELECT
     vwpv.board_bldg,
     vwpv.board_land,
     vwpv.board_tot,
+    vwpv.change_reason,
     -- Add lagged values for previous two years
     LAG(vwpv.mailed_bldg) OVER (
         PARTITION BY vwpv.pin
@@ -51,6 +52,10 @@ SELECT
         PARTITION BY vwpv.pin
         ORDER BY vwpv.pin, vwpv.year
     ) AS oneyr_pri_board_tot,
+    LAG(vwpv.change_reason) OVER (
+        PARTITION BY vwpv.pin
+        ORDER BY vwpv.pin, vwpv.year
+    ) AS oneyr_pri_change_reason,
     LAG(vwpv.mailed_bldg, 2) OVER (
         PARTITION BY vwpv.pin
         ORDER BY vwpv.pin, vwpv.year
@@ -86,7 +91,11 @@ SELECT
     LAG(vwpv.board_tot, 2) OVER (
         PARTITION BY vwpv.pin
         ORDER BY vwpv.pin, vwpv.year
-    ) AS twoyr_pri_board_tot
+    ) AS twoyr_pri_board_tot,
+    LAG(vwpv.change_reason, 2) OVER (
+        PARTITION BY vwpv.pin
+        ORDER BY vwpv.pin, vwpv.year
+    ) AS twoyr_pri_change_reason,
 
 FROM {{ ref('default.vw_pin_value') }} AS vwpv
 LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg

--- a/aws-athena/views/default-vw_pin_history.sql
+++ b/aws-athena/views/default-vw_pin_history.sql
@@ -95,7 +95,7 @@ SELECT
     LAG(vwpv.change_reason, 2) OVER (
         PARTITION BY vwpv.pin
         ORDER BY vwpv.pin, vwpv.year
-    ) AS twoyr_pri_change_reason,
+    ) AS twoyr_pri_change_reason
 
 FROM {{ ref('default.vw_pin_value') }} AS vwpv
 LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg

--- a/aws-athena/views/default-vw_pin_value.sql
+++ b/aws-athena/views/default-vw_pin_value.sql
@@ -111,8 +111,7 @@ change_reasons AS (
 
 SELECT
     vals.*,
-    reasons.reascd AS chng_rsn_code,
-    descr.description AS chng_rsn_desc
+    descr.description AS change_reason
 FROM clean_values AS vals
 LEFT JOIN change_reasons AS reasons
     ON vals.pin = reasons.pin

--- a/aws-athena/views/default-vw_pin_value.sql
+++ b/aws-athena/views/default-vw_pin_value.sql
@@ -73,19 +73,50 @@ WITH stage_values AS (
         AND deactivat IS NULL
         AND valclass IS NULL
     GROUP BY parid, taxyr
+),
+
+clean_values AS (
+    SELECT
+        stage_values.*,
+        -- Current stage indicator
+        CASE
+            WHEN stage_values.board_tot IS NOT NULL THEN 'BOARD CERTIFIED'
+            WHEN
+                stage_values.certified_tot IS NOT NULL
+                THEN 'ASSESSOR CERTIFIED'
+            WHEN stage_values.mailed_tot IS NOT NULL THEN 'MAILED'
+        END AS stage_name,
+        CASE
+            WHEN stage_values.board_tot IS NOT NULL THEN 3
+            WHEN stage_values.certified_tot IS NOT NULL THEN 2
+            WHEN stage_values.mailed_tot IS NOT NULL THEN 1
+        END AS stage_num
+    FROM stage_values
+),
+
+change_reasons AS (
+    SELECT
+        parid AS pin,
+        taxyr AS year,
+        reascd,
+        CASE
+            WHEN procname = 'CCAOVALUE' THEN 'MAILED'
+            WHEN procname = 'CCAOFINAL' THEN 'ASSESSOR CERTIFIED'
+            WHEN procname = 'BORVALUE' THEN 'BOARD CERTIFIED'
+        END AS stage_name
+    FROM {{ source('iasworld', 'aprval') }}
+    WHERE reascd IS NOT NULL
+        AND procname IS NOT NULL
 )
 
 SELECT
-    stage_values.*,
-    -- Current stage indicator
-    CASE
-        WHEN stage_values.board_tot IS NOT NULL THEN 'BOARD CERTIFIED'
-        WHEN stage_values.certified_tot IS NOT NULL THEN 'ASSESSOR CERTIFIED'
-        WHEN stage_values.mailed_tot IS NOT NULL THEN 'MAILED'
-    END AS stage_name,
-    CASE
-        WHEN stage_values.board_tot IS NOT NULL THEN 3
-        WHEN stage_values.certified_tot IS NOT NULL THEN 2
-        WHEN stage_values.mailed_tot IS NOT NULL THEN 1
-    END AS stage_num
-FROM stage_values
+    vals.*,
+    reasons.reascd,
+    descr.description
+FROM clean_values AS vals
+LEFT JOIN change_reasons AS reasons
+    ON vals.pin = reasons.pin
+    AND vals.year = reasons.year
+    AND vals.stage_name = reasons.stage_name
+LEFT JOIN ccao.aprval_reascd AS descr
+    ON reasons.reascd = descr.reascd

--- a/aws-athena/views/default-vw_pin_value.sql
+++ b/aws-athena/views/default-vw_pin_value.sql
@@ -111,8 +111,8 @@ change_reasons AS (
 
 SELECT
     vals.*,
-    reasons.reascd,
-    descr.description
+    reasons.reascd AS chng_rsn_code,
+    descr.description AS chng_rsn_desc
 FROM clean_values AS vals
 LEFT JOIN change_reasons AS reasons
     ON vals.pin = reasons.pin

--- a/dbt/models/ccao/docs.md
+++ b/dbt/models/ccao/docs.md
@@ -1,3 +1,11 @@
+# aprval_reascd
+
+{% docs table_aprval_reascd %}
+Reason codes and descriptions for changes to assessed value.
+
+**Primary Key**: `reascd`
+{% enddocs %}
+
 # class_dict
 
 {% docs table_class_dict %}

--- a/dbt/models/ccao/docs.md
+++ b/dbt/models/ccao/docs.md
@@ -1,7 +1,8 @@
 # aprval_reascd
 
 {% docs table_aprval_reascd %}
-Reason codes and descriptions for changes to assessed value.
+Reason codes and descriptions for changes to assessed value. The data feeding
+this table is a static parquet file from the data warehouse.
 
 **Primary Key**: `reascd`
 {% enddocs %}

--- a/dbt/models/default/schema/default.vw_pin_history.yml
+++ b/dbt/models/default/schema/default.vw_pin_history.yml
@@ -15,6 +15,8 @@ models:
         description: '{{ doc("shared_column_certified_land") }}'
       - name: certified_tot
         description: '{{ doc("shared_column_certified_tot") }}'
+      - name: change_reason
+        description: '{{ doc("shared_column_change_reason") }}'
       - name: class
         description: '{{ doc("shared_column_class") }}'
       - name: mailed_bldg
@@ -35,6 +37,8 @@ models:
         description: '{{ doc("shared_column_certified_land") }}'
       - name: oneyr_pri_certified_tot
         description: '{{ doc("shared_column_certified_tot") }}'
+      - name: oneyr_pri_change_reason
+        description: '{{ doc("shared_column_change_reason") }}'
       - name: oneyr_pri_mailed_bldg
         description: '{{ doc("shared_column_mailed_bldg") }}'
       - name: oneyr_pri_mailed_land
@@ -53,6 +57,8 @@ models:
         description: '{{ doc("shared_column_certified_land") }}'
       - name: twoyr_pri_certified_tot
         description: '{{ doc("shared_column_certified_tot") }}'
+      - name: twoyr_pri_change_reason
+        description: '{{ doc("shared_column_change_reason") }}'
       - name: twoyr_pri_mailed_bldg
         description: '{{ doc("shared_column_mailed_bldg") }}'
       - name: twoyr_pri_mailed_land

--- a/dbt/models/default/schema/default.vw_pin_value.yml
+++ b/dbt/models/default/schema/default.vw_pin_value.yml
@@ -15,6 +15,8 @@ models:
         description: '{{ doc("shared_column_certified_land") }}'
       - name: certified_tot
         description: '{{ doc("shared_column_certified_tot") }}'
+      - name: change_reason
+        description: '{{ doc("shared_column_change_reason") }}'
       - name: mailed_bldg
         description: '{{ doc("shared_column_mailed_bldg") }}'
       - name: mailed_land
@@ -33,7 +35,7 @@ models:
           Number of currently active/open stages.
 
           The possible values include:
-          
+
           - `1` = Mailed
           - `2` = Certified
           - `3` = Board

--- a/dbt/models/iasworld/columns.md
+++ b/dbt/models/iasworld/columns.md
@@ -743,67 +743,6 @@ Replacement cost new
 Replacement cost new less depreciation
 {% enddocs %}
 
-## reascd
-
-{% docs column_reascd %}
-Reason code for change in assessed value. Possible values for this variable are:
-
-- `1` = Assessor Correction
-- `2` = BOR Decision
-- `3` = Data Conversion Correction
-- `4` = BOR New Construction
-- `5` = Change of Exempt Status
-- `6` = Demolition
-- `7` = Farm Valuation
-- `8` = Foresty Program
-- `9` = Partial Exempt Value
-- `10` =  Model Home Approval
-- `11` =  Nature Preserve
-- `12` =  New Construction
-- `13` =  New Construction HIE Eligible
-- `14` =  Division
-- `15` =  C/E Correction
-- `16` =  Open Space Approval
-- `17` =  Township Open
-- `18` =  Township Close
-- `19` =  PTAB Override
-- `21` =  Reclassificiation of Use - Class Change
-- `22` =  Cert of Rehab Property - Landmark
-- `23` =  Removal From Farm
-- `24` =  Revaluation
-- `25` =  Vacancy Factor
-- `26` =  Occupancy Factor
-- `27` =  Land Rate Change
-- `28` =  Desk Review
-- `29` =  Removal From Incentive Program
-- `30` =  Incentive Program
-- `31` =  New Construction Partial
-- `32` =  Administrative Change
-- `33` =  Characteristic Update - No Value Change
-- `34` =  Assessor Appeal
-- `35` =  Demolition Partial
-- `36` =  Certificate of Correction (CC)
-- `37` =  Assessor Recommendation (AR)
-- `38` =  Natural Disaster
-- `40` =  Conservation Easement
-- `43` =  Court Order
-- `50` =  Mobile Home
-- `52` =  Veteran/Fraternal
-- `80` =  Omit
-- `81` =  Permit
-- `82` =  Owner Review Request
-- `83` =  Land Bank
-- `84` =  Preferential Assessment Removed
-- `85` =  Recpature
-- `86` =  Rollback
-- `87` =  ASMT Correction
-- `88` =  Fire Damage
-- `89` =  Leasehold Value Update
-- `90` =  New Leasehold
-- `91` =  Leasehold Terminated
-- `92` =  Flood Debasement
-{% enddocs %}
-
 ## recnr
 
 {% docs column_recnr %}

--- a/dbt/models/iasworld/columns.md
+++ b/dbt/models/iasworld/columns.md
@@ -743,6 +743,67 @@ Replacement cost new
 Replacement cost new less depreciation
 {% enddocs %}
 
+## reascd
+
+{% docs column_reascd %}
+Reason code for change in assessed value. Possible values for this variable are:
+
+- `1` = Assessor Correction
+- `2` = BOR Decision
+- `3` = Data Conversion Correction
+- `4` = BOR New Construction
+- `5` = Change of Exempt Status
+- `6` = Demolition
+- `7` = Farm Valuation
+- `8` = Foresty Program
+- `9` = Partial Exempt Value
+- `10` =  Model Home Approval
+- `11` =  Nature Preserve
+- `12` =  New Construction
+- `13` =  New Construction HIE Eligible
+- `14` =  Division
+- `15` =  C/E Correction
+- `16` =  Open Space Approval
+- `17` =  Township Open
+- `18` =  Township Close
+- `19` =  PTAB Override
+- `21` =  Reclassificiation of Use - Class Change
+- `22` =  Cert of Rehab Property - Landmark
+- `23` =  Removal From Farm
+- `24` =  Revaluation
+- `25` =  Vacancy Factor
+- `26` =  Occupancy Factor
+- `27` =  Land Rate Change
+- `28` =  Desk Review
+- `29` =  Removal From Incentive Program
+- `30` =  Incentive Program
+- `31` =  New Construction Partial
+- `32` =  Administrative Change
+- `33` =  Characteristic Update - No Value Change
+- `34` =  Assessor Appeal
+- `35` =  Demolition Partial
+- `36` =  Certificate of Correction (CC)
+- `37` =  Assessor Recommendation (AR)
+- `38` =  Natural Disaster
+- `40` =  Conservation Easement
+- `43` =  Court Order
+- `50` =  Mobile Home
+- `52` =  Veteran/Fraternal
+- `80` =  Omit
+- `81` =  Permit
+- `82` =  Owner Review Request
+- `83` =  Land Bank
+- `84` =  Preferential Assessment Removed
+- `85` =  Recpature
+- `86` =  Rollback
+- `87` =  ASMT Correction
+- `88` =  Fire Damage
+- `89` =  Leasehold Value Update
+- `90` =  New Leasehold
+- `91` =  Leasehold Terminated
+- `92` =  Flood Debasement
+{% enddocs %}
+
 ## recnr
 
 {% docs column_recnr %}

--- a/dbt/models/iasworld/schema/iasworld.aprval.yml
+++ b/dbt/models/iasworld/schema/iasworld.aprval.yml
@@ -196,7 +196,7 @@ sources:
           - name: procname
             description: '{{ doc("column_procname") }}'
           - name: reascd
-            description: '{{ doc("column_reascd") }}'
+            description: '{{ doc("shared_column_change_reason") }}'
           - name: resgrmval
             description: Gross rent multiplier value
           - name: revbldg

--- a/dbt/models/iasworld/schema/iasworld.aprval.yml
+++ b/dbt/models/iasworld/schema/iasworld.aprval.yml
@@ -196,7 +196,7 @@ sources:
           - name: procname
             description: '{{ doc("column_procname") }}'
           - name: reascd
-            description: Reason code for change in assessed value
+            description: '{{ doc("column_reascd") }}'
           - name: resgrmval
             description: Gross rent multiplier value
           - name: revbldg

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -210,6 +210,67 @@ This is the value after the first round of appeals at the Assessor's
 Office **and** the second round of appeals at the Board of Review.
 {% enddocs %}
 
+## change_reason
+
+{% docs shared_column_change_reason %}
+Reason for change in assessed value. Possible values for this variable are:
+
+- Assessor Correction
+- BOR Decision
+- Data Conversion Correction
+- BOR New Construction
+- Change of Exempt Status
+- Demolition
+- Farm Valuation
+- Foresty Program
+- Partial Exempt Value
+- Model Home Approval
+- Nature Preserve
+- New Construction
+- New Construction HIE Eligible
+- Division
+- C/E Correction
+- Open Space Approval
+- Township Open
+- Township Close
+- PTAB Override
+- Reclassificiation of Use - Class Change
+- Cert of Rehab Property - Landmark
+- Removal From Farm
+- Revaluation
+- Vacancy Factor
+- Occupancy Factor
+- Land Rate Change
+- Desk Review
+- Removal From Incentive Program
+- Incentive Program
+- New Construction Partial
+- Administrative Change
+- Characteristic Update - No Value Change
+- Assessor Appeal
+- Demolition Partial
+- Certificate of Correction (CC)
+- Assessor Recommendation (AR)
+- Natural Disaster
+- Conservation Easement
+- Court Order
+- Mobile Home
+- Veteran/Fraternal
+- Omit
+- Permit
+- Owner Review Request
+- Land Bank
+- Preferential Assessment Removed
+- Recpature
+- Rollback
+- ASMT Correction
+- Fire Damage
+- Leasehold Value Update
+- New Leasehold
+- Leasehold Terminated
+- Flood Debasement
+{% enddocs %}
+
 ## certified_bldg
 
 {% docs shared_column_certified_bldg %}

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -215,60 +215,60 @@ Office **and** the second round of appeals at the Board of Review.
 {% docs shared_column_change_reason %}
 Reason for change in assessed value. Possible values for this variable are:
 
-- Assessor Correction
-- BOR Decision
-- Data Conversion Correction
-- BOR New Construction
-- Change of Exempt Status
-- Demolition
-- Farm Valuation
-- Foresty Program
-- Partial Exempt Value
-- Model Home Approval
-- Nature Preserve
-- New Construction
-- New Construction HIE Eligible
-- Division
-- C/E Correction
-- Open Space Approval
-- Township Open
-- Township Close
-- PTAB Override
-- Reclassificiation of Use - Class Change
-- Cert of Rehab Property - Landmark
-- Removal From Farm
-- Revaluation
-- Vacancy Factor
-- Occupancy Factor
-- Land Rate Change
-- Desk Review
-- Removal From Incentive Program
-- Incentive Program
-- New Construction Partial
-- Administrative Change
-- Characteristic Update - No Value Change
-- Assessor Appeal
-- Demolition Partial
-- Certificate of Correction (CC)
-- Assessor Recommendation (AR)
-- Natural Disaster
-- Conservation Easement
-- Court Order
-- Mobile Home
-- Veteran/Fraternal
-- Omit
-- Permit
-- Owner Review Request
-- Land Bank
-- Preferential Assessment Removed
-- Recpature
-- Rollback
-- ASMT Correction
-- Fire Damage
-- Leasehold Value Update
-- New Leasehold
-- Leasehold Terminated
-- Flood Debasement
+- `1` = Assessor Correction
+- `2` = BOR Decision
+- `3` = Data Conversion Correction
+- `4` = BOR New Construction
+- `5` = Change of Exempt Status
+- `6` = Demolition
+- `7` = Farm Valuation
+- `8` = Foresty Program
+- `9` = Partial Exempt Value
+- `10` =  Model Home Approval
+- `11` =  Nature Preserve
+- `12` =  New Construction
+- `13` =  New Construction HIE Eligible
+- `14` =  Division
+- `15` =  C/E Correction
+- `16` =  Open Space Approval
+- `17` =  Township Open
+- `18` =  Township Close
+- `19` =  PTAB Override
+- `21` =  Reclassificiation of Use - Class Change
+- `22` =  Cert of Rehab Property - Landmark
+- `23` =  Removal From Farm
+- `24` =  Revaluation
+- `25` =  Vacancy Factor
+- `26` =  Occupancy Factor
+- `27` =  Land Rate Change
+- `28` =  Desk Review
+- `29` =  Removal From Incentive Program
+- `30` =  Incentive Program
+- `31` =  New Construction Partial
+- `32` =  Administrative Change
+- `33` =  Characteristic Update - No Value Change
+- `34` =  Assessor Appeal
+- `35` =  Demolition Partial
+- `36` =  Certificate of Correction (CC)
+- `37` =  Assessor Recommendation (AR)
+- `38` =  Natural Disaster
+- `40` =  Conservation Easement
+- `43` =  Court Order
+- `50` =  Mobile Home
+- `52` =  Veteran/Fraternal
+- `80` =  Omit
+- `81` =  Permit
+- `82` =  Owner Review Request
+- `83` =  Land Bank
+- `84` =  Preferential Assessment Removed
+- `85` =  Recpature
+- `86` =  Rollback
+- `87` =  ASMT Correction
+- `88` =  Fire Damage
+- `89` =  Leasehold Value Update
+- `90` =  New Leasehold
+- `91` =  Leasehold Terminated
+- `92` =  Flood Debasement
 {% enddocs %}
 
 ## certified_bldg


### PR DESCRIPTION
The field `aprval.reascd` contains the reason codes for changes in assessed values. It is used heavily within Inquire queries to append the change code to any query that uses `ASMT_ALL`. We should update our views to include this column where appropriate, as well as create a `CASE WHEN` statement or table containing the human-readable change reasons.

Additionally, we should add the change reasons to the dbt documentation for this column.