### PR TITLE
Update docstring for `spatial-corner_lot.R`

### DIFF
--- a/aws-s3/scripts-ccao-data-raw-us-east-1/spatial-corner_lot.R
+++ b/aws-s3/scripts-ccao-data-raw-us-east-1/spatial-corner_lot.R
@@ -2,10 +2,10 @@
 #
 # To run, set the township name variables below for the township you're
 # interested in, then run the script. The script will output shapefiles to the
-# `Base Data/` directory. These files should then be uploaded to the following
-# S3 path:
+# `spatial-corner_lot-raw/` directory. These files should then be uploaded to
+# the following S3 path:
 #
-# s3://ccao-data-raw-us-east-1/location/corner_lot/year={year}/*.shp
+# s3://ccao-data-raw-us-east-1/spatial/corner_lot/year={year}/*.shp
 #
 # At some point we may want to automate this upload, but it's manual for now.
 #


### PR DESCRIPTION
I took a brief look at `aws-s3/scripts-ccao-data-raw-us-east-1/spatial-corner_lot.R` after merging #265 and realized that there were a couple of pieces of outdated info in the docstring. This tiny PR fixes that info to ensure that future users have the correct instructions on where output files will get generated and how to upload them to S3.

Note that I'm not 100% confident in where these files should live in S3; I originally had thought that `location.corner_lot` made the most sense, but then refactored to `spatial.corner_lot` after noticing that the [`108-create-corner-lot-indicator` branch](https://github.com/ccao-data/data-architecture/tree/108-create-corner-lot-indicator) had previously used the `spatial` prefix. I'm open to either location as long as it's consistent, so let me know if you have strong preferences!