### PR TITLE
Update source freshness tests to publish to SNS on scheduled job failure

### DIFF
--- a/.github/workflows/test_dbt_source_freshness.yaml
+++ b/.github/workflows/test_dbt_source_freshness.yaml
@@ -41,7 +41,7 @@ jobs:
       # types should notify the GitHub user who triggered the event
       - name: Send failure notification
         if: github.event_name == 'workflow_dispatch' && failure()
-        uses: ./.github/actions/publist_sns_topic
+        uses: ./.github/actions/publish_sns_topic
         with:
           sns_topic_arn: ${{ secrets.AWS_SNS_NOTIFICATION_TOPIC_ARN }}
           subject: "dbt source freshness tests failed for workflow run: ${{ github.run_id }}"

--- a/.github/workflows/test_dbt_source_freshness.yaml
+++ b/.github/workflows/test_dbt_source_freshness.yaml
@@ -23,6 +23,10 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
 
+      - name: Fail the job for testing purposes
+        run: exit 1
+        shell: bash
+
       - name: Test source freshness
         run: dbt source freshness --target "$TARGET"
         working-directory: ${{ env.PROJECT_DIR }}
@@ -36,7 +40,7 @@ jobs:
       # Only publish to SNS on failure for scheduled runs, since other event
       # types should notify the GitHub user who triggered the event
       - name: Send failure notification
-        if: github.event_name == 'schedule' && failure()
+        if: github.event_name == 'workflow_dispatch' && failure()
         uses: ./.github/actions/publist_sns_topic
         with:
           sns_topic_arn: ${{ secrets.AWS_SNS_NOTIFICATION_TOPIC_ARN }}

--- a/.github/workflows/test_dbt_source_freshness.yaml
+++ b/.github/workflows/test_dbt_source_freshness.yaml
@@ -27,3 +27,22 @@ jobs:
         run: dbt source freshness --target "$TARGET"
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
+
+      - name: Get current time
+        if: failure()
+        run: echo "TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S")" >> "$GITHUB_ENV"
+        shell: bash
+
+      # Only publish to SNS on failure for scheduled runs, since other event
+      # types should notify the GitHub user who triggered the event
+      - name: Send failure notification
+        if: github.event_name == 'schedule' && failure()
+        uses: ./.github/actions/publist_sns_topic
+        with:
+          sns_topic_arn: ${{ secrets.AWS_SNS_NOTIFICATION_TOPIC_ARN }}
+          subject: "dbt source freshness tests failed for workflow run: ${{ github.run_id }}"
+          body: |
+            dbt source freshness tests failed for workflow ${{ github.run_id }}, run on ${{ env.TIMESTAMP }} UTC
+
+            Link to failing workflow:
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/test_dbt_source_freshness.yaml
+++ b/.github/workflows/test_dbt_source_freshness.yaml
@@ -23,10 +23,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
 
-      - name: Fail the job for testing purposes
-        run: exit 1
-        shell: bash
-
       - name: Test source freshness
         run: dbt source freshness --target "$TARGET"
         working-directory: ${{ env.PROJECT_DIR }}
@@ -40,7 +36,7 @@ jobs:
       # Only publish to SNS on failure for scheduled runs, since other event
       # types should notify the GitHub user who triggered the event
       - name: Send failure notification
-        if: github.event_name == 'workflow_dispatch' && failure()
+        if: github.event_name == 'schedule' && failure()
         uses: ./.github/actions/publish_sns_topic
         with:
           sns_topic_arn: ${{ secrets.AWS_SNS_NOTIFICATION_TOPIC_ARN }}


### PR DESCRIPTION
This PR updates the `test_dbt_source_freshness` workflow to publish a notification to the dbt testing SNS topic in case of failure. This behavior is only configured for scheduled runs, where GitHub will otherwise [notify the user who last edited the schedule](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule).

Workflow run testing the notification: https://github.com/ccao-data/data-architecture/actions/runs/7213700182/job/19654135786

Closes #269. 