### PR TITLE
Add corner lot indicator to modeling views

### DIFF
--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -19,6 +19,9 @@ SELECT
     sp.x_3435,
     sp.y_3435,
 
+    -- Corner lot indicator
+    lot.is_corner_lot AS ccao_is_corner_lot,
+
     -- PIN locations from spatial joins
     vwl.census_block_group_geoid,
     vwl.census_block_geoid,
@@ -132,5 +135,8 @@ LEFT JOIN {{ ref('location.vw_pin10_location') }} AS vwl
     AND par.taxyr = vwl.year
 LEFT JOIN {{ source('spatial', 'township') }} AS twn
     ON leg.user1 = CAST(twn.township_code AS VARCHAR)
+LEFT JOIN {{ source('ccao', 'corner_lot') }} AS lot
+    ON SUBSTR(par.parid, 1, 10) = lot.pin10
+
 WHERE par.cur = 'Y'
     AND par.deactivat IS NULL

--- a/aws-athena/views/model-vw_card_res_input.sql
+++ b/aws-athena/views/model-vw_card_res_input.sql
@@ -587,6 +587,7 @@ SELECT
             nn1.other_school_district_secondary_avg_rating IS NULL
             THEN nn2.other_school_district_secondary_avg_rating
     END AS other_school_district_secondary_avg_rating,
+    f1.ccao_is_corner_lot,
     f1.meta_year AS year
 FROM forward_fill AS f1
 LEFT JOIN (

--- a/aws-athena/views/model-vw_pin_shared_input.sql
+++ b/aws-athena/views/model-vw_pin_shared_input.sql
@@ -299,5 +299,5 @@ LEFT JOIN
         WHERE district_type = 'secondary'
     ) AS sdrs
     ON vwlf.school_secondary_district_geoid = sdrs.district_geoid
-LEFT JOIN {{ source('ccao.', 'corner_lot') }} AS lot
+LEFT JOIN {{ source('ccao', 'corner_lot') }} AS lot
     ON uni.pin10 = lot.pin10

--- a/aws-athena/views/model-vw_pin_shared_input.sql
+++ b/aws-athena/views/model-vw_pin_shared_input.sql
@@ -250,6 +250,9 @@ SELECT
     sdrs.school_district_avg_rating
         AS other_school_district_secondary_avg_rating,
 
+    -- Corner lot indicator
+    lot.is_corner_lot AS ccao_is_corner_lot,
+
     -- PIN nearest neighbors, used for filling missing data
     vwpf.nearest_neighbor_1_pin10,
     vwpf.nearest_neighbor_1_dist_ft,
@@ -296,3 +299,5 @@ LEFT JOIN
         WHERE district_type = 'secondary'
     ) AS sdrs
     ON vwlf.school_secondary_district_geoid = sdrs.district_geoid
+LEFT JOIN {{ source('ccao.', 'corner_lot') }} AS lot
+    ON uni.pin10 = lot.pin10

--- a/aws-athena/views/model-vw_pin_shared_input.sql
+++ b/aws-athena/views/model-vw_pin_shared_input.sql
@@ -251,7 +251,7 @@ SELECT
         AS other_school_district_secondary_avg_rating,
 
     -- Corner lot indicator
-    uni.ccao_is_corner_lot,
+    lot.is_corner_lot AS ccao_is_corner_lot,
 
     -- PIN nearest neighbors, used for filling missing data
     vwpf.nearest_neighbor_1_pin10,
@@ -299,3 +299,5 @@ LEFT JOIN
         WHERE district_type = 'secondary'
     ) AS sdrs
     ON vwlf.school_secondary_district_geoid = sdrs.district_geoid
+LEFT JOIN {{ source('ccao', 'corner_lot') }} AS lot
+    ON uni.pin10 = lot.pin10

--- a/aws-athena/views/model-vw_pin_shared_input.sql
+++ b/aws-athena/views/model-vw_pin_shared_input.sql
@@ -251,7 +251,7 @@ SELECT
         AS other_school_district_secondary_avg_rating,
 
     -- Corner lot indicator
-    lot.is_corner_lot AS ccao_is_corner_lot,
+    uni.ccao_is_corner_lot,
 
     -- PIN nearest neighbors, used for filling missing data
     vwpf.nearest_neighbor_1_pin10,
@@ -299,5 +299,3 @@ LEFT JOIN
         WHERE district_type = 'secondary'
     ) AS sdrs
     ON vwlf.school_secondary_district_geoid = sdrs.district_geoid
-LEFT JOIN {{ source('ccao', 'corner_lot') }} AS lot
-    ON uni.pin10 = lot.pin10

--- a/dbt/models/ccao/docs.md
+++ b/dbt/models/ccao/docs.md
@@ -25,6 +25,15 @@ CCAO commercial valuation data, aggregated from the commercial team spreadsheets
 **Primary Key**: `keypin`, `year`
 {% enddocs %}
 
+# corner_lot
+
+{% docs table_corner_lot %}
+CCAO corner lot indicator. Determined algorithmically by unobstructed access to
+perpidincular streets.
+
+**Primary Key**: `pin10`
+{% enddocs %}
+
 # hie
 
 {% docs table_hie %}

--- a/dbt/models/ccao/schema.yml
+++ b/dbt/models/ccao/schema.yml
@@ -14,6 +14,16 @@ sources:
         tags:
           - type_ic
 
+      - name: corner_lot
+        description: '{{ doc("table_corner_lot") }}'
+        columns:
+          - name: pin10
+            description: '{{ doc("shared_column_pin10") }}'
+          - name: is_corner_lot
+            description: Corner lot indicator.
+          - name: township
+            description: '{{ doc("shared_column_township_code") }}'
+
       - name: hie
         description: '{{ doc("table_hie") }}'
         tags:

--- a/dbt/models/ccao/schema.yml
+++ b/dbt/models/ccao/schema.yml
@@ -20,7 +20,7 @@ sources:
           - name: pin10
             description: '{{ doc("shared_column_pin10") }}'
           - name: is_corner_lot
-            description: Corner lot indicator.
+            description: '{{ doc("shared_column_is_corner_lot") }}'
           - name: township
             description: '{{ doc("shared_column_township_code") }}'
 

--- a/dbt/models/default/schema/default.vw_pin_universe.yml
+++ b/dbt/models/default/schema/default.vw_pin_universe.yml
@@ -252,6 +252,6 @@ models:
             - year
       - row_count:
           name: default_vw_pin_universe_row_count
-          above: 45079937 # as of 2023-11-22
+          above: 45079936 # as of 2024-01-03
       # TODO: Data completeness correlates with availability of spatial data
       # by year

--- a/dbt/models/default/schema/default.vw_pin_universe.yml
+++ b/dbt/models/default/schema/default.vw_pin_universe.yml
@@ -11,6 +11,8 @@ models:
         description: '{{ doc("column_access_cmap_walk_nta_score") }}'
       - name: access_cmap_walk_total_score
         description: '{{ doc("column_access_cmap_walk_total_score") }}'
+      - name: ccao_is_corner_lot
+        description: '{{ doc("shared_column_is_corner_lot") }}'
       - name: census_acs5_congressional_district_geoid
         description: '{{ doc("column_census_congressional_district_geoid") }}'
       - name: census_acs5_county_subdivision_geoid

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -136,6 +136,9 @@ models:
       - &acs5_percent_mobility_no_move
         name: acs5_percent_mobility_no_move
         description: '{{ doc("column_percent_mobility_no_move") }}'
+      - &ccao_is_corner_lot
+        name: ccao_is_corner_lot
+        description: '{{ doc("shared_column_is_corner_lot") }}'
       - &loc_access_cmap_walk_nta_score
         name: loc_access_cmap_walk_nta_score
         description: '{{ doc("column_access_cmap_walk_nta_score") }}'
@@ -425,6 +428,7 @@ models:
       - *acs5_percent_mobility_moved_from_other_state
       - *acs5_percent_mobility_moved_in_county
       - *acs5_percent_mobility_no_move
+      - *ccao_is_corner_lot
       - *loc_access_cmap_walk_nta_score
       - *loc_access_cmap_walk_total_score
       - *loc_census_acs5_data_year
@@ -653,6 +657,7 @@ models:
       - *acs5_percent_mobility_moved_from_other_state
       - *acs5_percent_mobility_moved_in_county
       - *acs5_percent_mobility_no_move
+      - *ccao_is_corner_lot
       - *loc_access_cmap_walk_nta_score
       - *loc_access_cmap_walk_total_score
       - *loc_census_acs5_data_year

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -786,6 +786,12 @@ percentage of fair cash value at which a property is assessed for taxing
 purposes. See `ccao.class_dict` for more information
 {% enddocs %}
 
+## is_corner_lot
+
+{% docs shared_column_is_corner_lot %}
+Corner lot indicator.
+{% enddocs %}
+
 ## modeling_group
 
 {% docs shared_column_modeling_group %}


### PR DESCRIPTION
Corner lots live in `ccao.corner_lot` but have not been added to any of the views used for modelling. Let's add it to `default.vw_card_res_char` and `default.vw_pin_condo_char` so that we can use it in the modeling pipelines.