### PR TITLE
Correct `env_airport_noise_data_year` fill misjoin

### DIFF
--- a/aws-athena/ctas/location-crosswalk_year_fill.sql
+++ b/aws-athena/ctas/location-crosswalk_year_fill.sql
@@ -46,13 +46,7 @@ WITH unfilled AS (
             AS env_flood_fs_data_year,
         MAX(environment.env_ohare_noise_contour_data_year)
             AS env_ohare_noise_contour_data_year,
-        MAX(
-            CASE
-                WHEN
-                    environment.env_airport_noise_data_year != 'omp'
-                    THEN environment.env_airport_noise_data_year
-            END
-        )
+        MAX(environment.env_airport_noise_data_year)
             AS env_airport_noise_data_year,
         MAX(school.school_data_year)
             AS school_data_year,
@@ -112,7 +106,11 @@ WITH unfilled AS (
             env_flood_fema_data_year,
             env_flood_fs_data_year,
             env_ohare_noise_contour_data_year,
-            env_airport_noise_data_year
+            CASE
+                WHEN
+                    env_airport_noise_data_year != 'omp'
+                    THEN env_airport_noise_data_year
+            END AS env_airport_noise_data_year
         FROM {{ ref('location.environment') }}
     ) AS environment ON pin.year = environment.year
     LEFT JOIN (

--- a/aws-athena/ctas/location-crosswalk_year_fill.sql
+++ b/aws-athena/ctas/location-crosswalk_year_fill.sql
@@ -46,9 +46,7 @@ WITH unfilled AS (
             AS env_flood_fs_data_year,
         MAX(environment.env_ohare_noise_contour_data_year)
             AS env_ohare_noise_contour_data_year,
-        MAX(CASE WHEN environment.env_airport_noise_data_year != 'omp'
-                THEN environment.env_airport_noise_data_year
-        END)
+        MAX(environment.env_airport_noise_data_year)
             AS env_airport_noise_data_year,
         MAX(school.school_data_year)
             AS school_data_year,
@@ -108,11 +106,7 @@ WITH unfilled AS (
             env_flood_fema_data_year,
             env_flood_fs_data_year,
             env_ohare_noise_contour_data_year,
-            CASE
-                WHEN
-                    env_airport_noise_data_year != 'omp'
-                    THEN env_airport_noise_data_year
-            END AS env_airport_noise_data_year
+            env_airport_noise_data_year
         FROM {{ ref('location.environment') }}
     ) AS environment ON pin.year = environment.year
     LEFT JOIN (
@@ -244,7 +238,7 @@ SELECT
         env_airport_noise_data_year,
         LAST_VALUE(env_airport_noise_data_year)
             IGNORE NULLS
-            OVER (ORDER BY unfilled.year)
+            OVER (ORDER BY unfilled.year DESC)
     ) AS env_airport_noise_data_year,
     COALESCE(
         school_data_year, LAST_VALUE(school_data_year)

--- a/aws-athena/ctas/location-crosswalk_year_fill.sql
+++ b/aws-athena/ctas/location-crosswalk_year_fill.sql
@@ -46,7 +46,13 @@ WITH unfilled AS (
             AS env_flood_fs_data_year,
         MAX(environment.env_ohare_noise_contour_data_year)
             AS env_ohare_noise_contour_data_year,
-        MAX(environment.env_airport_noise_data_year)
+        MAX(
+            CASE
+                WHEN
+                    environment.env_airport_noise_data_year != 'omp'
+                    THEN environment.env_airport_noise_data_year
+            END
+        )
             AS env_airport_noise_data_year,
         MAX(school.school_data_year)
             AS school_data_year,

--- a/aws-athena/ctas/location-crosswalk_year_fill.sql
+++ b/aws-athena/ctas/location-crosswalk_year_fill.sql
@@ -40,13 +40,13 @@ WITH unfilled AS (
             AS econ_industrial_growth_zone_data_year,
         MAX(economy.econ_qualified_opportunity_zone_data_year)
             AS econ_qualified_opportunity_zone_data_year,
-        MAX(environment.env_flood_fema_data_year)
+        MAX(environment1.env_flood_fema_data_year)
             AS env_flood_fema_data_year,
-        MAX(environment.env_flood_fs_data_year)
+        MAX(environment1.env_flood_fs_data_year)
             AS env_flood_fs_data_year,
-        MAX(environment.env_ohare_noise_contour_data_year)
+        MAX(environment1.env_ohare_noise_contour_data_year)
             AS env_ohare_noise_contour_data_year,
-        MAX(environment.env_airport_noise_data_year)
+        MAX(environment2.env_airport_noise_data_year)
             AS env_airport_noise_data_year,
         MAX(school.school_data_year)
             AS school_data_year,
@@ -105,14 +105,19 @@ WITH unfilled AS (
             year,
             env_flood_fema_data_year,
             env_flood_fs_data_year,
-            env_ohare_noise_contour_data_year,
+            env_ohare_noise_contour_data_year
+        FROM {{ ref('location.environment') }}
+    ) AS environment1 ON pin.year = environment1.year
+    LEFT JOIN (
+        SELECT DISTINCT
+            year,
             CASE
                 WHEN
                     env_airport_noise_data_year != 'omp'
                     THEN env_airport_noise_data_year
             END AS env_airport_noise_data_year
         FROM {{ ref('location.environment') }}
-    ) AS environment ON pin.year = environment.year
+    ) AS environment2 ON pin.year = environment2.year
     LEFT JOIN (
         SELECT DISTINCT
             year,

--- a/aws-athena/ctas/location-crosswalk_year_fill.sql
+++ b/aws-athena/ctas/location-crosswalk_year_fill.sql
@@ -40,13 +40,15 @@ WITH unfilled AS (
             AS econ_industrial_growth_zone_data_year,
         MAX(economy.econ_qualified_opportunity_zone_data_year)
             AS econ_qualified_opportunity_zone_data_year,
-        MAX(environment1.env_flood_fema_data_year)
+        MAX(environment.env_flood_fema_data_year)
             AS env_flood_fema_data_year,
-        MAX(environment1.env_flood_fs_data_year)
+        MAX(environment.env_flood_fs_data_year)
             AS env_flood_fs_data_year,
-        MAX(environment1.env_ohare_noise_contour_data_year)
+        MAX(environment.env_ohare_noise_contour_data_year)
             AS env_ohare_noise_contour_data_year,
-        MAX(environment2.env_airport_noise_data_year)
+        MAX(CASE WHEN environment.env_airport_noise_data_year != 'omp'
+                THEN environment.env_airport_noise_data_year
+        END)
             AS env_airport_noise_data_year,
         MAX(school.school_data_year)
             AS school_data_year,
@@ -105,19 +107,14 @@ WITH unfilled AS (
             year,
             env_flood_fema_data_year,
             env_flood_fs_data_year,
-            env_ohare_noise_contour_data_year
-        FROM {{ ref('location.environment') }}
-    ) AS environment1 ON pin.year = environment1.year
-    LEFT JOIN (
-        SELECT DISTINCT
-            year,
+            env_ohare_noise_contour_data_year,
             CASE
                 WHEN
                     env_airport_noise_data_year != 'omp'
                     THEN env_airport_noise_data_year
             END AS env_airport_noise_data_year
         FROM {{ ref('location.environment') }}
-    ) AS environment2 ON pin.year = environment2.year
+    ) AS environment ON pin.year = environment.year
     LEFT JOIN (
         SELECT DISTINCT
             year,
@@ -247,7 +244,7 @@ SELECT
         env_airport_noise_data_year,
         LAST_VALUE(env_airport_noise_data_year)
             IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
+            OVER (ORDER BY unfilled.year)
     ) AS env_airport_noise_data_year,
     COALESCE(
         school_data_year, LAST_VALUE(school_data_year)

--- a/aws-athena/views/location-vw_pin10_location_fill.sql
+++ b/aws-athena/views/location-vw_pin10_location_fill.sql
@@ -170,7 +170,7 @@ LEFT JOIN {{ ref('location.environment') }} AS env_flood_fs
 LEFT JOIN {{ ref('location.environment') }} AS env_ohare_noise_contour
     ON pin.pin10 = env_ohare_noise_contour.pin10
     AND cyf.env_ohare_noise_contour_data_year = env_ohare_noise_contour.year
--- Airport noise is joined differently year since it's filled during ingest and
+-- Airport noise is joined differently since it's filled during ingest and
 -- values for env_airport_noise_data_year won't match values for year
 LEFT JOIN {{ ref('location.environment') }} AS env_airport_noise
     ON pin.pin10 = env_airport_noise.pin10

--- a/aws-athena/views/location-vw_pin10_location_fill.sql
+++ b/aws-athena/views/location-vw_pin10_location_fill.sql
@@ -174,8 +174,7 @@ LEFT JOIN {{ ref('location.environment') }} AS env_ohare_noise_contour
 -- values for env_airport_noise_data_year won't match values for year
 LEFT JOIN {{ ref('location.environment') }} AS env_airport_noise
     ON pin.pin10 = env_airport_noise.pin10
-    AND cyf.env_airport_noise_data_year
-    = env_airport_noise.env_airport_noise_data_year
+    AND cyf.year = env_airport_noise.year
 LEFT JOIN {{ ref('location.school') }} AS school
     ON pin.pin10 = school.pin10
     AND cyf.school_data_year = school.year

--- a/aws-athena/views/location-vw_pin10_location_fill.sql
+++ b/aws-athena/views/location-vw_pin10_location_fill.sql
@@ -170,9 +170,12 @@ LEFT JOIN {{ ref('location.environment') }} AS env_flood_fs
 LEFT JOIN {{ ref('location.environment') }} AS env_ohare_noise_contour
     ON pin.pin10 = env_ohare_noise_contour.pin10
     AND cyf.env_ohare_noise_contour_data_year = env_ohare_noise_contour.year
+-- Airport noise is joined differently year since it's filled during ingest and
+-- values for env_airport_noise_data_year won't match values for year
 LEFT JOIN {{ ref('location.environment') }} AS env_airport_noise
     ON pin.pin10 = env_airport_noise.pin10
-    AND cyf.env_airport_noise_data_year = env_airport_noise.year
+    AND cyf.env_airport_noise_data_year
+    = env_airport_noise.env_airport_noise_data_year
 LEFT JOIN {{ ref('location.school') }} AS school
     ON pin.pin10 = school.pin10
     AND cyf.school_data_year = school.year


### PR DESCRIPTION
'omp' is a value for `env_airport_noise_data_year` in our location data crosswalk, but can't be joined to our generic `year`column. Airport noise is already filled during ingest so we don't need to use `env_airport_noise_data_year` when joining data for `location.vw_pin10_fill`