### PR TITLE
Add exemptions feature subquery/CTE

### DIFF
--- a/aws-athena/views/model-vw_card_res_input.sql
+++ b/aws-athena/views/model-vw_card_res_input.sql
@@ -600,6 +600,8 @@ SELECT
             nn1.other_school_district_secondary_avg_rating IS NULL
             THEN nn2.other_school_district_secondary_avg_rating
     END AS other_school_district_secondary_avg_rating,
+    f1.ccao_is_exe_homeowner_active,
+    f1.ccao_n_years_exe_homeowner_active,
     f1.ccao_is_corner_lot,
     f1.meta_year AS year
 FROM forward_fill AS f1

--- a/aws-athena/views/model-vw_card_res_input.sql
+++ b/aws-athena/views/model-vw_card_res_input.sql
@@ -601,19 +601,19 @@ SELECT
             THEN nn2.other_school_district_secondary_avg_rating
     END AS other_school_district_secondary_avg_rating,
     -- Exemptions data is usually missing for the 1 or 2 years prior
-    -- to the lien date, so we need to forward fill missing values i.e.
-    -- this assumes that people currently receiving exemptions keep them
+    -- to the lien date, so we need to fill missing values w/ down up fill
+    -- This assumes that people currently receiving exemptions keep them
     COALESCE(
         f1.ccao_is_active_exe_homeowner,
-        LAST_VALUE(f1.ccao_is_active_exe_homeowner)
+        LAG(f1.ccao_is_active_exe_homeowner)
             IGNORE NULLS
-            OVER (PARTITION BY f1.meta_pin ORDER BY f1.meta_year DESC)
+            OVER (PARTITION BY f1.meta_pin ORDER BY f1.meta_year)
     ) AS ccao_is_active_exe_homeowner,
     COALESCE(
         f1.ccao_n_years_exe_homeowner,
-        LAST_VALUE(f1.ccao_n_years_exe_homeowner)
+        LAG(f1.ccao_n_years_exe_homeowner)
             IGNORE NULLS
-            OVER (PARTITION BY f1.meta_pin ORDER BY f1.meta_year DESC)
+            OVER (PARTITION BY f1.meta_pin ORDER BY f1.meta_year)
     ) AS ccao_n_years_exe_homeowner,
     f1.ccao_is_corner_lot,
     f1.meta_year AS year

--- a/aws-athena/views/model-vw_pin_shared_input.sql
+++ b/aws-athena/views/model-vw_pin_shared_input.sql
@@ -279,6 +279,10 @@ SELECT
     sdrs.school_district_avg_rating
         AS other_school_district_secondary_avg_rating,
 
+    -- Exemption features
+    exemption_features.ccao_is_exe_homeowner_active,
+    exemption_features.ccao_n_years_exe_homeowner_active,
+
     -- Corner lot indicator
     lot.is_corner_lot AS ccao_is_corner_lot,
 
@@ -328,12 +332,8 @@ LEFT JOIN
         WHERE district_type = 'secondary'
     ) AS sdrs
     ON vwlf.school_secondary_district_geoid = sdrs.district_geoid
-LEFT JOIN
-    (
-        SELECT *
-        FROM exemption_features
-    ) AS exef
-    ON uni.pin = exef.pin
-    AND uni.year = exef.year
+LEFT JOIN exemption_features
+    ON uni.pin = exemption_features.pin
+    AND uni.year = exemption_features.year
 LEFT JOIN {{ source('ccao', 'corner_lot') }} AS lot
     ON uni.pin10 = lot.pin10

--- a/aws-athena/views/model-vw_pin_shared_input.sql
+++ b/aws-athena/views/model-vw_pin_shared_input.sql
@@ -109,8 +109,8 @@ exemption_features AS (
     SELECT
         year,
         pin,
-        SIGN(exe_homeowner) AS ccao_is_exe_homeowner_active,
-        act AS ccao_n_years_exe_homeowner_active
+        SIGN(exe_homeowner) AS ccao_is_active_exe_homeowner,
+        act AS ccao_n_years_exe_homeowner
     FROM (
         SELECT
             *,
@@ -280,8 +280,8 @@ SELECT
         AS other_school_district_secondary_avg_rating,
 
     -- Exemption features
-    exemption_features.ccao_is_exe_homeowner_active,
-    exemption_features.ccao_n_years_exe_homeowner_active,
+    exemption_features.ccao_is_active_exe_homeowner,
+    exemption_features.ccao_n_years_exe_homeowner,
 
     -- Corner lot indicator
     lot.is_corner_lot AS ccao_is_corner_lot,


### PR DESCRIPTION
This PR adds two exemption-related features to the residential model input view:

1. Whether or not a PIN has an exemption active in a given year
2. How many consecutive years a PIN has had an exemption active