### PR TITLE
Move conditional for nearest dist macro to CTE

### DIFF
--- a/aws-athena/ctas/proximity-dist_pin_to_cta_route.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_cta_route.sql
@@ -8,6 +8,13 @@
     )
 }}
 
+WITH cta_route AS (
+    SELECT *
+    FROM {{ source('spatial', 'transit_route') }}
+    WHERE agency = 'cta'
+        AND route_type = 1
+)
+
 SELECT
     pcl.pin10,
     ARBITRARY(xy.route_id) AS nearest_cta_route_id,
@@ -16,12 +23,7 @@ SELECT
     ARBITRARY(xy.year) AS nearest_cta_route_data_year,
     pcl.year
 FROM {{ source('spatial', 'parcel') }} AS pcl
-INNER JOIN ( {{
-        dist_to_nearest_geometry(
-            source('spatial', 'transit_route'),
-            'agency = \'cta\' AND route_type = 1'
-        )
-    }} ) AS xy
+INNER JOIN ( {{ dist_to_nearest_geometry('cta_route') }} ) AS xy
     ON pcl.x_3435 = xy.x_3435
     AND pcl.y_3435 = xy.y_3435
     AND pcl.year = xy.pin_year

--- a/aws-athena/ctas/proximity-dist_pin_to_cta_stop.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_cta_stop.sql
@@ -8,6 +8,13 @@
     )
 }}
 
+WITH cta_stop AS (
+    SELECT *
+    FROM {{ source('spatial', 'transit_stop') }}
+    WHERE agency = 'cta'
+        AND route_type = 1
+)
+
 SELECT
     pcl.pin10,
     ARBITRARY(xy.stop_id) AS nearest_cta_stop_id,
@@ -16,12 +23,7 @@ SELECT
     ARBITRARY(xy.year) AS nearest_cta_stop_data_year,
     pcl.year
 FROM {{ source('spatial', 'parcel') }} AS pcl
-INNER JOIN ( {{
-        dist_to_nearest_geometry(
-            source('spatial', 'transit_stop'),
-            'agency = \'cta\' AND route_type = 1'
-        )
-    }} ) AS xy
+INNER JOIN ( {{ dist_to_nearest_geometry('cta_stop') }} ) AS xy
     ON pcl.x_3435 = xy.x_3435
     AND pcl.y_3435 = xy.y_3435
     AND pcl.year = xy.pin_year

--- a/aws-athena/ctas/proximity-dist_pin_to_metra_route.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_metra_route.sql
@@ -8,6 +8,13 @@
     )
 }}
 
+WITH metra_route AS (
+    SELECT *
+    FROM {{ source('spatial', 'transit_route') }}
+    WHERE agency = 'metra'
+        AND route_type = 2
+)
+
 SELECT
     pcl.pin10,
     ARBITRARY(xy.route_id) AS nearest_metra_route_id,
@@ -16,12 +23,7 @@ SELECT
     ARBITRARY(xy.year) AS nearest_metra_route_data_year,
     pcl.year
 FROM {{ source('spatial', 'parcel') }} AS pcl
-INNER JOIN ( {{
-        dist_to_nearest_geometry(
-            source('spatial', 'transit_route'),
-            'agency = \'metra\' AND route_type = 2'
-        )
-    }} ) AS xy
+INNER JOIN ( {{ dist_to_nearest_geometry('metra_route') }} ) AS xy
     ON pcl.x_3435 = xy.x_3435
     AND pcl.y_3435 = xy.y_3435
     AND pcl.year = xy.pin_year

--- a/aws-athena/ctas/proximity-dist_pin_to_metra_stop.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_metra_stop.sql
@@ -8,6 +8,13 @@
     )
 }}
 
+WITH metra_stop AS (
+    SELECT *
+    FROM {{ source('spatial', 'transit_stop') }}
+    WHERE agency = 'metra'
+        AND route_type = 2
+)
+
 SELECT
     pcl.pin10,
     ARBITRARY(xy.stop_id) AS nearest_metra_stop_id,
@@ -16,12 +23,7 @@ SELECT
     ARBITRARY(xy.year) AS nearest_metra_stop_data_year,
     pcl.year
 FROM {{ source('spatial', 'parcel') }} AS pcl
-INNER JOIN ( {{
-        dist_to_nearest_geometry(
-            source('spatial', 'transit_stop'),
-            'agency = \'metra\' AND route_type = 2'
-        )
-    }} ) AS xy
+INNER JOIN ( {{ dist_to_nearest_geometry('metra_stop') }} ) AS xy
     ON pcl.x_3435 = xy.x_3435
     AND pcl.y_3435 = xy.y_3435
     AND pcl.year = xy.pin_year

--- a/aws-athena/ctas/proximity-dist_pin_to_park.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_park.sql
@@ -8,6 +8,12 @@
     )
 }}
 
+WITH parks AS (
+    SELECT *
+    FROM {{ source('spatial', 'park') }}
+    WHERE ST_AREA(ST_GEOMFROMBINARY(geometry_3435)) > 87120
+)
+
 SELECT
     pcl.pin10,
     ARBITRARY(xy.osm_id) AS nearest_park_osm_id,
@@ -16,12 +22,7 @@ SELECT
     ARBITRARY(xy.year) AS nearest_park_data_year,
     pcl.year
 FROM {{ source('spatial', 'parcel') }} AS pcl
-INNER JOIN ( {{
-        dist_to_nearest_geometry(
-            source('spatial', 'park'),
-            'ST_AREA(ST_GEOMFROMBINARY(geometry_3435)) > 87120'
-        )
-    }} ) AS xy
+INNER JOIN ( {{ dist_to_nearest_geometry('parks') }} ) AS xy
     ON pcl.x_3435 = xy.x_3435
     AND pcl.y_3435 = xy.y_3435
     AND pcl.year = xy.pin_year

--- a/aws-athena/ctas/proximity-dist_pin_to_university.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_university.sql
@@ -8,6 +8,25 @@
     )
 }}
 
+WITH major_universities AS (
+    SELECT *
+    FROM {{ source('spatial', 'school_location') }}
+    WHERE type = 'HigherEd'
+        AND name IN (
+            'Illinois Institute of Technology Chicago-Kent College of Law',
+            'Columbia College',
+            'University of Illinois at Chicago College of Medicine',
+            'Rush University Medical Center',
+            'University of Chicago',
+            'University of Illinois at Chicago',
+            'Northwestern University',
+            'Loyola University of Chicago',
+            'Chicago State University',
+            'Moraine Valley Community College'
+        )
+        OR gniscode IN (407022)
+)
+
 SELECT
     pcl.pin10,
     ARBITRARY(xy.name) AS nearest_university_name,
@@ -15,26 +34,7 @@ SELECT
     ARBITRARY(xy.year) AS nearest_university_data_year,
     pcl.year
 FROM {{ source('spatial', 'parcel') }} AS pcl
-INNER JOIN
-    ( {{
-        dist_to_nearest_geometry(
-            source('spatial', 'school_location'),
-            '(type = \'HigherEd\'
-            AND name IN (
-                \'Illinois Institute of Technology Chicago-Kent College of Law\',
-                \'Columbia College\',
-                \'University of Illinois at Chicago College of Medicine\',
-                \'Rush University Medical Center\',
-                \'University of Chicago\',
-                \'University of Illinois at Chicago\',
-                \'Northwestern University\',
-                \'Loyola University of Chicago\',
-                \'Chicago State University\',
-                \'Moraine Valley Community College\'
-            )
-            OR gniscode IN (407022))'
-        )
-    }} ) AS xy
+INNER JOIN ( {{ dist_to_nearest_geometry('major_universities') }} ) AS xy
     ON pcl.x_3435 = xy.x_3435
     AND pcl.y_3435 = xy.y_3435
     AND pcl.year = xy.pin_year


### PR DESCRIPTION
Per @jeancochrane's example in #295, I've refactored the distance to nearest geometry macro to use a CTE instead of a conditional passed as a macro argument. This is significantly simpler and more intuitive in my opinion while getting the same results.