### PR TITLE
Clean up and format dbt test workbook

### DIFF
--- a/.github/scripts/format_dbt_test_failures.py
+++ b/.github/scripts/format_dbt_test_failures.py
@@ -46,13 +46,13 @@ import sys
 import typing
 
 import openpyxl
+import openpyxl.cell
 import openpyxl.styles
+import openpyxl.styles.colors
 import openpyxl.utils
 import pyathena
 import pyathena.cursor
 import simplejson as json
-from openpyxl.worksheet.worksheet import Worksheet
-from openpyxl.styles import Alignment
 
 # Tests without a config.meta.category property will be grouped in
 # this default category
@@ -95,14 +95,14 @@ class FailedTestGroup:
     convenience methods for formatting those results for output to a report."""
 
     # Names of fields that are used for debugging
-    _debugging_field_names = [TEST_NAME_FIELD, DOCS_URL_FIELD]
+    _debugging_fieldnames = [TEST_NAME_FIELD, DOCS_URL_FIELD]
     # Names of fields that identify the failing test
-    _test_metadata_field_names = [
+    _test_metadata_fieldnames = [
         *[SOURCE_TABLE_FIELD, DESCRIPTION_FIELD],
-        *_debugging_field_names,
+        *_debugging_fieldnames,
     ]
     # Names of fields that are used for diagnostics
-    _diagnostic_field_names = [
+    _diagnostic_fieldnames = [
         TAXYR_FIELD,
         PARID_FIELD,
         CARD_FIELD,
@@ -111,9 +111,9 @@ class FailedTestGroup:
         WEN_FIELD,
     ]
     # The complete set of fixed fields
-    _fixed_field_names = [
-        *_test_metadata_field_names,
-        *_diagnostic_field_names,
+    _fixed_fieldnames = [
+        *_test_metadata_fieldnames,
+        *_diagnostic_fieldnames,
     ]
 
     def __init__(
@@ -141,9 +141,7 @@ class FailedTestGroup:
         # Remove any fixed fieldnames from the ordered list that are not
         # present in this group
         fixed_field_order = [
-            field
-            for field in self._fixed_field_names
-            if field in fieldnames
+            field for field in self._fixed_fieldnames if field in fieldnames
         ]
 
         # Reorder the fieldnames so that diagnostic fields are presented in the
@@ -165,63 +163,95 @@ class FailedTestGroup:
             for row in self.raw_rows
         ]
 
-    @property
-    def debugging_field_indexes(self) -> tuple:
-        """Get a list of field indexes (e.g. ["A", "B"]) for fields that
-        are used for debugging."""
-        fieldnames = self.fieldnames
+    def _get_filtered_fieldnames(
+        self, possible_fieldnames: typing.List[str]
+    ) -> typing.List[str]:
+        existing_fieldnames = self.fieldnames
+        return [
+            field
+            for field in possible_fieldnames
+            if field in existing_fieldnames
+        ]
+
+    def _get_filtered_field_indexes(
+        self, possible_fieldnames: typing.List[str]
+    ) -> tuple:
+        existing_fieldnames = self.fieldnames
         return tuple(
-            # openpyxl is 1-indexed while the index() method is 0-indexed
-            openpyxl.utils.get_column_letter(fieldnames.index(field) + 1)
-            for field in self._debugging_field_names
+            openpyxl.utils.get_column_letter(
+                # openpyxl is 1-indexed while the index() method is 0-indexed
+                existing_fieldnames.index(field)
+                + 1
             )
+            for field in self._get_filtered_fieldnames(possible_fieldnames)
+        )
 
     @property
-    def test_metadata_field_names(self) -> tuple:
-        """Get a list of field indexes (e.g. ["A", "B"]) for fields that
+    def debugging_fieldnames(self) -> typing.List[str]:
+        """Get a list of fieldnames (e.g. ["foo", "bar"]) for fields that
+        are used for debugging."""
+        return self._get_filtered_fieldnames(self._debugging_fieldnames)
+
+    @property
+    def debugging_field_indexes(self) -> tuple:
+        """Get a tuple of field indexes (e.g. ["A", "B"]) for fields that
+        are used for debugging."""
+        return self._get_filtered_field_indexes(self._debugging_fieldnames)
+
+    @property
+    def test_metadata_fieldnames(self) -> typing.List[str]:
+        """Get a list of fieldnames (e.g. ["foo", "bar"]) for fields that
         are used for identifying tests."""
-        fieldnames = self.fieldnames
-        return tuple(
-            openpyxl.utils.get_column_letter(fieldnames.index(field) + 1)
-            for field in self._test_metadata_field_names
-            if field in fieldnames
-        )
+        return self._get_filtered_fieldnames(self._test_metadata_fieldnames)
+
+    @property
+    def test_metadata_field_indexes(self) -> tuple:
+        """Get a tuple of field indexes (e.g. ["A", "B"]) for fields that
+        are used for identifying tests."""
+        return self._get_filtered_field_indexes(self._test_metadata_fieldnames)
+
+    @property
+    def diagnostic_fieldnames(self) -> typing.List[str]:
+        """Get a list of fieldnames (e.g. ["foo", "bar"]) for fields that
+        are used for diagnostics."""
+        return self._get_filtered_fieldnames(self._diagnostic_fieldnames)
 
     @property
     def diagnostic_field_indexes(self) -> tuple:
-        """Get a list of field indexes (e.g. ["A", "B"]) for fields that
+        """Get a tuple of field indexes (e.g. ["A", "B"]) for fields that
         are used for diagnostics."""
-        fieldnames = self.fieldnames
-        return tuple(
-            openpyxl.utils.get_column_letter(fieldnames.index(field) + 1)
-            for field in self._diagnostic_field_names
-            if field in fieldnames
-        )
+        return self._get_filtered_field_indexes(self._diagnostic_fieldnames)
+
+    @property
+    def fixed_fieldnames(self) -> typing.List[str]:
+        """Get a list of fieldnames (e.g. ["foo", "bar"]) for fields that
+        are fixed (i.e. whose position is always at the start of the sheet,
+        for diagnostic purposes)."""
+        return self._get_filtered_fieldnames(self._fixed_fieldnames)
 
     @property
     def fixed_field_indexes(self) -> tuple:
         """Get a list of field indexes (e.g. ["A", "B"]) for fields that
         are fixed (i.e. whose position is always at the start of the sheet,
         for diagnostic purposes)."""
+        return self._get_filtered_field_indexes(self._fixed_fieldnames)
+
+    @property
+    def nonfixed_fieldnames(self) -> typing.List[str]:
+        """Get a list of field names (e.g. ["foo", "bar"]) for fields that
+        are nonfixed (i.e. whose position comes after the fixed fields in the
+        sheet and are thus variable)."""
         fieldnames = self.fieldnames
-        return tuple(
-            openpyxl.utils.get_column_letter(fieldnames.index(field) + 1)
-            for field in self._fixed_field_names
-            if field in fieldnames
-        )
+        fixed_fieldnames = self._fixed_fieldnames
+        return [field for field in fieldnames if field not in fixed_fieldnames]
 
     @property
     def nonfixed_field_indexes(self) -> tuple:
         """Get a list of field indexes (e.g. ["A", "B"]) for fields that
         are nonfixed (i.e. whose position comes after the fixed fields in the
         sheet and are thus variable)."""
-        fieldnames = self.fieldnames
-        fixed_fieldnames = self._fixed_field_names
-        return tuple(
-            openpyxl.utils.get_column_letter(fieldnames.index(field) + 1)
-            for field in fieldnames
-            if field not in fixed_fieldnames
-        )
+        nonfixed_fieldnames = self.nonfixed_fieldnames
+        return self._get_filtered_field_indexes(nonfixed_fieldnames)
 
 
 # Type representing a mapping of sheet names to the tests contained therein
@@ -273,8 +303,12 @@ def main() -> None:
         )
 
     print("Generating the output workbook")
-    workbook = openpyxl.Workbook()
+    # It's important to use a write-only workbook here because otherwise
+    # the metadata required to store cell info about a large number of failing
+    # tests can cause the process to run out of memory
+    workbook = openpyxl.Workbook(write_only=True)
     for sheet_name, failed_test_group in failed_tests_by_category.items():
+        print(f"Adding sheet for {sheet_name}")
         add_sheet_to_workbook(workbook, sheet_name, failed_test_group)
     workbook.save(output_filepath)
     print(f"Output workbook saved to {output_filepath}")
@@ -488,80 +522,49 @@ def add_sheet_to_workbook(
     sheet_title: str,
     failed_test_group: FailedTestGroup,
 ) -> None:
-    """Add a sheet of failed dbt tests to an openpyxl Workbook."""
-    # openpyxl Workbooks are created with one untitled active sheet by
-    # default, so rename and fill out that sheet before creating any
-    # new sheets
-    sheet: Worksheet
-    if workbook.sheetnames == ["Sheet"]:
-        sheet = workbook.active
-    else:
-        sheet = workbook.create_sheet()
-
+    """Add a sheet of failed dbt tests to an openpyxl Workbook. Note that we
+    expect the workbook to be initialized with write_only=True."""
+    # openpyxl Workbooks are typically created with one untitled active sheet
+    # by default, but write-only sheets are an exception to this rule, so we
+    # always have to create a new sheet
+    sheet = workbook.create_sheet()
     sheet.title = sheet_title
-    sheet.append(failed_test_group.fieldnames)
 
-    # Style the header differently from rows so that it is visually
-    # distinct
-    bold_font = openpyxl.styles.Font(bold=True)
-    italic_font = openpyxl.styles.Font(italic=True)
-    for cell in sheet[1]:
-        cell.font = bold_font
-    sheet.freeze_panes = "A2"  # Freeze the header row
-
-    # Initialize the column dimensions based on the length of the header row
-    col_dims = {cell.column_letter: len(str(cell.value)) for cell in sheet[1]}
-    for row in failed_test_group.rows:
-        output_row = []
-        # Start enumeration at 1 since openpyxl columns are 1-indexed
-        for col_idx, cell in enumerate(row, 1):
-            if cell is not None:
-                cell_str = str(cell)
-                # Convert row values to string so that Excel doesn't apply
-                # autoformatting
-                output_row.append(cell_str)
-                # Check if this cell is longer than the longest cell we've seen
-                # so far, and adjust the column dimensions accordingly
-                column_letter = openpyxl.utils.get_column_letter(col_idx)
-                col_dims[column_letter] = max(
-                    col_dims.get(column_letter, 0), len(cell_str)
-                )
-
-        sheet.append(output_row)
+    # Freeze the header row. The syntax for the freeze_panes attribute is
+    # undocumented, but it freezes all rows above and all columns to the left
+    # of the given cell identifier. Note that freeze operations must be
+    # performed before any data is added to a sheet in a write-only workbook
+    data_header_idx = 3  # We have three headers; 2 for grouping and 1 for data
+    freeze_pane_letter = openpyxl.utils.get_column_letter(
+        len(failed_test_group.test_metadata_fieldnames) + 1
+    )
+    freeze_pane_number = data_header_idx + 1
+    sheet.freeze_panes = f"{freeze_pane_letter}{freeze_pane_number}"
 
     # Hide columns that are intended for debugging only, so that they don't
     # get in the way of non-technical workbook consumers
     for col_idx in failed_test_group.debugging_field_indexes:
         sheet.column_dimensions[col_idx].hidden = True
 
-    # Set columns widths so that they fit the longest column
-    for (
-        col,
-        value,
-    ) in col_dims.items():
-        # Pad with an extra two characters to account for the fact that
-        # non-monospace fonts do not have consistent character widths
-        sheet.column_dimensions[col].width = value + 2
-
-    # Add filters to fixed columns
-    fixed_field_indexes = failed_test_group.fixed_field_indexes
-    min_fixed_idx = f"{fixed_field_indexes[0]}1"
-    max_fixed_idx = f"{fixed_field_indexes[-1]}{sheet.max_row}"
-    fixed_field_range = f"{min_fixed_idx}:{max_fixed_idx}"
-    sheet.auto_filter.ref = fixed_field_range
-
     # Create groupings for columns with a special group header
-    sheet.insert_rows(1, amount=2)
+    bold_font = openpyxl.styles.Font(bold=True)
+    italic_font = openpyxl.styles.Font(italic=True)
+    center_align = openpyxl.styles.Alignment(horizontal="center")
+    title_row, subtitle_row, header_row, merged_cell_range = [], [], [], []
     column_groups = {
-        failed_test_group.test_metadata_field_names: {
+        failed_test_group.test_metadata_field_indexes: {
             "title": "Test description fields",
             "subtitle": "These fields identify a failing test.",
-            "style": "20 % - Accent3",
-            "header_style": "Accent3",
+            "fieldnames": failed_test_group.test_metadata_fieldnames,
+            "style": "20 % - Accent4",
+            "header_style": "Accent4",
         },
         failed_test_group.diagnostic_field_indexes: {
             "title": "Unique identifier fields",
-            "subtitle": "These fields identify the row that is failing a test.",
+            "subtitle": (
+                "These fields identify the row that is failing a test."
+            ),
+            "fieldnames": failed_test_group.diagnostic_fieldnames,
             "style": "20 % - Accent1",
             "header_style": "Accent1",
         },
@@ -569,8 +572,9 @@ def add_sheet_to_workbook(
             "title": "Problematic fields",
             "subtitle": (
                 "These fields contain values that are causing the test "
-                "to fail"
+                "to fail."
             ),
+            "fieldnames": failed_test_group.nonfixed_fieldnames,
             "style": "20 % - Accent2",
             "header_style": "Accent2",
         },
@@ -581,31 +585,119 @@ def add_sheet_to_workbook(
         if not col_group_indexes:
             continue
 
-        # Merge and center grouping header
-        for idx in range(1, 3):
-            sheet.merge_cells(
-                f"{col_group_indexes[0]}{idx}:{col_group_indexes[-1]}{idx}"
-            )
-            sheet[f"{col_group_indexes[0]}{idx}"].alignment = Alignment(
-                horizontal="center"
-            )
+        # Save merged cell info
+        for cell_range in [
+            f"{col_group_indexes[0]}1:{col_group_indexes[-1]}1",
+            f"{col_group_indexes[0]}2:{col_group_indexes[-1]}2",
+        ]:
+            merged_cell_range.append(cell_range)
 
         # Fill out and format grouping header
-        sheet[f"{col_group_indexes[0]}1"] = col_metadata["title"]
-        sheet[f"{col_group_indexes[0]}1"].font = bold_font
+        title_cell = openpyxl.cell.WriteOnlyCell(
+            sheet, value=col_metadata["title"]
+        )
+        title_cell.style = "Note"
+        title_cell.font = bold_font
+        title_cell.alignment = center_align
+        title_row.append(title_cell)
+        # Flesh out the empty title row cells that will be merged later on
+        for _ in range(len(col_group_indexes) - 1):
+            title_row.append("")
 
-        sheet[f"{col_group_indexes[0]}2"] = col_metadata["subtitle"]
-        sheet[f"{col_group_indexes[0]}2"].font = italic_font
+        subtitle_cell = openpyxl.cell.WriteOnlyCell(
+            sheet, value=col_metadata["subtitle"]
+        )
+        subtitle_cell.style = "Note"
+        subtitle_cell.font = italic_font
+        subtitle_cell.alignment = center_align
+        subtitle_row.append(subtitle_cell)
+        for _ in range(len(col_group_indexes) - 1):
+            subtitle_row.append("")
 
-        # Give each group a dedicated color
-        for cell in sheet[
-            f"{col_group_indexes[0]}3:{col_group_indexes[-1]}3"
-        ]:
-            cell[0].style = col_metadata["header_style"]
-        for cell in sheet[
-            f"{col_group_indexes[0]}4:{col_group_indexes[-1]}{sheet.max_row}"
-        ]:
-            cell[0].style = col_metadata["style"]
+        # Fill out and format the data header
+        for fieldname in col_metadata["fieldnames"]:
+            header_cell = openpyxl.cell.WriteOnlyCell(sheet, value=fieldname)
+            header_cell.style = col_metadata["header_style"]
+            header_cell.font = openpyxl.styles.Font(
+                bold=True, color=openpyxl.styles.colors.WHITE
+            )
+            header_row.append(header_cell)
+
+    # Initialize the column widths based on the length of values in
+    # the header row
+    column_widths = {
+        openpyxl.utils.get_column_letter(idx + 1): len(fieldname) + 2
+        for idx, fieldname in enumerate(failed_test_group.fieldnames)
+    }
+    # Iterate the rows to extract data and optionally update the column
+    # widths if the length of the cell value exceeds the length of the
+    # header value
+    data_rows = []
+    for row in failed_test_group.rows:
+        data_row = []
+        # Start enumeration at 1 since openpyxl columns are 1-indexed
+        for col_idx, cell in enumerate(row, 1):
+            # Convert row values to string so that Excel doesn't apply
+            # autoformatting
+            cell_str = str(cell) if cell is not None else ""
+            cell = openpyxl.cell.WriteOnlyCell(sheet, value=cell_str)
+
+            # Retrieve the cell style from the column groupings if one exists
+            cell_style = None
+            column_letter = openpyxl.utils.get_column_letter(col_idx)
+            for col_group_indexes, col_metadata in column_groups.items():
+                if column_letter in col_group_indexes:
+                    cell_style = col_metadata["style"]
+            if cell_style:
+                cell.style = cell_style
+            data_row.append(cell)
+
+            # Check if this cell is longer than the longest cell we've seen
+            # so far, and adjust the column dimensions accordingly
+            column_letter = openpyxl.utils.get_column_letter(col_idx)
+            column_widths[column_letter] = max(
+                column_widths.get(column_letter, 0), len(cell_str)
+            )
+
+        data_rows.append(data_row)
+
+    # Update column widths so that they fit the longest column
+    for (
+        column_letter,
+        column_width,
+    ) in column_widths.items():
+        # Pad with an extra two characters to account for the fact that
+        # non-monospace fonts do not have consistent character widths,
+        # and set a hard limit of 75 characters so no one field takes over
+        # the viewport of the spreadsheet
+        width = min(column_width + 2, 75)
+        sheet.column_dimensions[column_letter].width = width
+
+    # Add filters to fixed columns (i.e. columns that appear in every sheet
+    # in the same position)
+    fixed_field_indexes = failed_test_group.fixed_field_indexes
+    sheet_max_row_idx = data_header_idx + len(data_rows)
+    min_fixed_idx = f"{fixed_field_indexes[0]}{data_header_idx}"
+    max_fixed_idx = f"{fixed_field_indexes[-1]}{sheet_max_row_idx}"
+    fixed_field_range = f"{min_fixed_idx}:{max_fixed_idx}"
+    sheet.auto_filter.ref = fixed_field_range
+
+    # Add the data to the sheet. This should be one of the last steps in
+    # this function, since write-only sheets require all formatting to be
+    # set before data is added
+    sheet.append(title_row)
+    sheet.append(subtitle_row)
+    sheet.append(header_row)
+    for data_row in data_rows:
+        sheet.append(data_row)
+
+    # Merge cells in the grouping headers. This approach is a bit of a hack
+    # since merged cells are not fully supported in write-only workbooks, hence
+    # why it takes place _after_ rows have been added to the sheet whereas most
+    # formatting options for write-only workbooks need to happen _before_
+    # data is added. See here for details: https://stackoverflow.com/a/66159254
+    for cell_range in merged_cell_range:
+        sheet.merged_cells.ranges.add(cell_range)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/format_dbt_test_failures.py
+++ b/.github/scripts/format_dbt_test_failures.py
@@ -176,7 +176,7 @@ class FailedTestGroup:
             if field in existing_fieldnames
         ]
 
-    def __filter_for_existing_field_indexes(
+    def _filter_for_existing_field_indexes(
         self, possible_fieldnames: typing.List[str]
     ) -> tuple:
         """Helper function to filter a list of `possible_fieldnames` for
@@ -204,7 +204,7 @@ class FailedTestGroup:
     def debugging_field_indexes(self) -> tuple:
         """Get a tuple of field indexes (e.g. ["A", "B"]) for fields that
         are used for debugging."""
-        return self.__filter_for_existing_field_indexes(
+        return self._filter_for_existing_field_indexes(
             self._debugging_fieldnames
         )
 
@@ -220,7 +220,7 @@ class FailedTestGroup:
     def test_metadata_field_indexes(self) -> tuple:
         """Get a tuple of field indexes (e.g. ["A", "B"]) for fields that
         are used for identifying tests."""
-        return self.__filter_for_existing_field_indexes(
+        return self._filter_for_existing_field_indexes(
             self._test_metadata_fieldnames
         )
 
@@ -236,7 +236,7 @@ class FailedTestGroup:
     def diagnostic_field_indexes(self) -> tuple:
         """Get a tuple of field indexes (e.g. ["A", "B"]) for fields that
         are used for diagnostics."""
-        return self.__filter_for_existing_field_indexes(
+        return self._filter_for_existing_field_indexes(
             self._diagnostic_fieldnames
         )
 
@@ -252,7 +252,7 @@ class FailedTestGroup:
         """Get a list of field indexes (e.g. ["A", "B"]) for fields that
         are fixed (i.e. whose position is always at the start of the sheet,
         for diagnostic purposes)."""
-        return self.__filter_for_existing_field_indexes(self._fixed_fieldnames)
+        return self._filter_for_existing_field_indexes(self._fixed_fieldnames)
 
     @property
     def nonfixed_fieldnames(self) -> typing.List[str]:
@@ -269,7 +269,7 @@ class FailedTestGroup:
         are nonfixed (i.e. whose position comes after the fixed fields in the
         sheet and are thus variable)."""
         nonfixed_fieldnames = self.nonfixed_fieldnames
-        return self.__filter_for_existing_field_indexes(nonfixed_fieldnames)
+        return self._filter_for_existing_field_indexes(nonfixed_fieldnames)
 
 
 # Type representing a mapping of sheet names to the tests contained therein

--- a/.github/scripts/format_dbt_test_failures.py
+++ b/.github/scripts/format_dbt_test_failures.py
@@ -549,7 +549,6 @@ def add_sheet_to_workbook(
     # Create groupings for columns with a special group header
     bold_font = openpyxl.styles.Font(bold=True)
     italic_font = openpyxl.styles.Font(italic=True)
-    center_align = openpyxl.styles.Alignment(horizontal="center")
     title_row, subtitle_row, header_row, merged_cell_range = [], [], [], []
     column_groups = {
         failed_test_group.test_metadata_field_indexes: {
@@ -598,7 +597,6 @@ def add_sheet_to_workbook(
         )
         title_cell.style = "Note"
         title_cell.font = bold_font
-        title_cell.alignment = center_align
         title_row.append(title_cell)
         # Flesh out the empty title row cells that will be merged later on
         for _ in range(len(col_group_indexes) - 1):
@@ -609,7 +607,6 @@ def add_sheet_to_workbook(
         )
         subtitle_cell.style = "Note"
         subtitle_cell.font = italic_font
-        subtitle_cell.alignment = center_align
         subtitle_row.append(subtitle_cell)
         for _ in range(len(col_group_indexes) - 1):
             subtitle_row.append("")

--- a/.github/scripts/format_dbt_test_failures_requirements.txt
+++ b/.github/scripts/format_dbt_test_failures_requirements.txt
@@ -1,2 +1,3 @@
 openpyxl~=3.1.2
 PyAthena~=3.0.8
+simplejson~=3.19.2

--- a/.github/scripts/format_dbt_test_failures_requirements.txt
+++ b/.github/scripts/format_dbt_test_failures_requirements.txt
@@ -1,3 +1,4 @@
 openpyxl~=3.1.2
 PyAthena~=3.0.8
 simplejson~=3.19.2
+lxml~=5.1.0

--- a/dbt/.gitignore
+++ b/dbt/.gitignore
@@ -7,3 +7,4 @@ dbt_packages/
 assets/*.svg
 master-cache/
 *.xlsx
+failed_test_cache/*.json

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -154,6 +154,8 @@ sources:
               config:
                 <<: *unique-conditions
                 error_if: ">15300"
+              meta:
+                description: asmt_all should be unique by parid, procname, and taxyr
           - row_values_match_after_join:
               name: iasworld_asmt_all_class_matches_pardat_class
               column: substr(model.class, 1, 3)

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1029,6 +1029,9 @@ sources:
                   meta:
                     description: >
                       user34 (garage ext. wall construction) should not be null
+                  tags:
+                    # Currently too many failures for this signal to be useful
+                    - test_qc_exclude_from_workbook
               - accepted_values:
                   name: iasworld_dweldat_char_gar_cnst_accepted_values
                   values: ['1', '2', '3', '4']

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1128,7 +1128,7 @@ sources:
               config: *unique-conditions
               meta:
                 category: class_mismatch_or_issue
-                description: class should match pardat class
+                description: at least one dweldat class should match pardat class
           - expression_is_true:
               name: iasworld_dweldat_card_proration_rate_between_0_and_100
               expression: 'CAST(user24 AS decimal) BETWEEN 0.00 AND 100.00'

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1029,9 +1029,6 @@ sources:
                   meta:
                     description: >
                       user34 (garage ext. wall construction) should not be null
-                  tags:
-                    # Currently too many failures for this signal to be useful
-                    - test_qc_exclude_from_workbook
               - accepted_values:
                   name: iasworld_dweldat_char_gar_cnst_accepted_values
                   values: ['1', '2', '3', '4']
@@ -1041,6 +1038,9 @@ sources:
                     description: >
                       user34 (garage ext. wall construction) should be
                       an integer between 1 and 4
+                  tags:
+                    # Currently too many failures for this signal to be useful
+                    - test_qc_exclude_from_workbook
           - name: useramt
             description: RCN value of additions
           - name: userfact

--- a/dbt/models/iasworld/schema/iasworld.htpar.yml
+++ b/dbt/models/iasworld/schema/iasworld.htpar.yml
@@ -315,6 +315,9 @@ sources:
               meta:
                 description: >
                   Address columns should have no leading or trailing whitespace
+              tags:
+                # Currently too many failures for this signal to be useful
+                - test_qc_exclude_from_workbook
           - expression_is_true:
               name: iasworld_htpar_cpaddr3_length_lte_5
               expression: |

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -17,12 +17,13 @@ sources:
               - expression_is_true:
                   name: iasworld_land_acres_is_sf_transformed
                   expression: '* 43560 BETWEEN sf - 5 AND sf + 5'
-                  select_columns: &select-columns
+                  select_columns:
                     - taxyr
                     - parid
                     - card
                     - who
                     - wen
+                    - sf
                   config: &unique-conditions
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
@@ -199,7 +200,12 @@ sources:
               - accepted_range:
                   name: iasworld_land_price_gte_1
                   min_value: 1
-                  additional_select_columns: *select-columns
+                  additional_select_columns: &select-columns
+                    - taxyr
+                    - parid
+                    - card
+                    - who
+                    - wen
                   config:
                     where:
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -314,4 +314,5 @@ sources:
                   AND deactivat IS NULL
               meta:
                 category: class_mismatch_or_issue
-                description: class should match pardat class
+                description: >
+                  land major class (first digit) should match pardat class

--- a/dbt/models/iasworld/schema/iasworld.legdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.legdat.yml
@@ -243,6 +243,9 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: zip1 should not be 00000
+                  # Currently too many failures for this signal to be useful
+                  tags:
+                    - test_qc_exclude_from_workbook
           - name: zip2
             description: '{{ doc("shared_column_prop_address_zipcode_2") }}'
             tests:
@@ -253,6 +256,9 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: zip2 should not be 0000
+                  # Currently too many failures for this signal to be useful
+                  tags:
+                    - test_qc_exclude_from_workbook
 
         tests:
           - unique_combination_of_columns:
@@ -309,3 +315,6 @@ sources:
                   The following columns should have no leading or trailing
                   whitespace: adrpre, adrdir, adrstr, adrsuf, adrsuf2, unitdesc,
                   unitno, cityname, statecode, zip1, zip2
+              tags:
+                # Currently too many failures for this signal to be useful
+                - test_qc_exclude_from_workbook

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -313,4 +313,5 @@ sources:
               config: *unique-conditions
               meta:
                 category: class_mismatch_or_issue
-                description: class should match pardat class
+                description: >
+                  at least one major class (first digit) should match pardat class

--- a/dbt/models/iasworld/schema/iasworld.owndat.yml
+++ b/dbt/models/iasworld/schema/iasworld.owndat.yml
@@ -271,6 +271,9 @@ sources:
                   whitespace: own1, own2, addr1, addr2, addr3, addr4, addr5,
                   adrpre, adrdir, adrstr, adrsuf, unitdesc, unitno, cityname,
                   statecode, zip1, zip2, user27
+              tags:
+                # Currently too many failures for this signal to be useful
+                - test_qc_exclude_from_workbook
           - expression_is_true:
               name: iasworld_owndat_addr1_address_is_well_formed
               expression: |

--- a/dbt/models/iasworld/schema/iasworld.owndat.yml
+++ b/dbt/models/iasworld/schema/iasworld.owndat.yml
@@ -223,6 +223,9 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: zip1 should not be 00000
+                  # Currently too many failures for this signal to be useful
+                  tags:
+                    - test_qc_exclude_from_workbook
           - name: zip2
             description: '{{ doc("shared_column_mail_address_zipcode_2") }}'
             tests:
@@ -233,6 +236,9 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: zip2 should not be 0000
+                  # Currently too many failures for this signal to be useful
+                  tags:
+                    - test_qc_exclude_from_workbook
 
         tests:
           - unique_combination_of_columns:

--- a/dbt/models/qc/schema.yml
+++ b/dbt/models/qc/schema.yml
@@ -634,6 +634,7 @@ models:
     config:
       tags:
         - test_qc_sales
+        - test_qc_exclude_from_workbook
     tests:
       - expression_is_true:
           name: qc_vw_change_in_high_low_value_sales_ratio_high
@@ -769,6 +770,7 @@ models:
     config:
       tags:
         - test_qc_sales
+        - test_qc_exclude_from_workbook
     columns:
       - name: mydec_unmatched
         tests:
@@ -796,6 +798,7 @@ models:
     config:
       tags:
         - test_qc_sales
+        - test_qc_exclude_from_workbook
     tests:
       - expression_is_true:
           name: qc_vw_iasworld_sales_day_of_month_lte_half_observations

--- a/dbt/models/qc/schema.yml
+++ b/dbt/models/qc/schema.yml
@@ -717,6 +717,7 @@ models:
     config:
       tags:
         - test_qc_sales
+        - test_qc_exclude_from_workbook
     columns:
       - name: address
         tests:
@@ -749,6 +750,7 @@ models:
     config:
       tags:
         - test_qc_sales
+        - test_qc_exclude_from_workbook
     columns:
       - name: comparison
         tests:
@@ -797,7 +799,7 @@ models:
     tests:
       - expression_is_true:
           name: qc_vw_iasworld_sales_day_of_month_lte_half_observations
-          expression: sales_by_day > 0.5 * total_sales
+          expression: sales_by_day < 0.5 * total_sales
           select_columns:
             - taxyr
             - day_of_month
@@ -841,3 +843,8 @@ models:
             - document_number
             - price_iasworld
             - price_mydec
+          meta:
+            table_name: sales
+            category: sales_issues
+            description: >
+              price difference between iasworld and mydec should not exceed $1k


### PR DESCRIPTION
This PR makes a number of quality-of-life improvements to the dbt test workbook that gets output by the `.github/scripts/format_dbt_test_failures.py` script. It is the basis of the workbook that was sent over to the rest of the internal stakeholders for review.

Improvements include:

* Adds a test caching system to speed up workbook development
* Writes test results using a write-only openpyxl workbook in order to reduce memory use
* Adds groupings for worksheet columns, with dedicated colors and top-level headers
* Adds support for a new `test_qc_exclude_from_workbook` tag that can be used to exclude certain tests or models
* Adds a few missing descriptions and columns for failing tests

Changes were tested by generating the workbook with the following commands run in the `dbt/` subdirectory:

```
dbt test --select test_qc_* --exclude test_qc_exclude_from_workbook --store-failures
python3 ../.github/scripts/format_dbt_test_failures.py
```

Closes https://github.com/ccao-data/data-architecture/issues/288.