### PR TITLE
Fix duplicates in PIN proximity view

### DIFF
--- a/aws-athena/ctas/proximity-dist_pin_to_pin.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin.sql
@@ -1,11 +1,6 @@
 -- View that finds the 3 nearest neighbor PINs for every PIN for every year
-SELECT * FROM proximity.dist_pin_to_pin_1km
+SELECT * FROM proximity.dist_pin_to_pin_01
 UNION
--- Anti-join is necessary here because the 10km table sometimes contains
--- slightly different distances which don't get de-duped via UNION
-SELECT km10.*
-FROM proximity.dist_pin_to_pin_10km AS km10
-LEFT JOIN proximity.dist_pin_to_pin_1km AS km1
-    ON km10.pin10 = km1.pin10
-    AND km10.year = km1.year
-WHERE km1.pin10 IS NULL
+SELECT * FROM proximity.dist_pin_to_pin_02
+UNION
+SELECT * FROM proximity.dist_pin_to_pin_03

--- a/aws-athena/ctas/proximity-dist_pin_to_pin.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin.sql
@@ -1,4 +1,10 @@
 -- View that finds the 3 nearest neighbor PINs for every PIN for every year
 SELECT * FROM {{ ref('proximity.dist_pin_to_pin_1km') }}
 UNION
-SELECT * FROM {{ ref('proximity.dist_pin_to_pin_10km') }}
+-- Anti-join is necessary here because the 10km table sometimes contains
+-- slightly different distances which don't get de-duped via UNION
+SELECT *
+FROM {{ ref('proximity.dist_pin_to_pin_10km') }} AS km10
+LEFT JOIN {{ ref('proximity.dist_pin_to_pin_1km') }} AS km1
+USING (pin10, year)
+WHERE km1.pin10 IS NULL

--- a/aws-athena/ctas/proximity-dist_pin_to_pin.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin.sql
@@ -1,10 +1,11 @@
 -- View that finds the 3 nearest neighbor PINs for every PIN for every year
-SELECT * FROM {{ ref('proximity.dist_pin_to_pin_1km') }}
+SELECT * FROM proximity.dist_pin_to_pin_1km
 UNION
 -- Anti-join is necessary here because the 10km table sometimes contains
 -- slightly different distances which don't get de-duped via UNION
-SELECT *
-FROM {{ ref('proximity.dist_pin_to_pin_10km') }} AS km10
-LEFT JOIN {{ ref('proximity.dist_pin_to_pin_1km') }} AS km1
-USING (pin10, year)
+SELECT km10.*
+FROM proximity.dist_pin_to_pin_10km AS km10
+LEFT JOIN proximity.dist_pin_to_pin_1km AS km1
+    ON km10.pin10 = km1.pin10
+    AND km10.year = km1.year
 WHERE km1.pin10 IS NULL

--- a/aws-athena/ctas/proximity-dist_pin_to_pin.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin.sql
@@ -1,6 +1,6 @@
 -- View that finds the 3 nearest neighbor PINs for every PIN for every year
-SELECT * FROM proximity.dist_pin_to_pin_01
+SELECT * FROM {{ ref('proximity.dist_pin_to_pin_01') }}
 UNION
-SELECT * FROM proximity.dist_pin_to_pin_02
+SELECT * FROM {{ ref('proximity.dist_pin_to_pin_02') }}
 UNION
-SELECT * FROM proximity.dist_pin_to_pin_03
+SELECT * FROM {{ ref('proximity.dist_pin_to_pin_03') }}

--- a/aws-athena/ctas/proximity-dist_pin_to_pin_01.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin_01.sql
@@ -1,5 +1,5 @@
 -- CTAS that finds the 3 nearest neighbor PINs for every PIN for every year
--- within a 100 meter radius. Step 1 of 3
+-- within a 100 meter radius
 {{
     config(
         materialized='table',

--- a/aws-athena/ctas/proximity-dist_pin_to_pin_01.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin_01.sql
@@ -1,5 +1,5 @@
 -- CTAS that finds the 3 nearest neighbor PINs for every PIN for every year
--- within a 100 meter radius
+-- within a 100 foot radius
 {{
     config(
         materialized='table',

--- a/aws-athena/ctas/proximity-dist_pin_to_pin_01.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin_01.sql
@@ -1,5 +1,5 @@
 -- CTAS that finds the 3 nearest neighbor PINs for every PIN for every year
--- within a 1km radius
+-- within a 100 meter radius. Step 1 of 3
 {{
     config(
         materialized='table',
@@ -15,7 +15,7 @@ FROM (
         nearest_pin_neighbors(
             source('spatial', 'parcel'),
             3,
-            1000
+            100
         )
     }}
 )

--- a/aws-athena/ctas/proximity-dist_pin_to_pin_02.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin_02.sql
@@ -1,6 +1,6 @@
 -- CTAS that finds the 3 nearest neighbor PINs for every PIN for every year
--- within a 10km radius, filtered for PINs that do not have three neighbors
--- within a 1km radius
+-- within a 500 meter radius, filtered for PINs that do not have three
+-- neighbors within a 100 meter radius
 {{
     config(
         materialized='table',
@@ -16,12 +16,12 @@ WITH missing_matches AS (  -- noqa: ST03
         pcl.year,
         pcl.x_3435,
         pcl.y_3435,
-        dist_pin_to_pin_1km.pin10 AS matching_pin10
+        dist_pin_to_pin_01.pin10 AS matching_pin10
     FROM {{ source('spatial', 'parcel') }} AS pcl
-    LEFT JOIN {{ ref('proximity.dist_pin_to_pin_1km') }} AS dist_pin_to_pin_1km
-        ON pcl.pin10 = dist_pin_to_pin_1km.pin10
-        AND pcl.year = dist_pin_to_pin_1km.year
-    WHERE dist_pin_to_pin_1km.pin10 IS NULL
+    LEFT JOIN {{ ref('proximity.dist_pin_to_pin_01') }} AS dist_pin_to_pin_01
+        ON pcl.pin10 = dist_pin_to_pin_01.pin10
+        AND pcl.year = dist_pin_to_pin_01.year
+    WHERE dist_pin_to_pin_01.pin10 IS NULL
 )
 
 SELECT *
@@ -30,7 +30,7 @@ FROM (
         nearest_pin_neighbors(
             'missing_matches',
             3,
-            25000
+            500
         )
     }}
 )

--- a/aws-athena/ctas/proximity-dist_pin_to_pin_02.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin_02.sql
@@ -1,6 +1,6 @@
 -- CTAS that finds the 3 nearest neighbor PINs for every PIN for every year
--- within a 500 meter radius, filtered for PINs that do not have three
--- neighbors within a 100 meter radius
+-- within a 500 foot radius, filtered for PINs that do not have three
+-- neighbors within a 100 foot radius
 {{
     config(
         materialized='table',

--- a/aws-athena/ctas/proximity-dist_pin_to_pin_03.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin_03.sql
@@ -1,6 +1,6 @@
 -- CTAS that finds the 3 nearest neighbor PINs for every PIN for every year
--- within a 10,000 meter radius, filtered for PINs that do not have three
--- neighbors within a 500 meter radius
+-- within a 10,000 foot radius, filtered for PINs that do not have three
+-- neighbors within a 500 foot radius
 {{
     config(
         materialized='table',

--- a/aws-athena/ctas/proximity-dist_pin_to_pin_10km.sql
+++ b/aws-athena/ctas/proximity-dist_pin_to_pin_10km.sql
@@ -30,7 +30,7 @@ FROM (
         nearest_pin_neighbors(
             'missing_matches',
             3,
-            10000
+            25000
         )
     }}
 )

--- a/dbt/macros/nearest_pin_neighbors.sql
+++ b/dbt/macros/nearest_pin_neighbors.sql
@@ -1,7 +1,7 @@
 -- Macro that takes a `source_model` containing PIN geometries and joins it
 -- against spatial.parcel in order to generate the `num_neighbors` nearest
 -- neighbors for each PIN for each year in the data, where a "neighbor" is
--- defined as another PIN that is within `radius_km` of the given PIN.
+-- defined as another PIN that is within `radius_ft` of the given PIN.
 --
 -- The `source_model` must contain four required columns, and is modeled
 -- after spatial.parcel, which is the primary source for this macro:
@@ -10,7 +10,7 @@
 -- * year
 -- * x_3435
 -- * y_3435
-{% macro nearest_pin_neighbors(source_model, num_neighbors, radius_km) %}
+{% macro nearest_pin_neighbors(source_model, num_neighbors, radius_ft) %}
     with
         pin_locations as (
             select pin10, year, x_3435, y_3435, st_point(x_3435, y_3435) as point
@@ -47,7 +47,7 @@
                             inner join
                                 pin_locations as loc
                                 on st_contains(
-                                    st_buffer(sp.point, {{ radius_km }}), loc.point
+                                    st_buffer(sp.point, {{ radius_ft }}), loc.point
                                 )
                             -- This horrifying conditional is designed to trick the
                             -- Athena query planner. For some reason, adding a true

--- a/dbt/macros/nearest_pin_neighbors.sql
+++ b/dbt/macros/nearest_pin_neighbors.sql
@@ -50,13 +50,10 @@
                                     st_buffer(sp.point, {{ radius_km }}), loc.point
                                 )
                             -- This horrifying conditional is designed to trick the
-                            -- Athena query
-                            -- planner. For some reason, adding a true conditional to
-                            -- a query with a
-                            -- spatial join (like the one above) results in terrible
-                            -- performance,
-                            -- while doing a cross join then filtering the rows is
-                            -- much faster
+                            -- Athena query planner. For some reason, adding a true
+                            -- conditional to a query with a spatial join (like the
+                            -- one above) results in terrible performance, while doing
+                            -- a cross join then filtering the rows is much faster
                             where abs(cast(loc.year as int) - cast(sp.year as int)) = 0
                         ) as dists
                 )

--- a/dbt/models/proximity/docs.md
+++ b/dbt/models/proximity/docs.md
@@ -156,11 +156,13 @@ quite far (>1km) from the nearest three PINs, so we use intermediate tables
 to strike a balance between data completeness and computational efficiency.
 
 To compute the full set of distances in `proximity.dist_pin_to_pin`, we first
-generate PIN-to-PIN distances using a 1km buffer and store the results in the
-`proximity.dist_pin_to_pin_1km` table. Then, we query for PINs that did not have
-any matches within 1km and redo the distance query with an expanded 10km buffer,
-storing the results in the `proximity.dist_pin_to_pin_10km` table. Finally, the
-union of the 1km table and the 10km table is aliased to the
+generate PIN-to-PIN distances using a small buffer and store the results in the
+`proximity.dist_pin_to_pin_01` table. Then, we query for PINs that did not have
+any matches within the buffer and redo the distance query with a slightly larger
+buffer, storing the results in the `proximity.dist_pin_to_pin_02` table. The
+process repeats until neighbors are found for all PINs.
+
+Finally, the union of all the intermediate tables is aliased to the
 `proximity.dist_pin_to_pin` view for ease of querying.
 
 **Primary Key**: `pin10`, `year`

--- a/dbt/models/proximity/docs.md
+++ b/dbt/models/proximity/docs.md
@@ -152,7 +152,7 @@ Intermediate table used to generate `proximity.dist_pin_to_pin`.
 The `proximity.dist_pin_to_pin` view is intended to record distances to the
 three closest PINs for all PINs in the county for all years in the data.
 This type of recursive spatial query is expensive, however, and some PINs are
-quite far (>1km) from the nearest three PINs, so we use intermediate tables
+quite far (>1mi) from the nearest three PINs, so we use intermediate tables
 to strike a balance between data completeness and computational efficiency.
 
 To compute the full set of distances in `proximity.dist_pin_to_pin`, we first

--- a/dbt/models/proximity/proximity.dist_pin_to_pin_01.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_pin_01.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_pin_01.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_pin_02.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_pin_02.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_pin_02.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_pin_03.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_pin_03.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/ctas/proximity-dist_pin_to_pin_03.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_pin_10km.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_pin_10km.sql
@@ -1,1 +1,0 @@
-../../../aws-athena/ctas/proximity-dist_pin_to_pin_10km.sql

--- a/dbt/models/proximity/proximity.dist_pin_to_pin_1km.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_pin_1km.sql
@@ -1,1 +1,0 @@
-../../../aws-athena/ctas/proximity-dist_pin_to_pin_1km.sql

--- a/dbt/models/proximity/schema.yml
+++ b/dbt/models/proximity/schema.yml
@@ -49,6 +49,12 @@ models:
 
   - name: proximity.dist_pin_to_pin
     description: '{{ doc("view_dist_pin_to_pin") }}'
+    tests:
+      - unique_combination_of_columns:
+          name: proximity_dist_pin_to_pin_unique_by_10_digit_pin_and_year
+          combination_of_columns:
+            - pin10
+            - year
 
   - name: proximity.dist_pin_to_pin_01
     description: '{{ doc("table_dist_pin_to_pin_intermediate") }}'

--- a/dbt/models/proximity/schema.yml
+++ b/dbt/models/proximity/schema.yml
@@ -50,10 +50,13 @@ models:
   - name: proximity.dist_pin_to_pin
     description: '{{ doc("view_dist_pin_to_pin") }}'
 
-  - name: proximity.dist_pin_to_pin_1km
+  - name: proximity.dist_pin_to_pin_01
     description: '{{ doc("table_dist_pin_to_pin_intermediate") }}'
 
-  - name: proximity.dist_pin_to_pin_10km
+  - name: proximity.dist_pin_to_pin_02
+    description: '{{ doc("table_dist_pin_to_pin_intermediate") }}'
+
+  - name: proximity.dist_pin_to_pin_03
     description: '{{ doc("table_dist_pin_to_pin_intermediate") }}'
 
   - name: proximity.dist_pin_to_railroad


### PR DESCRIPTION
This PR fixes some subtle misbehavior in the PIN-to-PIN distance calculation CTAS queries.

## Issue

`proximity.dist_pin_to_pin` contains occasional duplicate rows, such as PIN10 3120118009. This leads to duplicate rows in downstream views such as `proximity.vw_pin10_proximity` and the model views.

## Cause

I initially thought the cause was somehow due to changing centroids over time. However, it seems that the duplicates are instead the result of some tricky anti-join behavior.

Let's look at 3120118009 as an example. This PIN *exists* in the results of the "first pass" CTAS with a buffer radius of 1km (`proximity.dist_pin_to_pin_1km`). However, it only has rows for 2004-2023 (even though the parcel data goes back to 2000). This is because prior to 2004, no PIN existed that was closer than 1km. Its nearest neighbor (3120118009) was created in 2004.

This becomes a problem due to the anti-join that feeds the "second stage" CTAS, as:

```sql
SELECT
    pcl.pin10,
    pcl.year,
    pcl.x_3435,
    pcl.y_3435,
    dist_pin_to_pin_1km.pin10 AS matching_pin10
FROM spatial.parcel AS pcl
LEFT JOIN proximity.dist_pin_to_pin_1km AS dist_pin_to_pin_1km
    ON pcl.pin10 = dist_pin_to_pin_1km.pin10
    AND pcl.year = dist_pin_to_pin_1km.year
WHERE dist_pin_to_pin_1km.pin10 IS NULL
AND pcl.pin10 = '3120102002'
```

returns 4 rows (2000-2003) because the target PIN doesn't have matches for those years. These 4 rows get fed to the `nearest_pin_neighbors()` macro. That macro searches for nearest neighbors using the **most recent input year's X,Y data** as an origin. In the case of our test PIN, the most recent input year is 2003, so it searches from that year and matches to all parcel years.

HOWEVER, the parcel location of this PIN changes microscopically in 2005, which results in two different sets of distances: one from the 2023 origin in `proximity.dist_pin_to_pin_1km` and one from the 2003 origin in `proximity.dist_pin_to_pin_10km`.

The resulting rows aren't distinct and therefore do not get de-duplicated by the `UNION` in the `dist_pin_to_pin` view. FIN.

## Solution

I did I super quick refactor to simplify the `nearest_pin_neighbors()` macro. I used the query planner hack that I discovered while building `dist_to_nearest_geometry()`. The result is a nearest PIN set that uses the coords for every year, not just the most recent parcel coords. The new solution covers every PIN and runs in about 30 minutes total.

## Row Counts

| year | parcel_count | old_dist_1km_count | old_dist_10km_count | old_dist_total_count | new_dist_100m_count | new_dist_500m_count | new_dist_10km_count | new_dist_total_count |
|------|--------------|--------------------|---------------------|----------------------|---------------------|---------------------|---------------------|----------------------|
| 2023 | 1417110      | 1412213            | 2101                | 1414304              | 876066              | 532390              | 8654                | 1417110              |
| 2022 | 1416347      | 1411441            | 2097                | 1413529              | 875453              | 532212              | 8682                | 1416347              |
| 2021 | 1415410      | 1411079            | 2089                | 1413157              | 874689              | 532056              | 8665                | 1415410              |
| 2020 | 1415664      | 1410810            | 2076                | 1412865              | 875645              | 531354              | 8665                | 1415664              |
| 2019 | 1415193      | 1410353            | 2079                | 1412408              | 875273              | 531253              | 8667                | 1415193              |
| 2018 | 1414731      | 1410106            | 2050                | 1412132              | 875081              | 530988              | 8662                | 1414731              |
| 2017 | 1414896      | 1410312            | 2045                | 1412333              | 875456              | 530780              | 8660                | 1414896              |
| 2016 | 1414449      | 1410026            | 2026                | 1412026              | 875442              | 530346              | 8661                | 1414449              |
| 2015 | 1414155      | 1409565            | 2085                | 1411613              | 873923              | 531576              | 8656                | 1414155              |
| 2014 | 1413788      | 1409117            | 2084                | 1411165              | 873683              | 531464              | 8641                | 1413788              |
| 2013 | 1413759      | 1409044            | 2084                | 1411088              | 873705              | 531406              | 8648                | 1413759              |
| 2012 | 1413732      | 1408914            | 2078                | 1410949              | 873718              | 531380              | 8634                | 1413732              |
| 2011 | 1413698      | 1408981            | 2078                | 1411013              | 874020              | 531034              | 8644                | 1413698              |
| 2010 | 1413699      | 1408982            | 2078                | 1411014              | 874024              | 531031              | 8644                | 1413699              |
| 2009 | 1413740      | 1408992            | 2068                | 1411015              | 874301              | 530801              | 8638                | 1413740              |
| 2008 | 1413206      | 1408946            | 2063                | 1410960              | 874462              | 530101              | 8643                | 1413206              |
| 2007 | 1410605      | 1406484            | 2073                | 1408497              | 873262              | 528673              | 8670                | 1410605              |
| 2006 | 1408738      | 1404744            | 2047                | 1406729              | 872448              | 527585              | 8705                | 1408738              |
| 2005 | 1405047      | 1401268            | 2008                | 1403219              | 870787              | 525524              | 8736                | 1405047              |
| 2004 | 1401506      | 1397916            | 2008                | 1399855              | 869513              | 523200              | 8793                | 1401506              |
| 2003 | 1398092      | 1394607            | 2009                | 1396551              | 868510              | 520731              | 8851                | 1398092              |
| 2002 | 1395387      | 1391982            | 1994                | 1393919              | 867278              | 519238              | 8871                | 1395387              |
| 2001 | 1393174      | 1389845            | 1996                | 1391783              | 866783              | 517524              | 8867                | 1393174              |
| 2000 | 1391620      | 1388355            | 1986                | 1390284              | 866255              | 516449              | 8916                | 1391620              |