### PR TITLE
Add proper dbt source freshness tests

### DIFF
--- a/dbt/models/iasworld/schema/iasworld.aasysjur.yml
+++ b/dbt/models/iasworld/schema/iasworld.aasysjur.yml
@@ -65,6 +65,8 @@ sources:
             description: Flag for Landisc `TAXYR`
           - name: legadd_inc
             description: Increment for new lines in table `LEGADD`
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: maildat_ind
             description: Flag for maildat functionality on `AA11`
           - name: max_taxyr

--- a/dbt/models/iasworld/schema/iasworld.aasysjur.yml
+++ b/dbt/models/iasworld/schema/iasworld.aasysjur.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,9 @@ sources:
     tables:
       - name: aasysjur
         description: '{{ doc("table_aasysjur") }}'
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: aprvalsum_ind

--- a/dbt/models/iasworld/schema/iasworld.aasysjur.yml
+++ b/dbt/models/iasworld/schema/iasworld.aasysjur.yml
@@ -9,8 +9,8 @@ sources:
       - name: aasysjur
         description: '{{ doc("table_aasysjur") }}'
         freshness:
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: aprvalsum_ind

--- a/dbt/models/iasworld/schema/iasworld.addn.yml
+++ b/dbt/models/iasworld/schema/iasworld.addn.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -9,6 +9,10 @@ sources:
     tables:
       - name: addn
         description: '{{ doc("table_addn") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: area

--- a/dbt/models/iasworld/schema/iasworld.addn.yml
+++ b/dbt/models/iasworld/schema/iasworld.addn.yml
@@ -125,6 +125,8 @@ sources:
               - not_null:
                   name: iasworld_addn_lline_not_null
                   config: *unique-conditions
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: lower
             description: Lower level addition code
           - name: mktadj

--- a/dbt/models/iasworld/schema/iasworld.addrindx.yml
+++ b/dbt/models/iasworld/schema/iasworld.addrindx.yml
@@ -10,8 +10,8 @@ sources:
         description: '{{ doc("table_addrindx") }}'
         freshness:
           filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: addrsrc

--- a/dbt/models/iasworld/schema/iasworld.addrindx.yml
+++ b/dbt/models/iasworld/schema/iasworld.addrindx.yml
@@ -74,6 +74,8 @@ sources:
             description: '{{ doc("column_jur") }}'
           - name: lline
             description: '{{ doc("shared_column_lline") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: loc2
             description: '{{ doc("column_loc2") }}'
           - name: parid

--- a/dbt/models/iasworld/schema/iasworld.addrindx.yml
+++ b/dbt/models/iasworld/schema/iasworld.addrindx.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: addrindx
         description: '{{ doc("table_addrindx") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: addrsrc

--- a/dbt/models/iasworld/schema/iasworld.aprval.yml
+++ b/dbt/models/iasworld/schema/iasworld.aprval.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: aprval
         description: '{{ doc("table_aprval") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: adjbldgfact

--- a/dbt/models/iasworld/schema/iasworld.aprval.yml
+++ b/dbt/models/iasworld/schema/iasworld.aprval.yml
@@ -165,6 +165,8 @@ sources:
                     description: landval must be between 0 and 1 billion
           - name: lastupd
             description: Date of last change to a value field
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: mandate
             description: Manual model date
           - name: manmodval

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -47,6 +47,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: luc
             description: '{{ doc("column_luc") }}'
           - name: ovrclass

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld

--- a/dbt/models/iasworld/schema/iasworld.asmt_hist.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_hist.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: asmt_hist
         description: '{{ doc("table_asmt_hist") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: class

--- a/dbt/models/iasworld/schema/iasworld.asmt_hist.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_hist.yml
@@ -26,6 +26,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: luc
             description: '{{ doc("column_luc") }}'
           - name: ovrclass

--- a/dbt/models/iasworld/schema/iasworld.cname.yml
+++ b/dbt/models/iasworld/schema/iasworld.cname.yml
@@ -83,6 +83,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: name1
             description: Name 1
           - name: name1_companyname

--- a/dbt/models/iasworld/schema/iasworld.cname.yml
+++ b/dbt/models/iasworld/schema/iasworld.cname.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,9 @@ sources:
     tables:
       - name: cname
         description: '{{ doc("table_cname") }}'
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: addr1

--- a/dbt/models/iasworld/schema/iasworld.cname.yml
+++ b/dbt/models/iasworld/schema/iasworld.cname.yml
@@ -9,8 +9,8 @@ sources:
       - name: cname
         description: '{{ doc("table_cname") }}'
         freshness:
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: addr1

--- a/dbt/models/iasworld/schema/iasworld.comdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.comdat.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -9,6 +9,10 @@ sources:
     tables:
       - name: comdat
         description: '{{ doc("table_comdat") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: adjfact

--- a/dbt/models/iasworld/schema/iasworld.comdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.comdat.yml
@@ -139,6 +139,8 @@ sources:
             description: Improvement name
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: mktadj
             description: '{{ doc("column_mktadj") }}'
           - name: mktrsn

--- a/dbt/models/iasworld/schema/iasworld.comnt.yml
+++ b/dbt/models/iasworld/schema/iasworld.comnt.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,9 @@ sources:
     tables:
       - name: comnt
         description: '{{ doc("table_comnt") }}'
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: caseno

--- a/dbt/models/iasworld/schema/iasworld.comnt.yml
+++ b/dbt/models/iasworld/schema/iasworld.comnt.yml
@@ -9,8 +9,8 @@ sources:
       - name: comnt
         description: '{{ doc("table_comnt") }}'
         freshness:
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: caseno

--- a/dbt/models/iasworld/schema/iasworld.comnt.yml
+++ b/dbt/models/iasworld/schema/iasworld.comnt.yml
@@ -29,6 +29,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: parid
             description: '{{ doc("shared_column_pin") }}'
           - name: status

--- a/dbt/models/iasworld/schema/iasworld.cvleg.yml
+++ b/dbt/models/iasworld/schema/iasworld.cvleg.yml
@@ -82,6 +82,8 @@ sources:
             description: Legal description line 3
           - name: legdesc
             description: Unlimited legal description
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: loc2
             description: '{{ doc("column_loc2") }}'
           - name: lot

--- a/dbt/models/iasworld/schema/iasworld.cvleg.yml
+++ b/dbt/models/iasworld/schema/iasworld.cvleg.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: cvleg
         description: '{{ doc("table_cvleg") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: acres

--- a/dbt/models/iasworld/schema/iasworld.cvown.yml
+++ b/dbt/models/iasworld/schema/iasworld.cvown.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: cvown
         description: '{{ doc("table_cvown") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: addr1

--- a/dbt/models/iasworld/schema/iasworld.cvown.yml
+++ b/dbt/models/iasworld/schema/iasworld.cvown.yml
@@ -10,8 +10,8 @@ sources:
         description: '{{ doc("table_cvown") }}'
         freshness:
           filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: addr1

--- a/dbt/models/iasworld/schema/iasworld.cvown.yml
+++ b/dbt/models/iasworld/schema/iasworld.cvown.yml
@@ -88,6 +88,8 @@ sources:
             description: '{{ doc("column_jur") }}'
           - name: link
             description: Owner link number
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: marstat
             description: '{{ doc("column_marstat") }}'
           - name: notecd

--- a/dbt/models/iasworld/schema/iasworld.cvown.yml
+++ b/dbt/models/iasworld/schema/iasworld.cvown.yml
@@ -9,7 +9,6 @@ sources:
       - name: cvown
         description: '{{ doc("table_cvown") }}'
         freshness:
-          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
           warn_after: {count: 192, period: hour} # 8 days
           error_after: {count: 360, period: hour} # 15 days
 

--- a/dbt/models/iasworld/schema/iasworld.cvtran.yml
+++ b/dbt/models/iasworld/schema/iasworld.cvtran.yml
@@ -72,6 +72,8 @@ sources:
             description: '{{ doc("column_jur") }}'
           - name: linkno
             description: Used to tie multi-parcel sales together (either instrument number, or transfer number, or book/page)
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: lots
             description: Total lots involved in this conveyance
           - name: mip

--- a/dbt/models/iasworld/schema/iasworld.cvtran.yml
+++ b/dbt/models/iasworld/schema/iasworld.cvtran.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: cvtran
         description: '{{ doc("table_cvtran") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: actconsid

--- a/dbt/models/iasworld/schema/iasworld.cvtran.yml
+++ b/dbt/models/iasworld/schema/iasworld.cvtran.yml
@@ -10,8 +10,8 @@ sources:
         description: '{{ doc("table_cvtran") }}'
         freshness:
           filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: actconsid

--- a/dbt/models/iasworld/schema/iasworld.dedit.yml
+++ b/dbt/models/iasworld/schema/iasworld.dedit.yml
@@ -19,6 +19,8 @@ sources:
             description: Column name of edit field 2
           - name: iasw_id
             description: '{{ doc("column_iasw_id") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: longdesc
             description: Long description
           - name: msg

--- a/dbt/models/iasworld/schema/iasworld.dedit.yml
+++ b/dbt/models/iasworld/schema/iasworld.dedit.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,9 @@ sources:
     tables:
       - name: dedit
         description: '{{ doc("table_dedit") }}'
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: fld1

--- a/dbt/models/iasworld/schema/iasworld.dedit.yml
+++ b/dbt/models/iasworld/schema/iasworld.dedit.yml
@@ -9,8 +9,8 @@ sources:
       - name: dedit
         description: '{{ doc("table_dedit") }}'
         freshness:
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: fld1

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -9,6 +9,10 @@ sources:
     tables:
       - name: dweldat
         description: '{{ doc("table_dweldat") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: ac

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -412,6 +412,8 @@ sources:
             description: Kitchen percentage
           - name: kityr
             description: Kitchen year
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: locmult
             description: Local multiplier
           - name: lumpcamod

--- a/dbt/models/iasworld/schema/iasworld.enter.yml
+++ b/dbt/models/iasworld/schema/iasworld.enter.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,9 @@ sources:
     tables:
       - name: enter
         description: '{{ doc("table_enter") }}'
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: cur

--- a/dbt/models/iasworld/schema/iasworld.enter.yml
+++ b/dbt/models/iasworld/schema/iasworld.enter.yml
@@ -29,6 +29,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: parid
             description: '{{ doc("shared_column_pin") }}'
           - name: seq

--- a/dbt/models/iasworld/schema/iasworld.exadmn.yml
+++ b/dbt/models/iasworld/schema/iasworld.exadmn.yml
@@ -74,6 +74,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: ownnum
             description: '{{ doc("column_ownnum") }}'
           - name: ownnum10

--- a/dbt/models/iasworld/schema/iasworld.exadmn.yml
+++ b/dbt/models/iasworld/schema/iasworld.exadmn.yml
@@ -10,8 +10,8 @@ sources:
         description: '{{ doc("table_exadmn") }}'
         freshness:
           filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: appname1

--- a/dbt/models/iasworld/schema/iasworld.exadmn.yml
+++ b/dbt/models/iasworld/schema/iasworld.exadmn.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: exadmn
         description: '{{ doc("table_exadmn") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: appname1

--- a/dbt/models/iasworld/schema/iasworld.exapp.yml
+++ b/dbt/models/iasworld/schema/iasworld.exapp.yml
@@ -60,6 +60,8 @@ sources:
             description: '{{ doc("column_jur") }}'
           - name: lline
             description: '{{ doc("shared_column_lline") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: marstat
             description: '{{ doc("column_marstat") }}'
           - name: ovrclass

--- a/dbt/models/iasworld/schema/iasworld.exapp.yml
+++ b/dbt/models/iasworld/schema/iasworld.exapp.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: exapp
         description: '{{ doc("table_exapp") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: apaddr1

--- a/dbt/models/iasworld/schema/iasworld.exapp.yml
+++ b/dbt/models/iasworld/schema/iasworld.exapp.yml
@@ -10,8 +10,8 @@ sources:
         description: '{{ doc("table_exapp") }}'
         freshness:
           filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: apaddr1

--- a/dbt/models/iasworld/schema/iasworld.excode.yml
+++ b/dbt/models/iasworld/schema/iasworld.excode.yml
@@ -10,8 +10,8 @@ sources:
         description: '{{ doc("table_excode") }}'
         freshness:
           filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: altsched

--- a/dbt/models/iasworld/schema/iasworld.excode.yml
+++ b/dbt/models/iasworld/schema/iasworld.excode.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: excode
         description: '{{ doc("table_excode") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: altsched

--- a/dbt/models/iasworld/schema/iasworld.excode.yml
+++ b/dbt/models/iasworld/schema/iasworld.excode.yml
@@ -50,6 +50,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: luc
             description: '{{ doc("column_luc") }}'
           - name: maxamt

--- a/dbt/models/iasworld/schema/iasworld.exdet.yml
+++ b/dbt/models/iasworld/schema/iasworld.exdet.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: exdet
         description: '{{ doc("table_exdet") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: assetid

--- a/dbt/models/iasworld/schema/iasworld.exdet.yml
+++ b/dbt/models/iasworld/schema/iasworld.exdet.yml
@@ -10,8 +10,8 @@ sources:
         description: '{{ doc("table_exdet") }}'
         freshness:
           filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: assetid

--- a/dbt/models/iasworld/schema/iasworld.exdet.yml
+++ b/dbt/models/iasworld/schema/iasworld.exdet.yml
@@ -60,6 +60,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: lineno
             description: Exemption line line number for this `parid`/`excode`
           - name: lline

--- a/dbt/models/iasworld/schema/iasworld.htagnt.yml
+++ b/dbt/models/iasworld/schema/iasworld.htagnt.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,9 @@ sources:
     tables:
       - name: htagnt
         description: '{{ doc("table_htagnt") }}'
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: addr1

--- a/dbt/models/iasworld/schema/iasworld.htagnt.yml
+++ b/dbt/models/iasworld/schema/iasworld.htagnt.yml
@@ -65,6 +65,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: name1
             description: Name line 1
           - name: name1_companyname

--- a/dbt/models/iasworld/schema/iasworld.htagnt.yml
+++ b/dbt/models/iasworld/schema/iasworld.htagnt.yml
@@ -9,8 +9,8 @@ sources:
       - name: htagnt
         description: '{{ doc("table_htagnt") }}'
         freshness:
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: addr1

--- a/dbt/models/iasworld/schema/iasworld.htdates.yml
+++ b/dbt/models/iasworld/schema/iasworld.htdates.yml
@@ -25,6 +25,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: notes
             description: Notes
           - name: parid

--- a/dbt/models/iasworld/schema/iasworld.htdates.yml
+++ b/dbt/models/iasworld/schema/iasworld.htdates.yml
@@ -9,8 +9,8 @@ sources:
       - name: htdates
         description: '{{ doc("table_htdates") }}'
         freshness:
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: caseno

--- a/dbt/models/iasworld/schema/iasworld.htdates.yml
+++ b/dbt/models/iasworld/schema/iasworld.htdates.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,9 @@ sources:
     tables:
       - name: htdates
         description: '{{ doc("table_htdates") }}'
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: caseno

--- a/dbt/models/iasworld/schema/iasworld.htpar.yml
+++ b/dbt/models/iasworld/schema/iasworld.htpar.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld

--- a/dbt/models/iasworld/schema/iasworld.htpar.yml
+++ b/dbt/models/iasworld/schema/iasworld.htpar.yml
@@ -115,6 +115,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: loc
             description: Location code
           - name: name1

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -142,6 +142,8 @@ sources:
                     description: lline should be sequential
           - name: lmod
             description: Land location model number
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: locfact
             description: Location factor
           - name: ltype

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -9,6 +9,10 @@ sources:
     tables:
       - name: land
         description: '{{ doc("table_land") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: acres

--- a/dbt/models/iasworld/schema/iasworld.legdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.legdat.yml
@@ -98,6 +98,8 @@ sources:
             description: Legal description line 3
           - name: legdesc
             description: Unlimited legal description
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: loc2
             description: '{{ doc("column_loc2") }}'
           - name: lot

--- a/dbt/models/iasworld/schema/iasworld.legdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.legdat.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: legdat
         description: '{{ doc("table_legdat") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: acres

--- a/dbt/models/iasworld/schema/iasworld.lpmod.yml
+++ b/dbt/models/iasworld/schema/iasworld.lpmod.yml
@@ -9,8 +9,8 @@ sources:
       - name: lpmod
         description: '{{ doc("table_lpmod") }}'
         freshness:
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: acradjflg

--- a/dbt/models/iasworld/schema/iasworld.lpmod.yml
+++ b/dbt/models/iasworld/schema/iasworld.lpmod.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,9 @@ sources:
     tables:
       - name: lpmod
         description: '{{ doc("table_lpmod") }}'
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: acradjflg

--- a/dbt/models/iasworld/schema/iasworld.lpmod.yml
+++ b/dbt/models/iasworld/schema/iasworld.lpmod.yml
@@ -35,6 +35,8 @@ sources:
             description: Land code
           - name: lmod
             description: Land location model number
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: ltype
             description: Land type (F, S, A, G, U)
           - name: modtype

--- a/dbt/models/iasworld/schema/iasworld.lpnbhd.yml
+++ b/dbt/models/iasworld/schema/iasworld.lpnbhd.yml
@@ -9,8 +9,8 @@ sources:
       - name: lpnbhd
         description: '{{ doc("table_lpnbhd") }}'
         freshness:
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: acmod

--- a/dbt/models/iasworld/schema/iasworld.lpnbhd.yml
+++ b/dbt/models/iasworld/schema/iasworld.lpnbhd.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,9 @@ sources:
     tables:
       - name: lpnbhd
         description: '{{ doc("table_lpnbhd") }}'
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: acmod

--- a/dbt/models/iasworld/schema/iasworld.lpnbhd.yml
+++ b/dbt/models/iasworld/schema/iasworld.lpnbhd.yml
@@ -59,6 +59,8 @@ sources:
             description: Percentage of Land allocation
           - name: lcodemod
             description: Land code model
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: lotmod
             description: Type F (Front Ft)- land model assignment
           - name: lotpct

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -9,6 +9,10 @@ sources:
     tables:
       - name: oby
         description: '{{ doc("table_oby") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: adjfact

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -147,6 +147,8 @@ sources:
                   min_value: 1
                   max_value: 100
                   config: *unique-conditions
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: locmult
             description: Local multiplier
           - name: lumpadj

--- a/dbt/models/iasworld/schema/iasworld.owndat.yml
+++ b/dbt/models/iasworld/schema/iasworld.owndat.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: owndat
         description: '{{ doc("table_owndat") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: addr1

--- a/dbt/models/iasworld/schema/iasworld.owndat.yml
+++ b/dbt/models/iasworld/schema/iasworld.owndat.yml
@@ -101,6 +101,8 @@ sources:
             description: '{{ doc("column_jur") }}'
           - name: link
             description: Owner link number
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: marstat
             description: '{{ doc("column_marstat") }}'
           - name: notecd

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -120,6 +120,8 @@ sources:
             description: Landisc frame number
           - name: livunit
             description: Number of living units
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: loc2
             description: '{{ doc("column_loc2") }}'
           - name: location

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: pardat
         description: '{{ doc("table_pardat") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: acres

--- a/dbt/models/iasworld/schema/iasworld.permit.yml
+++ b/dbt/models/iasworld/schema/iasworld.permit.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -9,9 +9,9 @@ sources:
       - name: permit
         description: '{{ doc("table_permit") }}'
         freshness:
-          filter: date_format(date_parse(permdt, '%Y-%m-%d %H:%i:%s.0'), '%Y') >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 48, period: hour}
-          error_after: {count: 72, period: hour}
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: addrvalid

--- a/dbt/models/iasworld/schema/iasworld.permit.yml
+++ b/dbt/models/iasworld/schema/iasworld.permit.yml
@@ -9,7 +9,6 @@ sources:
       - name: permit
         description: '{{ doc("table_permit") }}'
         freshness:
-          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
           warn_after: {count: 24, period: hour}
           error_after: {count: 48, period: hour}
 

--- a/dbt/models/iasworld/schema/iasworld.permit.yml
+++ b/dbt/models/iasworld/schema/iasworld.permit.yml
@@ -48,6 +48,8 @@ sources:
             description: ID field 2
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: longdesc
             description: Long description
           - name: notes

--- a/dbt/models/iasworld/schema/iasworld.rcoby.yml
+++ b/dbt/models/iasworld/schema/iasworld.rcoby.yml
@@ -9,8 +9,8 @@ sources:
       - name: rcoby
         description: '{{ doc("table_rcoby") }}'
         freshness:
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: altbasedate

--- a/dbt/models/iasworld/schema/iasworld.rcoby.yml
+++ b/dbt/models/iasworld/schema/iasworld.rcoby.yml
@@ -55,6 +55,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: incuse
             description: Income Type Use
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: locmultcd
             description: Local Multiplier Code
           - name: maxdimr

--- a/dbt/models/iasworld/schema/iasworld.rcoby.yml
+++ b/dbt/models/iasworld/schema/iasworld.rcoby.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,9 @@ sources:
     tables:
       - name: rcoby
         description: '{{ doc("table_rcoby") }}'
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: altbasedate

--- a/dbt/models/iasworld/schema/iasworld.sales.yml
+++ b/dbt/models/iasworld/schema/iasworld.sales.yml
@@ -80,6 +80,8 @@ sources:
             description: '{{ doc("column_jur") }}'
           - name: linkno
             description: Used to tie multi-parcel sales together (either instrument number, or transfer number, or book/page)
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: mktvalid
             description: Market validity code
           - name: newseq

--- a/dbt/models/iasworld/schema/iasworld.sales.yml
+++ b/dbt/models/iasworld/schema/iasworld.sales.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,9 @@ sources:
     tables:
       - name: sales
         description: '{{ doc("table_sales") }}'
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: adjamt

--- a/dbt/models/iasworld/schema/iasworld.splcom.yml
+++ b/dbt/models/iasworld/schema/iasworld.splcom.yml
@@ -10,8 +10,8 @@ sources:
         description: '{{ doc("table_splcom") }}'
         freshness:
           filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: alt_splitnum

--- a/dbt/models/iasworld/schema/iasworld.splcom.yml
+++ b/dbt/models/iasworld/schema/iasworld.splcom.yml
@@ -24,6 +24,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: newacr
             description: New acreage (deed)
           - name: newalt_id

--- a/dbt/models/iasworld/schema/iasworld.splcom.yml
+++ b/dbt/models/iasworld/schema/iasworld.splcom.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: splcom
         description: '{{ doc("table_splcom") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: alt_splitnum

--- a/dbt/models/iasworld/schema/iasworld.valclass.yml
+++ b/dbt/models/iasworld/schema/iasworld.valclass.yml
@@ -10,8 +10,8 @@ sources:
         description: '{{ doc("table_valclass") }}'
         freshness:
           filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
-          warn_after: {count: 24, period: hour}
-          error_after: {count: 48, period: hour}
+          warn_after: {count: 192, period: hour} # 8 days
+          error_after: {count: 360, period: hour} # 15 days
 
         columns:
           - name: assess_pct

--- a/dbt/models/iasworld/schema/iasworld.valclass.yml
+++ b/dbt/models/iasworld/schema/iasworld.valclass.yml
@@ -22,6 +22,8 @@ sources:
             description: '{{ doc("column_iasw_id") }}'
           - name: jur
             description: '{{ doc("column_jur") }}'
+          - name: loaded_at
+            description: '{{ doc("shared_column_loaded_at") }}'
           - name: luc
             description: '{{ doc("column_luc") }}'
           - name: ratio1

--- a/dbt/models/iasworld/schema/iasworld.valclass.yml
+++ b/dbt/models/iasworld/schema/iasworld.valclass.yml
@@ -1,6 +1,6 @@
 sources:
   - name: iasworld
-    loaded_at_field: date_parse(wen, '%Y-%m-%d %H:%i:%s.0')
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
     tags:
       - load_auto
       - test_qc_iasworld
@@ -8,6 +8,10 @@ sources:
     tables:
       - name: valclass
         description: '{{ doc("table_valclass") }}'
+        freshness:
+          filter: taxyr >= date_format(current_date - interval '1' year, '%Y')
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
 
         columns:
           - name: assess_pct

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -912,6 +912,14 @@ will be paid in calendar year 2024
 
 # iasWorld
 
+## loaded_at
+
+{% docs shared_column_loaded_at %}
+Timestamp (UTC) of when a record was pulled from the main iasWorld database.
+
+Created by sqoop using the Oracle DB system time
+{% enddocs %}
+
 ## seq
 
 {% docs shared_column_seq %}


### PR DESCRIPTION
This PR updates our iasWorld [dbt source freshness tests](https://docs.getdbt.com/docs/build/sources#snapshotting-source-data-freshness) to use an actual `loaded_at` column (added by https://github.com/ccao-data/service-sqoop-iasworld/pull/10), rather than the date of last change for a record.

It adds freshness checks for _all_ iasWorld tables pulled by sqoop. Since not all tables are updated daily, some checks expect weekly updates.

I can't test this properly until sqoop does a full DB refresh, which will happen tomorrow (2/10), but code review in the meantime would be appreciated!