### PR TITLE
Move class exclusion to `filled` pull

### DIFF
--- a/aws-athena/views/default-vw_pin_condo_char.sql
+++ b/aws-athena/views/default-vw_pin_condo_char.sql
@@ -171,8 +171,7 @@ chars AS (
         nonlivable detection, but upon human review have been deemed livable. */
     LEFT JOIN {{ source('ccao', 'pin_nonlivable') }} AS nonlivable
         ON par.parid = nonlivable.pin
-    WHERE par.class IN ('299', '2-99', '399')
-        AND par.cur = 'Y'
+    WHERE par.cur = 'Y'
         AND par.deactivat IS NULL
         AND (oby.row_no = 1 OR com.row_no = 1)
 ),
@@ -213,6 +212,7 @@ filled AS (
             OVER (PARTITION BY pin10, year)
             AS building_pins
     FROM chars
+    WHERE class IN ('299', '2-99', '399')
 )
 
 SELECT DISTINCT


### PR DESCRIPTION
The `bldg_is_mixed_use` indicator in `default.vw_pin_condo_char` isn't currently detecting _any_ mixed use buildings. This is due to its design and a conditional in the `chars` section of the `default.vw_pin_condo_char` sql script:

```
COALESCE(SUM(
            CASE
                WHEN
                    par.class NOT IN ('299', '2-99', '399')
                    THEN 1
                ELSE 0
            END
        )
            OVER (
                PARTITION BY SUBSTR(par.parid, 1, 10), par.taxyr
            )
        > 0, FALSE)
            AS bldg_is_mixed_use
```
and `WHERE class IN ('299', '2-99', '399')`

We need to allow non-299/399 class parcels into this part of the pull in order to be able to detect mixed-use buildings. We can filter them out later. I've included output below to show that these buildings are now being detected and that the new syntax has not altered parcel counts or other features such as CDU.