### PR TITLE
 Update land sf calculations with new split class influence reason

### DIFF
--- a/aws-athena/views/default-vw_pin_land.sql
+++ b/aws-athena/views/default-vw_pin_land.sql
@@ -17,10 +17,11 @@ WITH total_influ AS (
         SUM(CASE WHEN land.influ IS NULL THEN 0 ELSE 1 END)
             OVER (PARTITION BY land.parid, land.taxyr)
             AS non_null_influ,
+        COALESCE(land.infl1 = '35', FALSE) AS split_class,
         MAX(land.sf) OVER (PARTITION BY land.parid, land.taxyr) AS max_sf,
         MIN(land.sf) OVER (PARTITION BY land.parid, land.taxyr) AS min_sf,
         -- When the first landline for a pin is deactived we should take the
-        -- minimum value of lline as the top line. 
+        -- minimum value of lline as the top line.
         MIN(land.lline) OVER (PARTITION BY land.parid, land.taxyr) AS top_line
     FROM {{ source('iasworld', 'land') }} AS land
     WHERE
@@ -37,8 +38,11 @@ SELECT
         -- and all sf values are the same, we choose the topline land sf,
         -- otherwise we sum land sf.
         WHEN
-            total_influ.non_null_influ > 1
-            AND total_influ.max_sf = total_influ.min_sf
+            (
+                total_influ.non_null_influ > 1
+                AND total_influ.max_sf = total_influ.min_sf
+            )
+            OR total_influ.split_class
             THEN total_influ.sf_top
         ELSE total_influ.sf_sum
     END AS sf


### PR DESCRIPTION
> One of the updates in iasWorld that was implemented between 2023 and 2024 was the addition of a new field to handle prorations of land values. This was specifically needed for Condos, as their % owner interest amounts often have very specific values that go well to the right of the decimal. The closest thing that was in place to handle land prorations was the influence factor, but that only can divide to whole percentages. So for Condos, they were only using overrides for entering the values previously given this issue, but for split class properties where the prorations are typically in whole percentages, they used the influence factors. In these instances, the SF for the land for the parcel repeats on the various lines, as it's just using the factors to divide the values. With the new proration field, we have gone through the process of moving those influence factor values to the new proration fields. 

> So, in essence nothing actually changed as we just moved these values that were providing the split of the land into the various classes. But, there are a number of instances where we have left influence factor values and not moved them to the proration field, as those were using it for a different reason where it was just reducing the value for reasons not related to a split class proration. For the instances where we are using the proration field for these split classes, we have also entered an Influence Reason to indicate "Split Class Parcel". As far as it impacts you all, you can know that when the Reason is indicating Split Class Parcel, that you only need to count the land SF once for that PIN.