### PR TITLE
 Correctly join calculated number of parcels per sale to sales view

### DIFF
--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -130,7 +130,8 @@ unique_sales AS (
             ) AS sale_filter_deed_type
         FROM {{ source('iasworld', 'sales') }} AS sales
         LEFT JOIN calculated
-            ON sales.instruno = calculated.instruno
+            ON NULLIF(REPLACE(sales.instruno, 'D', ''), '')
+            = calculated.instruno
         LEFT JOIN
             town_class AS tc
             ON sales.parid = tc.parid

--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -77,6 +77,9 @@ models:
       - row_count:
           name: default_vw_pin_sale_row_count
           above: 2477674 # as of 2023-11-22
+      - not_null:
+          name: default_vw_pin_sale_num_parcels_sale_not_null
+          column_name: num_parcels_sale
       # TODO: Sale is validated (after sales validation has been added to
       # iasworld)
       # TODO: Validation is catching obvious outliers


### PR DESCRIPTION
Joining calculated number of sales currently uses an adjusted document number against an un-adjusted document number.