### PR TITLE
Address `NULL` values for `iasworld.sales.nopar` in construction of `default.vw_pin_sale.is_multisale`

### DIFF
--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -60,7 +60,7 @@ unique_sales AS (
             NULLIF(sales.instrtyp, '') AS deed_type,
             -- "nopar" is number of parcels sold
             NOT COALESCE(
-                sales.nopar <= 1 AND calculated.nopar_calculated = 1,
+                (sales.nopar <= 1 OR sales.nopar IS NULL) AND calculated.nopar_calculated = 1,
                 FALSE
             ) AS is_multisale,
             CASE

--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -60,7 +60,8 @@ unique_sales AS (
             NULLIF(sales.instrtyp, '') AS deed_type,
             -- "nopar" is number of parcels sold
             NOT COALESCE(
-                (sales.nopar <= 1 OR sales.nopar IS NULL) AND calculated.nopar_calculated = 1,
+                (sales.nopar <= 1 OR sales.nopar IS NULL)
+                AND calculated.nopar_calculated = 1,
                 FALSE
             ) AS is_multisale,
             CASE

--- a/aws-athena/views/default-vw_pin_sale.sql
+++ b/aws-athena/views/default-vw_pin_sale.sql
@@ -59,9 +59,8 @@ unique_sales AS (
             NULLIF(REPLACE(sales.instruno, 'D', ''), '') AS doc_no,
             NULLIF(sales.instrtyp, '') AS deed_type,
             -- "nopar" is number of parcels sold
-            NOT COALESCE(
-                (sales.nopar <= 1 OR sales.nopar IS NULL)
-                AND calculated.nopar_calculated = 1,
+            COALESCE(
+                sales.nopar > 1 OR calculated.nopar_calculated > 1,
                 FALSE
             ) AS is_multisale,
             CASE

--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -82,7 +82,7 @@ models:
           column_name: num_parcels_sale
       - expression_is_true:
           name: default_vw_pin_sale_is_multisale_num_parcels_sale_align
-          expression: (num_parcels_sale > 1 and is_multisale) OR (num_parcels_sale = 1 and NOT is_multisale)
+          expression: (num_parcels_sale > 1 AND is_multisale) OR (num_parcels_sale = 1 AND NOT is_multisale)
           select_columns:
             - num_parcels_sale
             - is_multisale

--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -80,6 +80,12 @@ models:
       - not_null:
           name: default_vw_pin_sale_num_parcels_sale_not_null
           column_name: num_parcels_sale
+      - expression_is_true:
+          name: default_vw_pin_sale_is_multisale_num_parcels_sale_align
+          expression: (num_parcels_sale > 1 and is_multisale) OR (num_parcels_sale = 1 and NOT is_multisale)
+          select_columns:
+            - num_parcels_sale
+            - is_multisale
       # TODO: Sale is validated (after sales validation has been added to
       # iasworld)
       # TODO: Validation is catching obvious outliers


### PR DESCRIPTION
There are 8 rows in `iasworld.sales` with `NULL` values for nopar that don't get properly handled during the construction of `is_multisale` in `default.vw_pin_sale`.