### PR TITLE
Refactor `additional_select_columns` dbt test params to support more configurable naming and aggregation

### DIFF
--- a/aws-athena/views/qc-vw_iasworld_sales_price_diff_sale_mydec.sql
+++ b/aws-athena/views/qc-vw_iasworld_sales_price_diff_sale_mydec.sql
@@ -3,6 +3,7 @@
 SELECT
     REGEXP_REPLACE(iasworld.instruno, '[^0-9]', '') AS document_number,
     SUBSTR(iasworld.saledt, 1, 4) AS taxyr,
+    iasworld.parid,
     iasworld.price AS price_iasworld,
     SUBSTR(mydec.year_of_sale, 1, 4) AS year_mydec,
     mydec.line_11_full_consideration AS price_mydec

--- a/dbt/macros/format_additional_select_columns.sql
+++ b/dbt/macros/format_additional_select_columns.sql
@@ -27,7 +27,6 @@
     additional_select_columns, raise_error_func
 ) %}
     {%- for col in additional_select_columns -%}
-        {%- set trailing_comma = "" if loop.last else "," %}
         {%- if col is mapping -%}
             {%- if "column" not in col -%}
                 {{-
@@ -41,15 +40,14 @@
                 {%- if col.agg_func -%}
                     {%- set alias = col.alias if col.alias else col.column -%}
                     {{- col.agg_func }} ({{ col.column }}) as {{ alias }}
-                    {{- trailing_comma }}
                 {%- else -%}
-                    {%- if col.alias -%}
-                        {{- col.column }} as {{ col.alias }}{{ trailing_comma }}
-                    {%- else -%} {{- col.column }}{{ trailing_comma }}
+                    {%- if col.alias -%} {{- col.column }} as {{ col.alias }}
+                    {%- else -%} {{- col.column }}
                     {%- endif -%}
                 {%- endif -%}
             {%- endif -%}
-        {%- else -%} {{ col }}{{ trailing_comma }}
+        {%- else -%} {{ col }}
         {%- endif -%}
+        {{- "" if loop.last else "," }}
     {%- endfor -%}
 {% endmacro %}

--- a/dbt/macros/format_additional_select_columns.sql
+++ b/dbt/macros/format_additional_select_columns.sql
@@ -45,8 +45,7 @@
                 {%- else -%}
                     {%- if col.alias -%}
                         {{- col.column }} as {{ col.alias }}{{ trailing_comma }}
-                    {%- else -%}
-                        {{- col.column }}{{ trailing_comma }}
+                    {%- else -%} {{- col.column }}{{ trailing_comma }}
                     {%- endif -%}
                 {%- endif -%}
             {%- endif -%}

--- a/dbt/macros/format_additional_select_columns.sql
+++ b/dbt/macros/format_additional_select_columns.sql
@@ -8,7 +8,7 @@
 --
 -- * `column` (required string): The name of the column to select
 -- * `alias` (optional string): The alias to use for the column
--- (defaults to `column`)
+-- (defaults to `column` or `{agg_func}_{column}`)
 -- * `agg_func` (optional string): An aggregation function to use to
 -- select the column (defaults to no aggregation)
 {% macro format_additional_select_columns(additional_select_columns) %}
@@ -38,7 +38,11 @@
                 -}}
             {%- else -%}
                 {%- if col.agg_func -%}
-                    {%- set alias = col.alias if col.alias else col.column -%}
+                    {%- set alias = (
+                        col.alias
+                        if col.alias
+                        else col.agg_func ~ "_" ~ col.column
+                    ) -%}
                     {{- col.agg_func }} ({{ col.column }}) as {{ alias }}
                 {%- else -%}
                     {%- if col.alias -%} {{- col.column }} as {{ col.alias }}

--- a/dbt/macros/format_additional_select_columns.sql
+++ b/dbt/macros/format_additional_select_columns.sql
@@ -11,9 +11,6 @@
 -- (defaults to `column`)
 -- * `agg_func` (optional string): An aggregation function to use to
 -- select the column (defaults to no aggregation)
---
--- If you call this macro, make sure not to follow it with a comma, since the
--- macro already appends a comma to the end of any lines that it formats.
 {% macro format_additional_select_columns(additional_select_columns) %}
     {{
         return(
@@ -28,6 +25,7 @@
     additional_select_columns, raise_error_func
 ) %}
     {%- for col in additional_select_columns -%}
+        {%- set trailing_comma = "" if loop.last else "," %}
         {%- if col is mapping -%}
             {%- if "column" not in col -%}
                 {{-
@@ -40,11 +38,12 @@
             {%- else -%}
                 {%- set label = col.label if col.label else col.column -%}
                 {%- if col.agg_func -%}
-                    {{- col.agg_func }} ({{ col.column }}) as {{ label }},
-                {%- else -%} {{- col.column }} as {{ label }},
+                    {{- col.agg_func }} ({{ col.column }}) as {{ label }}
+                    {{- trailing_comma }}
+                {%- else -%} {{- col.column }} as {{ label }}{{ trailing_comma }}
                 {%- endif -%}
             {%- endif -%}
-        {%- else -%} {{ col }} as {{ col }},
+        {%- else -%} {{ col }} as {{ col }}{{ trailing_comma }}
         {%- endif -%}
     {%- endfor -%}
 {% endmacro %}

--- a/dbt/macros/format_additional_select_columns.sql
+++ b/dbt/macros/format_additional_select_columns.sql
@@ -43,7 +43,7 @@
                 {%- else -%} {{- col.column }} as {{ label }}{{ trailing_comma }}
                 {%- endif -%}
             {%- endif -%}
-        {%- else -%} {{ col }} as {{ col }}{{ trailing_comma }}
+        {%- else -%} {{ col }}{{ trailing_comma }}
         {%- endif -%}
     {%- endfor -%}
 {% endmacro %}

--- a/dbt/macros/tests/test_all.sql
+++ b/dbt/macros/tests/test_all.sql
@@ -4,4 +4,5 @@
     {% do test_slugify() %}
     {% do test_generate_schema_name() %}
     {% do test_generate_alias_name() %}
+    {% do test_format_additional_select_columns() %}
 {% endmacro %}

--- a/dbt/macros/tests/test_format_additional_select_columns.sql
+++ b/dbt/macros/tests/test_format_additional_select_columns.sql
@@ -74,9 +74,9 @@
     {{
         assert_equals(
             "test_format_additional_select_columns_dict_element_array_w_alias",
-            format_additional_select_columns([
-                {"column": "foo", "alias": "bar", "agg_func": "max"}
-            ]),
+            format_additional_select_columns(
+                [{"column": "foo", "alias": "bar", "agg_func": "max"}]
+            ),
             "max (foo) as bar",
         )
     }}

--- a/dbt/macros/tests/test_format_additional_select_columns.sql
+++ b/dbt/macros/tests/test_format_additional_select_columns.sql
@@ -1,5 +1,6 @@
 {% macro test_format_additional_select_columns() %}
     {% do test_format_additional_select_columns_string_element() %}
+    {% do test_format_additional_select_columns_string_element_with_alias() %}
     {% do test_format_additional_select_columns_string_list() %}
     {% do test_format_additional_select_columns_dict_element_no_column() %}
     {% do test_format_additional_select_columns_dict_element_no_alias() %}
@@ -14,6 +15,16 @@
             "test_format_additional_select_columns_string_element",
             format_additional_select_columns(["foo"]),
             "foo",
+        )
+    }}
+{% endmacro %}
+
+{% macro test_format_additional_select_columns_string_element_with_alias() %}
+    {{
+        assert_equals(
+            "test_format_additional_select_columns_string_element_with_alias",
+            format_additional_select_columns(["foo as bar"]),
+            "foo as bar",
         )
     }}
 {% endmacro %}

--- a/dbt/macros/tests/test_format_additional_select_columns.sql
+++ b/dbt/macros/tests/test_format_additional_select_columns.sql
@@ -76,7 +76,7 @@
         assert_equals(
             "test_format_additional_select_columns_dict_element_array_agg",
             format_additional_select_columns([{"column": "foo", "agg_func": "max"}]),
-            "max (foo) as foo",
+            "max (foo) as max_foo",
         )
     }}
 {% endmacro %}

--- a/dbt/macros/tests/test_format_additional_select_columns.sql
+++ b/dbt/macros/tests/test_format_additional_select_columns.sql
@@ -2,9 +2,10 @@
     {% do test_format_additional_select_columns_string_element() %}
     {% do test_format_additional_select_columns_string_list() %}
     {% do test_format_additional_select_columns_dict_element_no_column() %}
-    {% do test_format_additional_select_columns_dict_element_no_label() %}
-    {% do test_format_additional_select_columns_dict_element_with_label() %}
+    {% do test_format_additional_select_columns_dict_element_no_alias() %}
+    {% do test_format_additional_select_columns_dict_element_with_alias() %}
     {% do test_format_additional_select_columns_dict_element_array_agg() %}
+    {% do test_format_additional_select_columns_dict_element_array_w_alias() %}
 {% endmacro %}
 
 {% macro test_format_additional_select_columns_string_element() %}
@@ -12,7 +13,7 @@
         assert_equals(
             "test_format_additional_select_columns_string_element",
             format_additional_select_columns(["foo"]),
-            "foo as foo,",
+            "foo",
         )
     }}
 {% endmacro %}
@@ -22,7 +23,7 @@
         assert_equals(
             "test_format_additional_select_columns_string_element",
             format_additional_select_columns(["foo", "bar"]),
-            "foo as foo,bar as bar,",
+            "foo,bar",
         )
     }}
 {% endmacro %}
@@ -32,29 +33,29 @@
         assert_equals(
             "test_format_additional_select_columns_dict_element_no_column",
             _format_additional_select_columns(
-                [{"label": "foo"}], mock_raise_compiler_error
+                [{"alias": "foo"}], mock_raise_compiler_error
             ),
-            "Missing required \"column\" key in config: {'label': 'foo'}",
+            "Missing required \"column\" key in config: {'alias': 'foo'}",
         )
     }}
 {% endmacro %}
 
-{% macro test_format_additional_select_columns_dict_element_no_label() %}
+{% macro test_format_additional_select_columns_dict_element_no_alias() %}
     {{
         assert_equals(
-            "test_format_additional_select_columns_dict_element_no_label",
+            "test_format_additional_select_columns_dict_element_no_alias",
             format_additional_select_columns([{"column": "foo"}]),
-            "foo as foo,",
+            "foo",
         )
     }}
 {% endmacro %}
 
-{% macro test_format_additional_select_columns_dict_element_with_label() %}
+{% macro test_format_additional_select_columns_dict_element_with_alias() %}
     {{
         assert_equals(
-            "test_format_additional_select_columns_dict_element_with_label",
-            format_additional_select_columns([{"column": "foo", "label": "bar"}]),
-            "foo as bar,",
+            "test_format_additional_select_columns_dict_element_with_alias",
+            format_additional_select_columns([{"column": "foo", "alias": "bar"}]),
+            "foo as bar",
         )
     }}
 {% endmacro %}
@@ -64,7 +65,19 @@
         assert_equals(
             "test_format_additional_select_columns_dict_element_array_agg",
             format_additional_select_columns([{"column": "foo", "agg_func": "max"}]),
-            "max (foo) as foo,",
+            "max (foo) as foo",
+        )
+    }}
+{% endmacro %}
+
+{% macro test_format_additional_select_columns_dict_element_array_w_alias() %}
+    {{
+        assert_equals(
+            "test_format_additional_select_columns_dict_element_array_w_alias",
+            format_additional_select_columns([
+                {"column": "foo", "alias": "bar", "agg_func": "max"}
+            ]),
+            "max (foo) as bar",
         )
     }}
 {% endmacro %}

--- a/dbt/macros/tests/test_format_additional_select_columns.sql
+++ b/dbt/macros/tests/test_format_additional_select_columns.sql
@@ -1,0 +1,70 @@
+{% macro test_format_additional_select_columns() %}
+    {% do test_format_additional_select_columns_string_element() %}
+    {% do test_format_additional_select_columns_string_list() %}
+    {% do test_format_additional_select_columns_dict_element_no_column() %}
+    {% do test_format_additional_select_columns_dict_element_no_label() %}
+    {% do test_format_additional_select_columns_dict_element_with_label() %}
+    {% do test_format_additional_select_columns_dict_element_array_agg() %}
+{% endmacro %}
+
+{% macro test_format_additional_select_columns_string_element() %}
+    {{
+        assert_equals(
+            "test_format_additional_select_columns_string_element",
+            format_additional_select_columns(["foo"]),
+            "foo as foo,",
+        )
+    }}
+{% endmacro %}
+
+{% macro test_format_additional_select_columns_string_list() %}
+    {{
+        assert_equals(
+            "test_format_additional_select_columns_string_element",
+            format_additional_select_columns(["foo", "bar"]),
+            "foo as foo,bar as bar,",
+        )
+    }}
+{% endmacro %}
+
+{% macro test_format_additional_select_columns_dict_element_no_column() %}
+    {{
+        assert_equals(
+            "test_format_additional_select_columns_dict_element_no_column",
+            _format_additional_select_columns(
+                [{"label": "foo"}], mock_raise_compiler_error
+            ),
+            "Missing required \"column\" key in config: {'label': 'foo'}",
+        )
+    }}
+{% endmacro %}
+
+{% macro test_format_additional_select_columns_dict_element_no_label() %}
+    {{
+        assert_equals(
+            "test_format_additional_select_columns_dict_element_no_label",
+            format_additional_select_columns([{"column": "foo"}]),
+            "foo as foo,",
+        )
+    }}
+{% endmacro %}
+
+{% macro test_format_additional_select_columns_dict_element_with_label() %}
+    {{
+        assert_equals(
+            "test_format_additional_select_columns_dict_element_with_label",
+            format_additional_select_columns([{"column": "foo", "label": "bar"}]),
+            "foo as bar,",
+        )
+    }}
+{% endmacro %}
+
+{% macro test_format_additional_select_columns_dict_element_array_agg() %}
+    {{
+        assert_equals(
+            "test_format_additional_select_columns_dict_element_array_agg",
+            format_additional_select_columns([{"column": "foo", "agg_func": "max"}]),
+            "max (foo) as foo,",
+        )
+    }}
+{% endmacro %}

--- a/dbt/macros/tests/test_generate_schema_name.sql
+++ b/dbt/macros/tests/test_generate_schema_name.sql
@@ -12,10 +12,6 @@
     {% endif %}
 {% endmacro %}
 
-{% macro mock_raise_compiler_error(_error) %}
-    {{ return("Compiler error raised") }}
-{% endmacro %}
-
 {% macro test_generate_schema_name_handles_dev_env() %}
     {% do assert_equals(
         "test_generate_schema_name_handles_dev_env",
@@ -68,6 +64,10 @@
             mock_env_var,
             mock_raise_compiler_error,
         ),
-        "Compiler error raised",
+        (
+            "Missing schema definition for test. Its containing subdirectory "
+            "is probably missing a `+schema` attribute under the `models` "
+            "config in dbt_project.yml."
+        ),
     ) %}
 {% endmacro %}

--- a/dbt/macros/tests/utils.sql
+++ b/dbt/macros/tests/utils.sql
@@ -6,3 +6,5 @@
         ) %}
     {% endif %}
 {% endmacro %}
+
+{% macro mock_raise_compiler_error(_error) %} {{ return(_error) }} {% endmacro %}

--- a/dbt/models/default/schema/default.vw_pin_address.yml
+++ b/dbt/models/default/schema/default.vw_pin_address.yml
@@ -78,6 +78,6 @@ models:
       - expression_is_true:
           name: default_vw_pin_address_numeric_pin
           expression: REGEXP_COUNT(pin, '[0-9]') = 14 AND LENGTH(pin) = 14
-          select_columns:
+          additional_select_columns:
             - pin
       # TODO: Site addresses are all in Cook County

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -80,7 +80,7 @@ models:
             ))
             OR
             (change is null)
-          select_columns:
+          additional_select_columns:
             - pin
             - year
             - case_no
@@ -97,7 +97,7 @@ models:
       - expression_is_true:
           name: default_vw_pin_appeal_no_unexpected_change_values
           expression: change is null or change in ('change', 'no change')
-          select_columns:
+          additional_select_columns:
             - pin
             - year
             - case_no

--- a/dbt/models/default/schema/default.vw_pin_exempt.yml
+++ b/dbt/models/default/schema/default.vw_pin_exempt.yml
@@ -33,5 +33,5 @@ models:
       - expression_is_true:
           name: default_vw_pin_exempt_numeric_pin
           expression: REGEXP_COUNT(pin, '[0-9]') = 14 AND LENGTH(pin) = 14
-          select_columns:
+          additional_select_columns:
             - pin

--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -83,7 +83,7 @@ models:
       - expression_is_true:
           name: default_vw_pin_sale_is_multisale_num_parcels_sale_align
           expression: (num_parcels_sale > 1 AND is_multisale) OR (num_parcels_sale = 1 AND NOT is_multisale)
-          select_columns:
+          additional_select_columns:
             - num_parcels_sale
             - is_multisale
       # TODO: Sale is validated (after sales validation has been added to

--- a/dbt/models/default/schema/default.vw_pin_universe.yml
+++ b/dbt/models/default/schema/default.vw_pin_universe.yml
@@ -257,7 +257,7 @@ models:
       - expression_is_true:
           name: default_vw_pin_universe_numeric_pin
           expression: REGEXP_COUNT(pin, '[0-9]') = 14 AND LENGTH(pin) = 14
-          select_columns:
+          additional_select_columns:
             - pin
       # TODO: Data completeness correlates with availability of spatial data
       # by year

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -39,7 +39,19 @@ sources:
                     description: class code must be valid
               - res_class_matches_pardat:
                   name: iasworld_asmt_all_class_matches_pardat_class
-                  select_columns_aggregated_with_max: *select-columns
+                  additional_select_columns:
+                    - column: filtered_model.taxyr
+                      label: taxyr
+                      agg_func: max
+                    - column: filtered_model.parid
+                      label: parid
+                      agg_func: max
+                    - column: filtered_model.who
+                      label: who
+                      agg_func: max
+                    - column: filtered_model.wen
+                      label: wen
+                      agg_func: max
                   config: &unique-conditions
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -40,10 +40,14 @@ sources:
               - res_class_matches_pardat:
                   name: iasworld_asmt_all_class_matches_pardat_class
                   additional_select_columns:
-                    - {"column": "taxyr", "agg_func": "max"}
-                    - {"column": "parid", "agg_func": "max"}
-                    - {"column": "who", "agg_func": "max"}
-                    - {"column": "wen", "agg_func": "max"}
+                    - column: taxyr
+                      agg_func: max
+                    - column: parid
+                      agg_func: max
+                    - column: who
+                      agg_func: max
+                    - column: wen
+                      agg_func: max
                   config: &unique-conditions
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -40,18 +40,10 @@ sources:
               - res_class_matches_pardat:
                   name: iasworld_asmt_all_class_matches_pardat_class
                   additional_select_columns:
-                    - column: filtered_model.taxyr
-                      label: taxyr
-                      agg_func: max
-                    - column: filtered_model.parid
-                      label: parid
-                      agg_func: max
-                    - column: filtered_model.who
-                      label: who
-                      agg_func: max
-                    - column: filtered_model.wen
-                      label: wen
-                      agg_func: max
+                    - {"column": "taxyr", "agg_func": "max"}
+                    - {"column": "parid", "agg_func": "max"}
+                    - {"column": "who", "agg_func": "max"}
+                    - {"column": "wen", "agg_func": "max"}
                   config: &unique-conditions
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}

--- a/dbt/models/iasworld/schema/iasworld.comdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.comdat.yml
@@ -88,7 +88,17 @@ sources:
                   name: iasworld_comdat_chgrsn_eq_5_mktadj_not_null
                   expression: |
                     != '5' OR mktadj IS NOT NULL
+                  additional_select_columns:
+                    - parid
+                    - taxyr
+                    - card
+                    - who
+                    - wen
+                    - mktadj
                   config: *unique-conditions
+                  meta:
+                    category: incorrect_values
+                    description: chgrsn should only be 5 if mktadj is not null
           - name: class
             description: '{{ doc("shared_column_class") }}'
             tests:
@@ -96,6 +106,7 @@ sources:
                   name: iasworld_comdat_class_in_ccao_class_dict
                   to: source('ccao', 'class_dict')
                   field: class_code
+                  additional_select_columns: *select-columns
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
@@ -103,6 +114,9 @@ sources:
                       AND class NOT IN ('EX', 'RR')
                       AND cur = 'Y'
                       AND deactivat IS NULL
+                  meta:
+                    category: class_mismatch_or_issue
+                    description: class code must be valid
           - name: convbldg
             description: '{{ doc("column_convbldg") }}'
             tests:

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -169,12 +169,22 @@ sources:
                       AND deactivat IS NULL
               - res_class_matches_pardat:
                   name: iasworld_dweldat_class_matches_pardat_class
-                  select_columns_aggregated_with_array: ["card"]
-                  select_columns_aggregated_with_max:
-                    - taxyr
-                    - parid
-                    - who
-                    - wen
+                  additional_select_columns:
+                    - column: filtered_model.card
+                      label: card
+                      agg_func: array_agg
+                    - column: filtered_model.taxyr
+                      label: taxyr
+                      agg_func: max
+                    - column: filtered_model.parid
+                      label: parid
+                      agg_func: max
+                    - column: filtered_model.who
+                      label: who
+                      agg_func: max
+                    - column: filtered_model.wen
+                      label: wen
+                      agg_func: max
                   config: *unique-conditions
                   meta:
                     description: at least one class should match pardat class

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -174,11 +174,16 @@ sources:
               - res_class_matches_pardat:
                   name: iasworld_dweldat_class_matches_pardat_class
                   additional_select_columns:
-                    - {"column": "card", "agg_func": "array_agg"}
-                    - {"column": "taxyr", "agg_func": "max"}
-                    - {"column": "parid", "agg_func": "max"}
-                    - {"column": "who", "agg_func": "max"}
-                    - {"column": "wen", "agg_func": "max"}
+                    - column: card
+                      agg_func: array_agg
+                    - column: taxyr
+                      agg_func: max
+                    - column: parid
+                      agg_func: max
+                    - column: who
+                      agg_func: max
+                    - column: wen
+                      agg_func: max
                   config: *unique-conditions
                   meta:
                     description: at least one class should match pardat class

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -519,7 +519,7 @@ sources:
                   name: iasworld_dweldat_mktrsn_eq_5_mktadj_not_null
                   expression: |
                     != '5' OR mktadj IS NOT NULL
-                  select_columns:
+                  additional_select_columns:
                     - taxyr
                     - parid
                     - card
@@ -679,7 +679,7 @@ sources:
               - expression_is_true:
                   name: iasworld_dweldat_rmbed_lte_rmtot
                   expression: <= rmtot
-                  select_columns:
+                  additional_select_columns:
                     - parid
                     - taxyr
                     - card
@@ -859,7 +859,7 @@ sources:
               - expression_is_true:
                   name: iasworld_dweldat_stories_in_accepted_values
                   expression: 'IN (1.00, 2.00, 3.00, 4.00, 5.00, 9.90)'
-                  select_columns: *select-columns
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
                     category: incorrect_values
@@ -1222,7 +1222,7 @@ sources:
           - expression_is_true:
               name: iasworld_dweldat_card_proration_rate_between_0_and_100
               expression: 'CAST(user24 AS decimal) BETWEEN 0.00 AND 100.00'
-              select_columns:
+              additional_select_columns:
                 - parid
                 - taxyr
                 - card
@@ -1236,7 +1236,7 @@ sources:
           - expression_is_true:
               name: iasworld_dweldat_char_ncu_between_0_and_5
               expression: 'CAST(user20 AS decimal) BETWEEN 0 AND 5'
-              select_columns:
+              additional_select_columns:
                 - parid
                 - taxyr
                 - card
@@ -1250,7 +1250,7 @@ sources:
           - expression_is_true:
               name: iasworld_dweldat_bsmt_and_user12_match_234_class
               expression: bsmt = '3' and user12 = '1'
-              select_columns:
+              additional_select_columns:
                 - parid
                 - taxyr
                 - card

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -170,21 +170,11 @@ sources:
               - res_class_matches_pardat:
                   name: iasworld_dweldat_class_matches_pardat_class
                   additional_select_columns:
-                    - column: filtered_model.card
-                      label: card
-                      agg_func: array_agg
-                    - column: filtered_model.taxyr
-                      label: taxyr
-                      agg_func: max
-                    - column: filtered_model.parid
-                      label: parid
-                      agg_func: max
-                    - column: filtered_model.who
-                      label: who
-                      agg_func: max
-                    - column: filtered_model.wen
-                      label: wen
-                      agg_func: max
+                    - {"column": "card", "agg_func": "array_agg"}
+                    - {"column": "taxyr", "agg_func": "max"}
+                    - {"column": "parid", "agg_func": "max"}
+                    - {"column": "who", "agg_func": "max"}
+                    - {"column": "wen", "agg_func": "max"}
                   config: *unique-conditions
                   meta:
                     description: at least one class should match pardat class

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -161,12 +161,16 @@ sources:
                   name: iasworld_dweldat_class_in_ccao_class_dict
                   to: source('ccao', 'class_dict')
                   field: class_code
+                  additional_select_columns: *select-columns
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND class NOT IN ('EX', 'RR')
                       AND cur = 'Y'
                       AND deactivat IS NULL
+                  meta:
+                    category: class_mismatch_or_issue
+                    description: class code must be valid
               - res_class_matches_pardat:
                   name: iasworld_dweldat_class_matches_pardat_class
                   additional_select_columns:

--- a/dbt/models/iasworld/schema/iasworld.htpar.yml
+++ b/dbt/models/iasworld/schema/iasworld.htpar.yml
@@ -325,7 +325,7 @@ sources:
               expression: |
                 LENGTH(cpaddr3) = 5
                 OR (LENGTH(cpaddr3) = 10 AND cpaddr3 LIKE '%-%')
-              select_columns:
+              additional_select_columns:
                 - parid
                 - taxyr
                 - who

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -21,7 +21,7 @@ sources:
               - expression_is_true:
                   name: iasworld_land_acres_is_sf_transformed
                   expression: '* 43560 BETWEEN sf - 5 AND sf + 5'
-                  select_columns:
+                  additional_select_columns:
                     - taxyr
                     - parid
                     - card

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -95,18 +95,10 @@ sources:
                   name: iasworld_land_class_matches_pardat_class
                   major_class_only: true
                   additional_select_columns:
-                    - column: filtered_model.taxyr
-                      label: taxyr
-                      agg_func: max
-                    - column: filtered_model.parid
-                      label: parid
-                      agg_func: max
-                    - column: filtered_model.who
-                      label: who
-                      agg_func: max
-                    - column: filtered_model.wen
-                      label: wen
-                      agg_func: max
+                    - {"column": "taxyr", "agg_func": "max"}
+                    - {"column": "parid", "agg_func": "max"}
+                    - {"column": "who", "agg_func": "max"}
+                    - {"column": "wen", "agg_func": "max"}
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -95,10 +95,14 @@ sources:
                   name: iasworld_land_class_matches_pardat_class
                   major_class_only: true
                   additional_select_columns:
-                    - {"column": "taxyr", "agg_func": "max"}
-                    - {"column": "parid", "agg_func": "max"}
-                    - {"column": "who", "agg_func": "max"}
-                    - {"column": "wen", "agg_func": "max"}
+                    - column: taxyr
+                      agg_func: max
+                    - column: parid
+                      agg_func: max
+                    - column: who
+                      agg_func: max
+                    - column: wen
+                      agg_func: max
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -94,11 +94,19 @@ sources:
               - res_class_matches_pardat:
                   name: iasworld_land_class_matches_pardat_class
                   major_class_only: true
-                  select_columns_aggregated_with_max:
-                    - taxyr
-                    - parid
-                    - who
-                    - wen
+                  additional_select_columns:
+                    - column: filtered_model.taxyr
+                      label: taxyr
+                      agg_func: max
+                    - column: filtered_model.parid
+                      label: parid
+                      agg_func: max
+                    - column: filtered_model.who
+                      label: who
+                      agg_func: max
+                    - column: filtered_model.wen
+                      label: wen
+                      agg_func: max
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}

--- a/dbt/models/iasworld/schema/iasworld.legdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.legdat.yml
@@ -290,7 +290,7 @@ sources:
           - expression_is_true:
               name: iasworld_legdat_adrno_length_lte_5
               expression: LENGTH(CAST(adrno AS varchar)) <= 5
-              select_columns:
+              additional_select_columns:
                 - parid
                 - taxyr
                 - who

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -104,21 +104,11 @@ sources:
                   name: iasworld_oby_class_matches_pardat_class
                   major_class_only: true
                   additional_select_columns:
-                    - column: filtered_model.card
-                      label: card
-                      agg_func: array_agg
-                    - column: filtered_model.taxyr
-                      label: taxyr
-                      agg_func: max
-                    - column: filtered_model.parid
-                      label: parid
-                      agg_func: max
-                    - column: filtered_model.who
-                      label: who
-                      agg_func: max
-                    - column: filtered_model.wen
-                      label: wen
-                      agg_func: max
+                    - {"column": "card", "agg_func": "array_agg"}
+                    - {"column": "taxyr", "agg_func": "max"}
+                    - {"column": "parid", "agg_func": "max"}
+                    - {"column": "who", "agg_func": "max"}
+                    - {"column": "wen", "agg_func": "max"}
                   config: *unique-conditions
                   meta:
                     description: >

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -103,12 +103,22 @@ sources:
               - res_class_matches_pardat:
                   name: iasworld_oby_class_matches_pardat_class
                   major_class_only: true
-                  select_columns_aggregated_with_array: ["card"]
-                  select_columns_aggregated_with_max:
-                    - taxyr
-                    - parid
-                    - who
-                    - wen
+                  additional_select_columns:
+                    - column: filtered_model.card
+                      label: card
+                      agg_func: array_agg
+                    - column: filtered_model.taxyr
+                      label: taxyr
+                      agg_func: max
+                    - column: filtered_model.parid
+                      label: parid
+                      agg_func: max
+                    - column: filtered_model.who
+                      label: who
+                      agg_func: max
+                    - column: filtered_model.wen
+                      label: wen
+                      agg_func: max
                   config: *unique-conditions
                   meta:
                     description: >

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -104,11 +104,16 @@ sources:
                   name: iasworld_oby_class_matches_pardat_class
                   major_class_only: true
                   additional_select_columns:
-                    - {"column": "card", "agg_func": "array_agg"}
-                    - {"column": "taxyr", "agg_func": "max"}
-                    - {"column": "parid", "agg_func": "max"}
-                    - {"column": "who", "agg_func": "max"}
-                    - {"column": "wen", "agg_func": "max"}
+                    - column: card
+                      agg_func: array_agg
+                    - column: taxyr
+                      agg_func: max
+                    - column: parid
+                      agg_func: max
+                    - column: who
+                      agg_func: max
+                    - column: wen
+                      agg_func: max
                   config: *unique-conditions
                   meta:
                     description: >

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -304,7 +304,7 @@ sources:
           - expression_is_true:
               name: iasworld_pardat_adrno_length_lte_5
               expression: LENGTH(CAST(adrno AS varchar)) <= 5
-              select_columns:
+              additional_select_columns:
                 - parid
                 - taxyr
                 - who

--- a/dbt/models/iasworld/schema/iasworld.sales.yml
+++ b/dbt/models/iasworld/schema/iasworld.sales.yml
@@ -221,7 +221,7 @@ sources:
           - expression_is_true:
               name: iasworld_sales_saledt_lte_now
               expression: DATE_PARSE(SUBSTR(saledt, 1, 10), '%Y-%m-%d') <= current_date
-              select_columns:
+              additional_select_columns:
                 - parid
                 - saledt
                 - instruno

--- a/dbt/models/iasworld/schema/iasworld.sales.yml
+++ b/dbt/models/iasworld/schema/iasworld.sales.yml
@@ -204,16 +204,16 @@ sources:
                 - instruno
               additional_select_columns:
                 - column: substr(saledt, 1, 4)
-                  label: taxyr
+                  alias: taxyr
                   agg_func: max
                 - column: substr(saledt, 1, 4)
-                  label: sale_year
+                  alias: sale_year
                   agg_func: array_agg
                 - column: who
-                  label: who
+                  alias: who
                   agg_func: array_agg
                 - column: wen
-                  label: wen
+                  alias: wen
                   agg_func: array_agg
               config: *unique-conditions
               meta:

--- a/dbt/models/qc/schema.yml
+++ b/dbt/models/qc/schema.yml
@@ -100,7 +100,7 @@ models:
           - expression_is_true:
               name: qc_vw_incorrect_asmt_value_class_equals_luc
               expression: '= luc'
-              select_columns:
+              additional_select_columns:
                 - taxyr
                 - parid
                 - township_code
@@ -110,7 +110,6 @@ models:
               config: &time-filter
                 where: |
                   CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-
               meta:
                 table_name: asmt
                 category: relationships
@@ -119,7 +118,7 @@ models:
       - expression_is_true:
           name: qc_vw_incorrect_asmt_value_no_yoy_inc_gt_500k
           expression: (cur_year_fmv - pri_year_fmv) <= 500000
-          select_columns: &select-columns-cur-and-pri-year-fmv
+          additional_select_columns: &select-columns-cur-and-pri-year-fmv
             - taxyr
             - parid
             - township_code
@@ -136,7 +135,7 @@ models:
       - expression_is_true:
           name: qc_vw_incorrect_asmt_value_no_yoy_dec_gt_1m
           expression: (cur_year_fmv - pri_year_fmv) >= -1000000
-          select_columns: *select-columns-cur-and-pri-year-fmv
+          additional_select_columns: *select-columns-cur-and-pri-year-fmv
           config: *time-filter
           meta:
             table_name: asmt
@@ -588,7 +587,7 @@ models:
       - expression_is_true:
           name: qc_vw_change_in_high_low_value_sales_ratio_high
           expression: "price_less_than_10k_growth_status = 'No significant change'"
-          select_columns:
+          additional_select_columns:
             - source
             - taxyr
             - price_less_than_10k_growth_status
@@ -602,7 +601,7 @@ models:
       - expression_is_true:
           name: qc_vw_change_in_high_low_value_sales_ratio_low
           expression: "price_greater_than_1m_growth_status = 'No significant change'"
-          select_columns:
+          additional_select_columns:
             - source
             - taxyr
             - price_greater_than_1m_growth_status
@@ -752,7 +751,7 @@ models:
       - expression_is_true:
           name: qc_vw_iasworld_sales_day_of_month_lte_half_observations
           expression: sales_by_day < 0.5 * total_sales
-          select_columns:
+          additional_select_columns:
             - taxyr
             - day_of_month
             - sales_by_day
@@ -790,7 +789,7 @@ models:
       - expression_is_true:
           name: qc_vw_iasworld_sales_price_diff_sale_mydec_gte_1000
           expression: ABS(price_iasworld - price_mydec) < 999
-          select_columns:
+          additional_select_columns:
             - parid
             - taxyr
             - document_number

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -50,7 +50,7 @@ models:
     - expression_is_true:
         name: reporting_res_report_summary_sale_year_eq_year_minus_one
         expression: CAST(sale_year AS INTEGER) = CAST(year AS INTEGER) - 1
-        select_columns:
+        additional_select_columns:
           - sale_year
           - year
     - expression_is_true:
@@ -60,7 +60,7 @@ models:
           AND geography_type IS NOT NULL
           AND property_group IS NOT NULL
           AND assessment_stage IS NOT NULL
-        select_columns:
+        additional_select_columns:
           - triad
           - geography_type
           - property_group
@@ -131,13 +131,13 @@ models:
       - expression_is_true:
           name: reporting_vw_ratio_stats_sale_year_equals_year_minus_one
           expression: CAST(sale_year AS INTEGER) = CAST(year AS INTEGER) - 1
-          select_columns:
+          additional_select_columns:
             - sale_year
             - year
       - expression_is_true:
           name: reporting_vw_ratio_stats_ratio_greater_than_zero
           expression: ratio >= 0
-          select_columns:
+          additional_select_columns:
             - ratio
 
   - name: reporting.vw_top_5

--- a/dbt/tests/generic/test_accepted_range.sql
+++ b/dbt/tests/generic/test_accepted_range.sql
@@ -9,7 +9,7 @@
     additional_select_columns=[]
 ) %}
 
-    {%- set columns_csv = additional_select_columns | join(", ") %}
+    {%- set columns_csv = format_additional_select_columns(additional_select_columns) %}
 
     with
         meet_condition as (

--- a/dbt/tests/generic/test_accepted_values.sql
+++ b/dbt/tests/generic/test_accepted_values.sql
@@ -4,7 +4,7 @@
     model, column_name, values, quote=True, additional_select_columns=[]
 ) %}
 
-    {%- set columns_csv = additional_select_columns | join(", ") %}
+    {%- set columns_csv = format_additional_select_columns(additional_select_columns) %}
 
     select {{ column_name }}{%- if columns_csv %}, {{ columns_csv }}{% endif %}
     from {{ model }}

--- a/dbt/tests/generic/test_column_is_subset_of_external_column.sql
+++ b/dbt/tests/generic/test_column_is_subset_of_external_column.sql
@@ -11,7 +11,9 @@
     additional_select_columns=[]
 ) %}
 
-    {%- set additional_select_columns_csv = additional_select_columns | join(", ") %}
+    {%- set additional_select_columns_csv = format_additional_select_columns(
+        additional_select_columns
+    ) %}
     {%- set columns_csv = additional_select_columns_csv ~ ", " ~ column %}
 
     with

--- a/dbt/tests/generic/test_column_length.sql
+++ b/dbt/tests/generic/test_column_length.sql
@@ -8,14 +8,16 @@
 -- additional_select_columns argument.
 {% test column_length(model, columns, length, additional_select_columns=[]) %}
 
-    {%- set columns_csv = additional_select_columns | join(", ") %}
+    {%- set additional_select_columns_csv = format_additional_select_columns(
+        additional_select_columns
+    ) %}
 
     {%- set length_columns = [] %}
     {%- for column in columns %}
         {%- set length_columns = length_columns.append([column, "len_" + column]) %}
     {%- endfor %}
 
-    {%- set select_columns = additional_select_columns %}
+    {%- set select_columns = [] %}
     {%- set filter_conditions = [] %}
 
     {%- for column, length_column in length_columns %}
@@ -36,7 +38,15 @@
     {%- set columns_csv = select_columns | join(", ") %}
     {%- set filter_conditions_str = filter_conditions | join(" or ") %}
 
-    with column_lengths as (select {{ columns_csv }} from {{ model }})
+    with
+        column_lengths as (
+            select
+                {{ columns_csv }}
+                {%- if additional_select_columns_csv -%}
+                    , {{ additional_select_columns_csv }}
+                {%- endif %}
+            from {{ model }}
+        )
     select *
     from column_lengths
     where {{ filter_conditions_str }}

--- a/dbt/tests/generic/test_columns_match.sql
+++ b/dbt/tests/generic/test_columns_match.sql
@@ -3,8 +3,8 @@
     {%- set columns_csv = columns | join(", ") -%}
     {%- set columns_csv = column_name ~ ", " ~ columns_csv -%}
     {%- if additional_select_columns -%}
-        {%- set additional_select_columns_csv = additional_select_columns | join(
-            ", "
+        {%- set additional_select_columns_csv = format_additional_select_columns(
+            additional_select_columns
         ) -%}
         {%- set columns_csv = columns_csv ~ ", " ~ additional_select_columns_csv -%}
     {%- endif -%}

--- a/dbt/tests/generic/test_expression_is_true.sql
+++ b/dbt/tests/generic/test_expression_is_true.sql
@@ -1,13 +1,17 @@
 -- Filter for rows where a given `expression` is false.
 --
 -- Adapted from `dbt_utils.expression_is_true`, and extended to support
--- an optional `select_columns` option representing an array of columns to
--- select for failing rows in addition to `column_name`. If no `select_columns`
--- array is provided, defaults to selecting the column represented by
--- `column_name`; if `column_name` is also missing, falls back to selecting 1
--- for failing rows.
-{% test expression_is_true(model, column_name, expression, select_columns=[]) %}
-    {%- set select_columns_csv = select_columns | join(", ") -%}
+-- an optional `additional_select_columns` option representing an array of
+-- columns to select for failing rows in addition to `column_name`. If no
+-- `additional_select_columns` array is provided, defaults to selecting the
+-- column represented by `column_name`; if `column_name` is also missing, falls
+-- back to selecting 1 for failing rows.
+{% test expression_is_true(
+    model, column_name, expression, additional_select_columns=[]
+) %}
+    {%- set select_columns_csv = format_additional_select_columns(
+        additional_select_columns
+    ) -%}
     {%- if column_name -%}
         {%- set columns_csv = column_name -%}
         {%- if select_columns_csv -%}

--- a/dbt/tests/generic/test_not_accepted_values.sql
+++ b/dbt/tests/generic/test_not_accepted_values.sql
@@ -4,7 +4,7 @@
     model, column_name, values, quote=True, additional_select_columns=[]
 ) %}
 
-    {%- set columns_csv = additional_select_columns | join(", ") %}
+    {%- set columns_csv = format_additional_select_columns(additional_select_columns) %}
 
     select {{ column_name }}{%- if columns_csv %}, {{ columns_csv }}{% endif %}
     from {{ model }}

--- a/dbt/tests/generic/test_not_null.sql
+++ b/dbt/tests/generic/test_not_null.sql
@@ -4,7 +4,9 @@
 
     {%- set columns_csv = "*" %}
     {%- if additional_select_columns %}
-        {%- set columns_csv = additional_select_columns | join(", ") %}
+        {%- set columns_csv = format_additional_select_columns(
+            additional_select_columns
+        ) %}
     {%- endif %}
 
     select {{ columns_csv }}

--- a/dbt/tests/generic/test_relationships.sql
+++ b/dbt/tests/generic/test_relationships.sql
@@ -2,7 +2,7 @@
 -- columns for debugging
 {% test relationships(model, column_name, to, field, additional_select_columns=[]) %}
 
-    {%- set columns_csv = additional_select_columns | join(", ") %}
+    {%- set columns_csv = format_additional_select_columns(additional_select_columns) %}
 
     with
         child as (

--- a/dbt/tests/generic/test_res_class_matches_pardat.sql
+++ b/dbt/tests/generic/test_res_class_matches_pardat.sql
@@ -13,11 +13,7 @@
 -- (which uses the `array_agg()` function to select the columns) or
 -- `select_columns_aggregated_with_max` (which uses the `max()` function).
 {% test res_class_matches_pardat(
-    model,
-    column_name,
-    major_class_only=false,
-    select_columns_aggregated_with_array=[],
-    select_columns_aggregated_with_max=[]
+    model, column_name, major_class_only=false, additional_select_columns=[]
 ) %}
 
     {%- set num_class_digits = 1 if major_class_only else 3 %}
@@ -39,12 +35,7 @@
 
     select
         array_agg(filtered_model.{{ column_name }}) as {{ column_name }},
-        {%- for col in select_columns_aggregated_with_array %}
-            array_agg(filtered_model.{{ col }}) as {{ col }},
-        {%- endfor %}
-        {%- for col in select_columns_aggregated_with_max %}
-            max(filtered_model.{{ col }}) as {{ col }},
-        {%- endfor %}
+        {{ format_additional_select_columns(additional_select_columns) }}
         -- Pardat should be unique by (parid, taxyr), so we can select the
         -- max rather than array_agg
         max(pardat.class) as pardat_class

--- a/dbt/tests/generic/test_res_class_matches_pardat.sql
+++ b/dbt/tests/generic/test_res_class_matches_pardat.sql
@@ -26,8 +26,11 @@
             {%- for key, val in col.items() if key != "column" %}
                 {%- set _ = updated_col.update({key: val}) %}
             {%- endfor %}
-            {%- if "label" not in updated_col %}
-                {%- set _ = updated_col.update({"label": col.column}) %}
+            -- It's necessary to explicitly set the alias, since otherwise
+            -- it will default to `filtered_model.{column}` according to
+            -- the fallback behavior of format_additional_select_columns
+            {%- if "alias" not in updated_col %}
+                {%- set _ = updated_col.update({"alias": col.column}) %}
             {%- endif %}
             {%- set _ = processed_additional_select_columns.append(updated_col) %}
         {%- else %}

--- a/dbt/tests/generic/test_res_class_matches_pardat.sql
+++ b/dbt/tests/generic/test_res_class_matches_pardat.sql
@@ -55,7 +55,7 @@
 
     select
         array_agg(filtered_model.{{ column_name }}) as {{ column_name }},
-        {{ format_additional_select_columns(processed_additional_select_columns) }}
+        {{ format_additional_select_columns(processed_additional_select_columns) }},
         -- Pardat should be unique by (parid, taxyr), so we can select the
         -- max rather than array_agg
         max(pardat.class) as pardat_class

--- a/dbt/tests/generic/test_res_class_matches_pardat.sql
+++ b/dbt/tests/generic/test_res_class_matches_pardat.sql
@@ -15,10 +15,12 @@
 {% test res_class_matches_pardat(
     model, column_name, major_class_only=false, additional_select_columns=[]
 ) %}
-    -- Process `additional_select_columns` to add the necessary prefix for
-    -- the filtered version of the input model. This is necessary to
-    -- disambiguate selected columns that are shared between the input model
-    -- and pardat
+    {#-
+        Process `additional_select_columns` to add the necessary prefix for
+        the filtered version of the input model. This is necessary to
+        disambiguate selected columns that are shared between the input model
+        and pardat
+    -#}
     {%- set processed_additional_select_columns = [] %}
     {%- for col in additional_select_columns %}
         {%- if col is mapping %}
@@ -26,9 +28,11 @@
             {%- for key, val in col.items() if key != "column" %}
                 {%- set _ = updated_col.update({key: val}) %}
             {%- endfor %}
-            -- It's necessary to explicitly set the alias, since otherwise
-            -- it will default to `filtered_model.{column}` according to
-            -- the fallback behavior of format_additional_select_columns
+            {#-
+                It's necessary to explicitly set the alias, since otherwise
+                it will default to `filtered_model.{column}` according to
+                the fallback behavior of format_additional_select_columns
+            -#}
             {%- if "alias" not in updated_col %}
                 {%- set _ = updated_col.update({"alias": col.column}) %}
             {%- endif %}

--- a/dbt/tests/generic/test_res_class_matches_pardat.sql
+++ b/dbt/tests/generic/test_res_class_matches_pardat.sql
@@ -15,7 +15,27 @@
 {% test res_class_matches_pardat(
     model, column_name, major_class_only=false, additional_select_columns=[]
 ) %}
-
+    -- Process `additional_select_columns` to add the necessary prefix for
+    -- the filtered version of the input model. This is necessary to
+    -- disambiguate selected columns that are shared between the input model
+    -- and pardat
+    {%- set processed_additional_select_columns = [] %}
+    {%- for col in additional_select_columns %}
+        {%- if col is mapping %}
+            {%- set updated_col = {"column": "filtered_model." ~ col.column} %}
+            {%- for key, val in col.items() if key != "column" %}
+                {%- set _ = updated_col.update({key: val}) %}
+            {%- endfor %}
+            {%- if "label" not in updated_col %}
+                {%- set _ = updated_col.update({"label": col.column}) %}
+            {%- endif %}
+            {%- set _ = processed_additional_select_columns.append(updated_col) %}
+        {%- else %}
+            {%- set _ = processed_additional_select_columns.append(
+                "filtered_model." ~ col
+            ) %}
+        {%- endif %}
+    {%- endfor %}
     {%- set num_class_digits = 1 if major_class_only else 3 %}
 
     with
@@ -35,7 +55,7 @@
 
     select
         array_agg(filtered_model.{{ column_name }}) as {{ column_name }},
-        {{ format_additional_select_columns(additional_select_columns) }}
+        {{ format_additional_select_columns(processed_additional_select_columns) }}
         -- Pardat should be unique by (parid, taxyr), so we can select the
         -- max rather than array_agg
         max(pardat.class) as pardat_class

--- a/dbt/tests/generic/test_row_values_match_after_join.sql
+++ b/dbt/tests/generic/test_row_values_match_after_join.sql
@@ -14,7 +14,9 @@
 ) %}
 
     {%- set join_columns_csv = join_columns | join(", ") -%}
-    {%- set additional_select_columns_csv = additional_select_columns | join(", ") -%}
+    {%- set additional_select_columns_csv = format_additional_select_columns(
+        additional_select_columns
+    ) -%}
 
     {%- if "." in column -%} {%- set model_col = column -%}
     {%- else -%} {%- set model_col = "model" ~ "." ~ column -%}

--- a/dbt/tests/generic/test_unique_combination_of_columns.sql
+++ b/dbt/tests/generic/test_unique_combination_of_columns.sql
@@ -20,7 +20,7 @@
 
     select
         {{ columns_csv }},
-        {{ format_additional_select_columns(additional_select_columns) }}
+        {{ format_additional_select_columns(additional_select_columns) }},
         count(*) as num_duplicates
     from {{ model }}
     group by {{ columns_csv }}

--- a/dbt/tests/generic/test_unique_combination_of_columns.sql
+++ b/dbt/tests/generic/test_unique_combination_of_columns.sql
@@ -17,10 +17,15 @@
 ) %}
 
     {%- set columns_csv = combination_of_columns | join(", ") %}
+    {%- set additional_select_columns_csv = format_additional_select_columns(
+        additional_select_columns
+    ) %}
 
     select
         {{ columns_csv }},
-        {{ format_additional_select_columns(additional_select_columns) }},
+        {%- if additional_select_columns_csv %}
+            {{- additional_select_columns_csv }},
+        {%- endif %}
         count(*) as num_duplicates
     from {{ model }}
     group by {{ columns_csv }}

--- a/dbt/tests/generic/test_unique_combination_of_columns.sql
+++ b/dbt/tests/generic/test_unique_combination_of_columns.sql
@@ -20,12 +20,7 @@
 
     select
         {{ columns_csv }},
-        {%- for col in additional_select_columns %}
-            {%- if col is mapping %}
-                {{ col.agg_func }} ({{ col.column }}) as {{ col.label }},
-            {%- else %} array_agg({{ col }}) as {{ col }},
-            {%- endif %}
-        {%- endfor %}
+        {{ format_additional_select_columns(additional_select_columns) }}
         count(*) as num_duplicates
     from {{ model }}
     group by {{ columns_csv }}


### PR DESCRIPTION
Most of our generic dbt test functions support an `additional_select_columns` parameter that instructs the test to select additional columns from the base table for use in test failure reporting. There are a few problems with the current implementation, however:

* Each test generic implements `additional_select_columns` separately
* The `expression_is_true` test uses the older name `select_columns` for the same parameter
* `unique_combination_of_columns` and `res_class_matches_pardat` both permit an object structure for aliasing and aggregation, but this structure is not supported in other generics, and the two generics that do support it implement it differently

This PR represents an attempt to resolve these issues and standardize our implementation of `additional_select_columns` attributes using a new macro `format_additional_select_columns`.

Closes https://github.com/ccao-data/data-architecture/issues/330.