### PR TITLE
Update `cleanup_dbt_resources` for seeds and fix `location.neighborhood_group.nbhd` type

### DIFF
--- a/.github/scripts/cleanup_dbt_resources.sh
+++ b/.github/scripts/cleanup_dbt_resources.sh
@@ -36,7 +36,7 @@ if [ "$1" == "prod" ]; then
     exit 1
 fi
 
-schemas_json=$(dbt --quiet list --resource-type model --target "$1" \
+schemas_json=$(dbt --quiet list --resource-types model seed --target "$1" \
     --exclude config.materialized:ephemeral --output json --output-keys schema \
 ) || (\
     echo "Error in dbt call" && exit 1

--- a/dbt/seeds/location/schema.yml
+++ b/dbt/seeds/location/schema.yml
@@ -1,6 +1,10 @@
 seeds:
   - name: location.neighborhood_group
     description: '{{ doc("seed_neighborhood_group") }}'
+    config:
+      column_types:
+        # Set nbhd to varchar, or else it gets automatically parsed as integer
+        nbhd: varchar
 
     columns:
       - name: nbhd


### PR DESCRIPTION
This PR implements two small changes I neglected to include as part of https://github.com/ccao-data/data-architecture/pull/343:

1. Updating the `cleanup_dbt_resources` workflow so that it determines which staging schemas to delete based on seeds as well as models
2. Manually overriding the column type for `location.neighborhood_group.nbhd` so that it gets parsed as a string rather than an integer

Note that excluding change 1 from #343 didn't actually cause a bug in the cleanup behavior. Since the only seed we have in the project is currently stored under the `location` schema, and the `location` schema is shared with other models, the cleanup workflow successfully deleted the schema based on the existence of models under the `location` schema ([evidence](https://github.com/ccao-data/data-architecture/actions/runs/8298514234/job/22712039938#step:5:27)). However, eventually we may have schemas for seeds that are not shared by any models, in which case this change will ensure that the cleanup script still works as expected.

See `"z_ci_jeancochrane-update-cleanup-dbt-resources-to-handle-seeds_location"."neighborhood_group"` for evidence that `nbhd` now has the correct type, and see [this test cleanup workflow run](https://github.com/ccao-data/data-architecture/actions/runs/8299309340/job/22714703816#step:5:27) for evidence that `cleanup_dbt_resources` continues to work correctly after this change.