### PR TITLE
Change `geography_id` type to string in `ratio_stats.py`

### DIFF
--- a/aws-glue/jobs/reporting-ratio_stats.py
+++ b/aws-glue/jobs/reporting-ratio_stats.py
@@ -261,7 +261,7 @@ def report_summarise(df, geography_id, geography_type):
         "sale_year",
     ]
 
-    df["geography_id"] = pull[geography_id]
+    df["geography_id"] = pull[geography_id].astype(str)
     df["geography_type"] = geography_type
 
     # Remove groups with less than three observations


### PR DESCRIPTION
Switching `geography_id` to string in [ratio_stats.py](https://github.com/ccao-data/data-architecture/blob/master/aws-glue/jobs/reporting-ratio_stats.py) would make reporting easier for @ccao-jardine 