### PR TITLE
Add descriptions and selected columns for all non failing tests

### DIFF
--- a/dbt/models/iasworld/schema/iasworld.addn.yml
+++ b/dbt/models/iasworld/schema/iasworld.addn.yml
@@ -91,7 +91,10 @@ sources:
                   name: iasworld_addn_cur_in_accepted_values
                   values: ['Y', 'D']
                   additional_select_columns: *select-columns
-                  config: *unique-conditions
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.addn.yml
+++ b/dbt/models/iasworld/schema/iasworld.addn.yml
@@ -94,7 +94,6 @@ sources:
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.addn.yml
+++ b/dbt/models/iasworld/schema/iasworld.addn.yml
@@ -46,11 +46,21 @@ sources:
             tests:
               - not_null:
                   name: iasworld_addn_card_not_null
+                  additional_select_columns: &select-columns-no-card
+                    - taxyr
+                    - parid
+                    - who
+                    - wen
                   config: *unique-conditions
-              - dbt_utils.accepted_range:
+                  meta:
+                    description: card should not be null
+              - accepted_range:
                   name: iasworld_addn_card_gte_1
                   min_value: 1
+                  additional_select_columns: *select-columns-no-card
                   config: *unique-conditions
+                  meta:
+                    description: card should be >= 1
           - name: cdu
             description: '{{ doc("column_cdu") }}'
           - name: chgrsn
@@ -80,17 +90,23 @@ sources:
               - accepted_values:
                   name: iasworld_addn_cur_in_accepted_values
                   values: ['Y', 'D']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: cur should be 'Y' or 'D'
           - name: deactivat
             description: '{{ doc("column_deactivat") }}'
           - name: depr
             description: Percent good from tables (based on age+cdu)
             tests:
-              - dbt_utils.accepted_range:
+              - accepted_range:
                   name: iasworld_addn_depr_between_0_and_100
                   min_value: 0
                   max_value: 100
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: depr should be between 0 and 100
           - name: eff_area
             description: Support value per line
           - name: effageovr
@@ -124,7 +140,10 @@ sources:
             tests:
               - not_null:
                   name: iasworld_addn_lline_not_null
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: lline should not be null
           - name: loaded_at
             description: '{{ doc("shared_column_loaded_at") }}'
           - name: lower
@@ -148,12 +167,23 @@ sources:
             tests:
               - not_null:
                   name: iasworld_addn_parid_not_null
+                  additional_select_columns: &select-columns-no-parid
+                    - taxyr
+                    - card
+                    - who
+                    - wen
                   config: *unique-conditions
+                  meta:
+                    description: parid should not be null
               - relationships:
                   name: iasworld_addn_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  additional_select_columns: *select-columns-no-parid
                   config: *unique-conditions
+                  meta:
+                    category: parid
+                    description: parid should be in pardat
           - name: pctcomp
             description: '{{ doc("column_pctcomp") }}'
           - name: prodamage
@@ -199,13 +229,19 @@ sources:
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_addn_seq_all_sequential_exist
                   group_by_columns:
                     - parid
                     - taxyr
                     - card
                     - lline
+                  additional_select_columns:
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: seq should be sequential
           - name: status
             description: '{{ doc("column_status") }}'
           - name: taxyr
@@ -213,7 +249,14 @@ sources:
             tests:
               - not_null:
                   name: iasworld_addn_taxyr_not_null
+                  additional_select_columns:
+                    - parid
+                    - card
+                    - who
+                    - wen
                   config: *unique-conditions
+                  meta:
+                    description: taxyr should not be null
           - name: third
             description: Third floor addition code
           - name: trans_id
@@ -245,3 +288,13 @@ sources:
                 - taxyr
                 - card
                 - lline
+              additional_select_columns:
+                - column: who
+                  alias: who
+                  agg_func: array_agg
+                - column: wen
+                  alias: wen
+                  agg_func: array_agg
+              config: *unique-conditions
+              meta:
+                description: addn should be unique by parid, taxyr, card, and lline

--- a/dbt/models/iasworld/schema/iasworld.aprval.yml
+++ b/dbt/models/iasworld/schema/iasworld.aprval.yml
@@ -122,7 +122,6 @@ sources:
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.aprval.yml
+++ b/dbt/models/iasworld/schema/iasworld.aprval.yml
@@ -62,7 +62,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: aprtot should be between 0 and 2 billion
+                    description: aprtot should be between 0 and 2,000,000,000
           - name: areasum
             description: '{{ doc("column_areasum") }}'
           - name: assmkt

--- a/dbt/models/iasworld/schema/iasworld.aprval.yml
+++ b/dbt/models/iasworld/schema/iasworld.aprval.yml
@@ -119,7 +119,10 @@ sources:
                   name: iasworld_aprval_cur_in_accepted_values
                   values: ['Y', 'D']
                   additional_select_columns: *select-columns
-                  config: *unique-conditions
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.aprval.yml
+++ b/dbt/models/iasworld/schema/iasworld.aprval.yml
@@ -38,7 +38,7 @@ sources:
                       AND cur = 'Y'
                       AND deactivat IS NULL
                   meta:
-                    description: aprbldg must be between 0 and 1 billion
+                    description: aprbldg should be between 0 and 1 billion
           - name: aprdate
             description: '`APRTOT` calc date'
           - name: aprland
@@ -51,7 +51,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: aprland must be between 0 and 1 billion
+                    description: aprland should be between 0 and 1 billion
           - name: aprtot
             description: '{{ doc("column_aprtot") }}'
             tests:
@@ -62,7 +62,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: aprtot must be between 0 and 2 billion
+                    description: aprtot should be between 0 and 2 billion
           - name: areasum
             description: '{{ doc("column_areasum") }}'
           - name: assmkt
@@ -72,11 +72,14 @@ sources:
           - name: bldgval
             description: Building value
             tests:
-              - dbt_utils.accepted_range:
+              - accepted_range:
                   name: iasworld_aprval_bldgval_between_0_and_1b
                   min_value: 0
                   max_value: 1000000000
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: bldgval should be between 0 and 1 billion
           - name: comincval
             description: Commercial income value
           - name: commktsf
@@ -115,6 +118,10 @@ sources:
               - accepted_values:
                   name: iasworld_aprval_cur_in_accepted_values
                   values: ['Y', 'D']
+                  additional_select_columns: *select-columns
+                  config: *unique-conditions
+                  meta:
+                    description: cur should be 'Y' or 'D'
           - name: deactivat
             description: '{{ doc("column_deactivat") }}'
           - name: dwelval
@@ -165,7 +172,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: landval must be between 0 and 1 billion
+                    description: landval should be between 0 and 1 billion
           - name: lastupd
             description: Date of last change to a value field
           - name: loaded_at
@@ -199,12 +206,22 @@ sources:
             tests:
               - not_null:
                   name: iasworld_aprval_parid_not_null
+                  additional_select_columns: &select-columns-no-parid
+                    - taxyr
+                    - who
+                    - wen
                   config: *unique-conditions
+                  meta:
+                    description: aprval should not be null
               - relationships:
                   name: iasworld_aprval_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  additional_select_columns: *select-columns-no-parid
                   config: *unique-conditions
+                  meta:
+                    category: parid
+                    description: parid should be in pardat
           - name: posttype
             description: Assessment posting type
           - name: ppcomval
@@ -248,11 +265,17 @@ sources:
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_aprval_seq_all_sequential_exist
                   group_by_columns:
                     - parid
                     - taxyr
+                  additional_select_columns:
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: seq should be sequential
           - name: spcflg
             description: Special processing flag
           - name: splitno
@@ -268,7 +291,13 @@ sources:
             tests:
               - not_null:
                   name: iasworld_aprval_taxyr_not_null
+                  additional_select_columns:
+                    - parid
+                    - who
+                    - wen
                   config: *unique-conditions
+                  meta:
+                    description: taxyr should not be null
           - name: tiebackbldg
             description: Sum of building value for all children in the income tieback group
           - name: tiebackland
@@ -298,3 +327,13 @@ sources:
               combination_of_columns:
                 - parid
                 - taxyr
+              additional_select_columns:
+                - column: who
+                  alias: who
+                  agg_func: array_agg
+                - column: wen
+                  alias: wen
+                  agg_func: array_agg
+              config: *unique-conditions
+              meta:
+                description: aprval should be unique by parid and taxyr

--- a/dbt/models/iasworld/schema/iasworld.aprval.yml
+++ b/dbt/models/iasworld/schema/iasworld.aprval.yml
@@ -215,7 +215,7 @@ sources:
                     - wen
                   config: *unique-conditions
                   meta:
-                    description: aprval should not be null
+                    description: parid should not be null
               - relationships:
                   name: iasworld_aprval_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')

--- a/dbt/models/iasworld/schema/iasworld.aprval.yml
+++ b/dbt/models/iasworld/schema/iasworld.aprval.yml
@@ -38,7 +38,7 @@ sources:
                       AND cur = 'Y'
                       AND deactivat IS NULL
                   meta:
-                    description: aprbldg should be between 0 and 1 billion
+                    description: aprbldg should be between 0 and 1,000,000,000
           - name: aprdate
             description: '`APRTOT` calc date'
           - name: aprland
@@ -51,7 +51,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: aprland should be between 0 and 1 billion
+                    description: aprland should be between 0 and 1,000,000,000
           - name: aprtot
             description: '{{ doc("column_aprtot") }}'
             tests:
@@ -79,7 +79,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: bldgval should be between 0 and 1 billion
+                    description: bldgval should be between 0 and 1,000,000,000
           - name: comincval
             description: Commercial income value
           - name: commktsf
@@ -172,7 +172,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: landval should be between 0 and 1 billion
+                    description: landval should be between 0 and 1,000,000,000
           - name: lastupd
             description: Date of last change to a value field
           - name: loaded_at

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -154,9 +154,7 @@ sources:
                   additional_select_columns:
                     - who
                     - wen
-                  config:
-                    <<: *unique-conditions
-                    error_if: ">15300"
+                  config: *unique-conditions
                   meta:
                     description: seq should be sequential
           - name: splitno

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -115,7 +115,12 @@ sources:
                   name: iasworld_asmt_all_procname_in_accepted_values
                   values: ['CCAOVALUE', 'CCAOFINAL', 'BORVALUE', 'CONVERT']
                   additional_select_columns: *select-columns
-                  config: *unique-conditions
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND rolltype != 'RR'
+                      AND deactivat IS NULL
+                      AND valclass IS NULL
                   meta:
                     description: >
                       procname should be 'CCAOVALUE', 'CCAOFINAL', 'BORVALUE', or 'CONVERT'

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -64,7 +64,9 @@ sources:
                   name: iasworld_asmt_all_cur_in_accepted_values
                   values: ['Y', 'D', 'N']
                   additional_select_columns: *select-columns
-                  config: *unique-conditions
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                   meta:
                     description: cur should be 'Y', 'D', or 'N'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -63,6 +63,10 @@ sources:
               - accepted_values:
                   name: iasworld_asmt_all_cur_in_accepted_values
                   values: ['Y', 'D', 'N']
+                  additional_select_columns: *select-columns
+                  config: *unique-conditions
+                  meta:
+                    description: cur should be 'Y', 'D', or 'N'
           - name: deactivat
             description: '{{ doc("column_deactivat") }}'
           - name: distcode
@@ -86,12 +90,22 @@ sources:
             tests:
               - not_null:
                   name: iasworld_asmt_all_parid_not_null
+                  additional_select_columns: &select-columns-no-parid
+                    - taxyr
+                    - who
+                    - wen
                   config: *unique-conditions
+                  meta:
+                    description: parid should not be null
               - relationships:
                   name: iasworld_asmt_all_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  additional_select_columns: *select-columns-no-parid
                   config: *unique-conditions
+                  meta:
+                    category: parid
+                    description: parid should be in pardat
           - name: procdate
             description: '{{ doc("column_procdate") }}'
           - name: procname
@@ -100,6 +114,11 @@ sources:
               - accepted_values:
                   name: iasworld_asmt_all_procname_in_accepted_values
                   values: ['CCAOVALUE', 'CCAOFINAL', 'BORVALUE', 'CONVERT']
+                  additional_select_columns: *select-columns
+                  config: *unique-conditions
+                  meta:
+                    description: >
+                      procname should be 'CCAOVALUE', 'CCAOFINAL', 'BORVALUE', or 'CONVERT'
           - name: reascd
             description: Reason code for change in assessed value
           - name: rolltype
@@ -119,15 +138,20 @@ sources:
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_asmt_all_seq_all_sequential_exist
                   group_by_columns:
                     - parid
                     - taxyr
                     - procname
+                  additional_select_columns:
+                    - who
+                    - wen
                   config:
                     <<: *unique-conditions
                     error_if: ">15300"
+                  meta:
+                    description: seq should be sequential
           - name: splitno
             description: '{{ doc("column_splitno") }}'
           - name: status
@@ -139,7 +163,13 @@ sources:
             tests:
               - not_null:
                   name: iasworld_asmt_all_taxyr_not_null
+                  additional_select_columns:
+                    - parid
+                    - who
+                    - wen
                   config: *unique-conditions
+                  meta:
+                    description: taxyr should not be null
           - name: tottax
             description: Total tax
           - name: trans_id

--- a/dbt/models/iasworld/schema/iasworld.comdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.comdat.yml
@@ -153,7 +153,10 @@ sources:
                   name: iasworld_comdat_cur_in_accepted_values
                   values: ['Y', 'D']
                   additional_select_columns: *select-columns
-                  config: *unique-conditions
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.comdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.comdat.yml
@@ -156,7 +156,6 @@ sources:
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.comdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.comdat.yml
@@ -18,15 +18,23 @@ sources:
           - name: adjfact
             description: '{{ doc("column_adjfact") }}'
             tests:
-              - dbt_utils.accepted_range:
+              - accepted_range:
                   name: iasworld_comdat_adjfact_between_0_and_1
                   min_value: 0
                   max_value: 1
+                  additional_select_columns: &select-columns
+                    - parid
+                    - taxyr
+                    - card
+                    - who
+                    - wen
                   config: &unique-conditions
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND cur = 'Y'
                       AND deactivat IS NULL
+                  meta:
+                    description: adjfact should be between 0 and 1
           - name: areasum
             description: '{{ doc("column_areasum") }}'
           - name: bld_modelid
@@ -38,11 +46,14 @@ sources:
           - name: bldgval
             description: Building value
             tests:
-              - dbt_utils.accepted_range:
+              - accepted_range:
                   name: iasworld_comdat_bldgval_between_0_and_1b
                   min_value: 0
                   max_value: 1000000000
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: bldgval should be between 0 and 1,000,000,000
           - name: bldnum
             description: Building number
           - name: busla
@@ -55,12 +66,7 @@ sources:
               - accepted_values:
                   name: iasworld_comdat_calc_meth_accepted_values
                   values: ["E"]
-                  additional_select_columns: &select-columns
-                    - parid
-                    - taxyr
-                    - card
-                    - who
-                    - wen
+                  additional_select_columns: *select-columns
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
@@ -68,17 +74,27 @@ sources:
                       AND deactivat IS NULL
                       AND calc_meth IS NOT NULL
                   meta:
-                    description: calc_meth should be null or 'E'
+                    description: calc_meth should be 'E' if not null
           - name: card
             description: '{{ doc("column_card") }}'
             tests:
               - not_null:
                   name: iasworld_comdat_card_not_null
+                  additional_select_columns: &select-columns-no-card
+                    - parid
+                    - taxyr
+                    - who
+                    - wen
                   config: *unique-conditions
-              - dbt_utils.accepted_range:
+                  meta:
+                    description: card should not be null
+              - accepted_range:
                   name: iasworld_comdat_card_gte_1
                   min_value: 1
+                  additional_select_columns: *select-columns-no-card
                   config: *unique-conditions
+                  meta:
+                    description: card should be >= 1
           - name: cdu
             description: '{{ doc("column_cdu") }}'
           - name: chgrsn
@@ -120,11 +136,14 @@ sources:
           - name: convbldg
             description: '{{ doc("column_convbldg") }}'
             tests:
-              - dbt_utils.accepted_range:
+              - accepted_range:
                   name: iasworld_comdat_convbldg_between_0_and_1b
                   min_value: 0
                   max_value: 1000000000
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: convbldg should be between 0 and 1,000,000,000
           - name: cubicft
             description: Cubic feet
           - name: cur
@@ -133,16 +152,23 @@ sources:
               - accepted_values:
                   name: iasworld_comdat_cur_in_accepted_values
                   values: ['Y', 'D']
+                  additional_select_columns: *select-columns
+                  config: *unique-conditions
+                  meta:
+                    description: cur should be 'Y' or 'D'
           - name: deactivat
             description: '{{ doc("column_deactivat") }}'
           - name: depr
             description: Percent good from tables
             tests:
-              - dbt_utils.accepted_range:
+              - accepted_range:
                   name: iasworld_comdat_depr_between_0_and_1
                   min_value: 0
                   max_value: 1
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: depr should be between 0 and 1
           - name: deprt
             description: '{{ doc("column_deprt") }}'
           - name: effageovr
@@ -154,11 +180,14 @@ sources:
           - name: exmppct
             description: '{{ doc("column_exmppct") }}'
             tests:
-              - dbt_utils.accepted_range:
+              - accepted_range:
                   name: iasworld_comdat_exmppct_between_0_and_100
                   min_value: 0
                   max_value: 100
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: exmppct should be between 0 and 100
           - name: exmpval
             description: '{{ doc("column_exmpval") }}'
           - name: external_calc_rcnld
@@ -284,12 +313,18 @@ sources:
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_comdat_seq_all_sequential_exist
                   group_by_columns:
                     - parid
                     - taxyr
                     - card
+                  additional_select_columns:
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: seq should be sequential
           - name: status
             description: '{{ doc("column_status") }}'
           - name: structure
@@ -321,20 +356,18 @@ sources:
             tests:
               - not_null:
                   name: iasworld_comdat_yrblt_not_null
-                  additional_select_columns:
-                    - taxyr
-                    - parid
-                    - card
-                    - who
-                    - wen
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
                     description: yrblt should not be null
-              - dbt_utils.accepted_range:
+              - accepted_range:
                   name: iasworld_comdat_yrblt_between_1850_and_now
                   min_value: 1850
                   max_value: cast(year(current_date) as decimal)
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: yrblt should be between 1850 and now
 
         tests:
           - unique_combination_of_columns:
@@ -343,3 +376,13 @@ sources:
                 - parid
                 - taxyr
                 - card
+              additional_select_columns:
+                - column: who
+                  alias: who
+                  agg_func: array_agg
+                - column: wen
+                  alias: wen
+                  agg_func: array_agg
+              config: *unique-conditions
+              meta:
+                description: comdat should be unique by parid, card, and year

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -69,6 +69,7 @@ sources:
               - accepted_values:
                   name: iasworld_dweldat_attic_in_accepted_values
                   values: ['1', '2', '3', '4', '5']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
                     description: >
@@ -135,11 +136,21 @@ sources:
             tests:
               - not_null:
                   name: iasworld_dweldat_card_not_null
+                  additional_select_columns: &select-columns-no-card
+                    - parid
+                    - taxyr
+                    - who
+                    - wen
                   config: *unique-conditions
-              - dbt_utils.accepted_range:
+                  meta:
+                    description: card should not be null
+              - accepted_range:
                   name: iasworld_dweldat_card_gte_1
                   min_value: 1
+                  additional_select_columns: *select-columns-no-card
                   config: *unique-conditions
+                  meta:
+                    description: card should be >= 1
           - name: catharea
             description: Cathedral ceiling area
           - name: cathval
@@ -221,6 +232,14 @@ sources:
               - accepted_values:
                   name: iasworld_dweldat_cur_in_accepted_values
                   values: ['Y', 'D']
+                  additional_select_columns: *select-columns
+                  config:
+                    where: |
+                        CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                        AND deactivat IS NULL
+                        AND class NOT IN ('201', '213', '218', '219', '220', '221', '224', '225', '236', '240', '241', '290', '294', '297')
+                  meta:
+                    description: cur should be 'Y' or 'D'
           - name: deactivat
             description: '{{ doc("column_deactivat") }}'
           - name: degrem
@@ -586,11 +605,23 @@ sources:
             tests:
               - not_null:
                   name: iasworld_dweldat_parid_not_null
+                  additional_select_columns: &select-columns-no-parid
+                    - taxyr
+                    - card
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: parid should not be null
               - relationships:
                   name: iasworld_dweldat_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  additional_select_columns: *select-columns-no-parid
                   config: *unique-conditions
+                  meta:
+                    category: parid
+                    description: parid should be in pardat
           - name: pctcomplete
             description: Percent of construction completed
           - name: plumbgrade
@@ -798,18 +829,27 @@ sources:
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_dweldat_seq_all_sequential_exist
                   group_by_columns:
                     - parid
                     - taxyr
                     - card
+                  additional_select_columns:
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: seq should be sequential
           - name: sfla
             description: '{{ doc("shared_column_char_bldg_sf") }}'
             tests:
               - not_null:
                   name: iasworld_dweldat_sfla_not_null
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: sfla should not be null
               - accepted_range:
                   name: iasworld_dweldat_sfla_sf_between_1_and_10000
                   min_value: 1
@@ -886,6 +926,14 @@ sources:
             tests:
               - not_null:
                   name: iasworld_dweldat_taxyr_not_null
+                  additional_select_columns:
+                    - parid
+                    - card
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: taxyr should not be null
           - name: trans_id
             description: '{{ doc("column_trans_id") }}'
           - name: trimval
@@ -920,7 +968,11 @@ sources:
               - accepted_values:
                   name: iasworld_dweldat_char_renovation_in_accepted_values
                   values: ['0', '1']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: >
+                      user3 (property renovation indicator) should be '0' or '1'
           - name: user4
             description: '{{ doc("shared_column_char_tp_dsgn") }}'
             tests:
@@ -949,7 +1001,10 @@ sources:
               - accepted_values:
                   name: iasworld_dweldat_char_tp_plan_in_accepted_values
                   values: ['0', '1', '2']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: user5 (design plan) should be '0', '1', or '2'
           - name: user6
             description: '{{ doc("shared_column_char_attic_fnsh") }}'
             tests:
@@ -962,7 +1017,10 @@ sources:
               - accepted_values:
                   name: iasworld_dweldat_char_attic_fnsh_in_accepted_values
                   values: ['1', '2', '3']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: user6 (attic finish) should be '1', '2', or '3'
           - name: user7
             description: '{{ doc("shared_column_char_air") }}'
             tests:
@@ -975,7 +1033,10 @@ sources:
               - accepted_values:
                   name: iasworld_dweldat_char_air_accepted_values
                   values: ['1', '2']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: user7 (central air indicator) should be '1' or '2'
           - name: user12
             description: '{{ doc("shared_column_char_bsmt_fin") }}'
             tests:
@@ -1005,7 +1066,11 @@ sources:
               - accepted_values:
                   name: iasworld_dweldat_char_roof_cnst_accepted_values
                   values: ['1', '2', '3', '4', '5', '6']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: >
+                      user13 (roof material) should be an integer between 1 and 6
           - name: user14
             description: '{{ doc("shared_column_char_apts") }}'
             tests:
@@ -1045,11 +1110,14 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      user15 (single or multi-family use) should not be null
+                      user15 (single- or multi-family use) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_use_accepted_values
                   values: ['1', '2']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: user15 (single- or multi-family use) should be '1' or '2'
           - name: user17
             description: Age. Deprecated, use `yrblt`
           - name: user20
@@ -1083,7 +1151,10 @@ sources:
               - accepted_values:
                   name: iasworld_dweldat_char_porch_accepted_values
                   values: ['0', '1', '2']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: user30 (porch type) should be '0', '1', or '2'
           - name: user31
             description: '{{ doc("shared_column_char_gar_att") }}'
             tests:
@@ -1097,7 +1168,11 @@ sources:
               - accepted_values:
                   name: iasworld_dweldat_char_gar_att_accepted_values
                   values: ['1', '2']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: >
+                      user31 (attached garage indicator) should be '1' or '2'
           - name: user32
             description: '{{ doc("shared_column_char_gar_area") }}'
             tests:
@@ -1111,7 +1186,11 @@ sources:
               - accepted_values:
                   name: iasworld_dweldat_char_gar_area_accepted_values
                   values: ['1', '2']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: >
+                      user32 (garage area inclusion indicator) should be '1' or '2'
           - name: user33
             description: '{{ doc("shared_column_char_gar_size") }}'
             tests:
@@ -1228,6 +1307,16 @@ sources:
                 - parid
                 - taxyr
                 - card
+              additional_select_columns:
+                - column: who
+                  alias: who
+                  agg_func: array_agg
+                - column: wen
+                  alias: wen
+                  agg_func: array_agg
+              config: *unique-conditions
+              meta:
+                description: dweldat should be unique by parid, card, and taxyr
           - expression_is_true:
               name: iasworld_dweldat_card_proration_rate_between_0_and_100
               expression: 'CAST(user24 AS decimal) BETWEEN 0.00 AND 100.00'

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -236,8 +236,6 @@ sources:
                   config:
                     where: |
                         CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                        AND deactivat IS NULL
-                        AND class NOT IN ('201', '213', '218', '219', '220', '221', '224', '225', '236', '240', '241', '290', '294', '297')
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1343,8 +1343,9 @@ sources:
                 - user20
               config: *unique-conditions
               meta:
-                category: missing_values
-                description: user24 (proration rate) should not be null
+                category: incorrect_values
+                description: >
+                  user20 (num. commercial units) should be an integer between 0 and 5
           - expression_is_true:
               name: iasworld_dweldat_bsmt_and_user12_match_234_class
               expression: bsmt = '3' and user12 = '1'

--- a/dbt/models/iasworld/schema/iasworld.htagnt.yml
+++ b/dbt/models/iasworld/schema/iasworld.htagnt.yml
@@ -127,3 +127,12 @@ sources:
               name: iasworld_htagnt_unique_by_agent
               combination_of_columns:
                 - agent
+              additional_select_columns:
+                - column: who
+                  alias: who
+                  agg_func: array_agg
+                - column: wen
+                  alias: wen
+                  agg_func: array_agg
+              meta:
+                description: htagnt should be unique by agent

--- a/dbt/models/iasworld/schema/iasworld.htpar.yml
+++ b/dbt/models/iasworld/schema/iasworld.htpar.yml
@@ -78,7 +78,6 @@ sources:
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: curbldg

--- a/dbt/models/iasworld/schema/iasworld.htpar.yml
+++ b/dbt/models/iasworld/schema/iasworld.htpar.yml
@@ -70,6 +70,17 @@ sources:
               - accepted_values:
                   name: iasworld_htpar_cur_in_accepted_values
                   values: ['Y', 'D']
+                  additional_select_columns: &select-columns
+                    - taxyr
+                    - parid
+                    - who
+                    - wen
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND deactivat IS NULL
+                  meta:
+                    description: cur should be 'Y' or 'D'
           - name: curbldg
             description: Current building value
           - name: curland
@@ -104,11 +115,14 @@ sources:
               - accepted_values:
                   name: iasworld_htpar_hrstatus_in_accepted_values
                   values: ['C', 'O', 'P', 'X']
+                  additional_select_columns: *select-columns
                   config: &unique-conditions
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND cur = 'Y'
                       AND deactivat IS NULL
+                  meta:
+                    description: hrstatus should be 'C', 'O', 'P', or 'X'
           - name: httimejur
             description: Schedule jurisdiction
           - name: iasw_id
@@ -168,12 +182,22 @@ sources:
             tests:
               - not_null:
                   name: iasworld_htpar_parid_not_null
+                  additional_select_columns: &select-columns-no-parid
+                    - taxyr
+                    - who
+                    - wen
                   config: *unique-conditions
+                  meta:
+                    description: parid should not be null
               - relationships:
                   name: iasworld_htpar_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
+                  additional_select_columns: *select-columns-no-parid
                   config: *unique-conditions
+                  meta:
+                    category: parid
+                    description: parid should be in pardat
           - name: petemail
             description: Petitioner email address
           - name: petfax
@@ -229,13 +253,17 @@ sources:
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_htpar_seq_all_sequential_exist
                   group_by_columns:
                     - parid
                     - taxyr
                     - caseno
                     - subkey
+                  additional_select_columns:
+                    - who
+                    - wen
+                  config: *unique-conditions
                   meta:
                     description: seq must be sequential
           - name: status
@@ -257,6 +285,13 @@ sources:
             tests:
               - not_null:
                   name: iasworld_htpar_taxyr_not_null
+                  additional_select_columns:
+                    - parid
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: taxyr should not be null
           - name: trans_id
             description: '{{ doc("column_trans_id") }}'
           - name: txpyval
@@ -269,7 +304,7 @@ sources:
               - accepted_values:
                   name: iasworld_htpar_user38_in_accepted_values
                   values: ['RS', 'IC', 'CC', 'CE', 'CI', 'CO', 'CV', 'IM', 'LD', 'OM', 'RC']
-                  additional_select_columns: ["taxyr", "parid", "who", "wen"]
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
                     description: >
@@ -297,9 +332,19 @@ sources:
                 - caseno
                 - taxyr
                 - subkey
+              additional_select_columns:
+                - column: who
+                  alias: who
+                  agg_func: array_agg
+                - column: wen
+                  alias: wen
+                  agg_func: array_agg
               config:
                 <<: *unique-conditions
                 error_if: ">2"
+              meta:
+                description: >
+                  htpar should be unique by parid, caseno, taxyr, and subkey
           - no_extra_whitespace:
               name: iasworld_htpar_address_columns_no_whitespace
               column_names:

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -128,8 +128,6 @@ sources:
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND class NOT IN ('EX', 'RR')
-                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -124,6 +124,14 @@ sources:
               - accepted_values:
                   name: iasworld_land_cur_in_accepted_values
                   values: ['Y', 'D']
+                  additional_select_columns: *select-columns
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND class NOT IN ('EX', 'RR')
+                      AND deactivat IS NULL
+                  meta:
+                    description: cur should be 'Y' or 'D'
           - name: deactivat
             description: '{{ doc("column_deactivat") }}'
           - name: depfact
@@ -157,11 +165,14 @@ sources:
           - name: influ
             description: Influence percent (+/-)
             tests:
-              - dbt_utils.accepted_range:
+              - accepted_range:
                   name: iasworld_land_influ_between_neg_100_and_pos_100
                   min_value: -100
                   max_value: 100
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: influ should be between -100 and 100
           - name: influ2
             description: Influence percent (+/-)
           - name: jur
@@ -173,11 +184,13 @@ sources:
           - name: lline
             description: '{{ doc("shared_column_lline") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_land_lline_is_sequential
                   group_by_columns:
                     - parid
                     - taxyr
+                  additional_select_columns: *select-columns
+                  config: *unique-conditions
                   meta:
                     description: lline should be sequential
           - name: lmod
@@ -231,11 +244,19 @@ sources:
             tests:
               - not_null:
                   name: iasworld_land_parid_not_null
+                  additional_select_columns: &select-columns-no-parid
+                    - taxyr
+                    - card
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: parid should not be null
               - relationships:
                   name: iasworld_land_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
-                  additional_select_columns: ["taxyr", "card", "who", "wen"]
+                  additional_select_columns: *select-columns-no-parid
                   config: *unique-conditions
                   meta:
                     category: parid
@@ -264,16 +285,21 @@ sources:
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_land_seq_all_sequential_exist
                   group_by_columns:
                     - parid
                     - taxyr
                     - lline
+                  additional_select_columns:
+                    - who
+                    - wen
                   config:
                     where:
                       cur = 'Y'
                       AND deactivat IS NULL
+                  meta:
+                    description: seq should be sequential
           - name: sf
             description: '{{ doc("shared_column_char_land_sf") }}'
             tests:
@@ -307,6 +333,13 @@ sources:
             tests:
               - not_null:
                   name: iasworld_land_taxyr_not_null
+                  additional_select_columns:
+                    - parid
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: taxyr should not be null
           - name: topofact
             description: Topography Factor
           - name: trans_id
@@ -337,3 +370,16 @@ sources:
                 - parid
                 - lline
                 - taxyr
+              additional_select_columns:
+                - column: card
+                  alias: card
+                  agg_func: array_agg
+                - column: who
+                  alias: who
+                  agg_func: array_agg
+                - column: wen
+                  alias: wen
+                  agg_func: array_agg
+              config: *unique-conditions
+              meta:
+                description: land should be unique by parid, lline, and taxyr

--- a/dbt/models/iasworld/schema/iasworld.legdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.legdat.yml
@@ -100,7 +100,6 @@ sources:
                   config:
                     where:
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.legdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.legdat.yml
@@ -96,6 +96,13 @@ sources:
               - accepted_values:
                   name: iasworld_legdat_cur_in_accepted_values
                   values: ['Y', 'D']
+                  additional_select_columns: *select-columns
+                  config:
+                    where:
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND deactivat IS NULL
+                  meta:
+                    description: cur should be 'Y' or 'D'
           - name: deactivat
             description: '{{ doc("column_deactivat") }}'
           - name: floorno
@@ -127,11 +134,18 @@ sources:
             tests:
               - not_null:
                   name: iasworld_legdat_parid_not_null
+                  additional_select_columns: &select-columns-no-parid
+                    - taxyr
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: parid should not be null
               - relationships:
                   name: iasworld_legdat_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
-                  additional_select_columns: ["taxyr", "who", "wen"]
+                  additional_select_columns: *select-columns-no-parid
                   config: *unique-conditions
                   meta:
                     category: parid
@@ -161,12 +175,17 @@ sources:
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_legdat_seq_all_sequential_exist
                   group_by_columns:
                     - parid
                     - taxyr
+                  additional_select_columns:
+                    - who
+                    - wen
                   config: *unique-conditions
+                  meta:
+                    description: seq should be sequential
           - name: sortkey
             description: Block, lot and qualifier, reformatted for sorting
           - name: splitno
@@ -181,7 +200,10 @@ sources:
               - accepted_values:
                   name: iasworld_legdat_statecode_in_accepted_values
                   values: ['IL']
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: statecode should be 'IL'
           - name: status
             description: '{{ doc("column_status") }}'
           - name: strcd
@@ -217,6 +239,13 @@ sources:
             tests:
               - not_null:
                   name: iasworld_legdat_taxyr_not_null
+                  additional_select_columns:
+                    - parid
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: taxyr should not be null
           - name: trans_id
             description: '{{ doc("column_trans_id") }}'
           - name: unitdesc
@@ -233,12 +262,15 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user1 should not be null
+                    description: user1 (township code) should not be null
               - relationships:
                   name: iasworld_legdat_user1_in_spatial_township_township_code
                   to: source('spatial', 'township')
                   field: township_code
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: user1 (township code) should be valid
           - name: wen
             description: '{{ doc("shared_column_updated_at") }}'
           - name: wencalc
@@ -286,6 +318,16 @@ sources:
               combination_of_columns:
                 - parid
                 - taxyr
+              additional_select_columns:
+                - column: who
+                  alias: who
+                  agg_func: array_agg
+                - column: wen
+                  alias: wen
+                  agg_func: array_agg
+              config: *unique-conditions
+              meta:
+                description: legdat should be unique by parid and taxyr
           # Not using column_length here because adrno needs to be cast first
           - expression_is_true:
               name: iasworld_legdat_adrno_length_lte_5

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -62,7 +62,7 @@ sources:
                       AND deactivat IS NULL
                       AND calc_meth IS NOT NULL
                   meta:
-                    description: calc_meth should be null or 'E'
+                    description: calc_meth should be 'E' if not null
           - name: card
             description: '{{ doc("column_card") }}'
             tests:
@@ -83,19 +83,24 @@ sources:
                   name: iasworld_oby_chgrsn_eq_5_mktadj_not_null
                   expression: |
                     != '5' OR mktadj IS NOT NULL
-                  config: *unique-conditions
-          - name: class
-            description: '{{ doc("shared_column_class") }}'
-            tests:
-              - not_accepted_values:
-                  name: iasworld_oby_class_mismatch_no_289s
-                  values: ["289"]
                   additional_select_columns:
                     - taxyr
                     - parid
                     - card
                     - who
                     - wen
+                    - mktadj
+                  config: *unique-conditions
+                  meta:
+                    category: incorrect_values
+                    description: chgrsn should only be 5 if mktadj is not null
+          - name: class
+            description: '{{ doc("shared_column_class") }}'
+            tests:
+              - not_accepted_values:
+                  name: iasworld_oby_class_mismatch_no_289s
+                  values: ["289"]
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
                     category: class_mismatch_or_issue
@@ -144,6 +149,13 @@ sources:
               - accepted_values:
                   name: iasworld_oby_cur_in_accepted_values
                   values: ['Y', 'D']
+                  additional_select_columns: *select-columns
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND deactivat IS NULL
+                  meta:
+                    description: cur should be 'Y' or 'D'
           - name: curmult
             description: Current multiplier
           - name: deactivat
@@ -237,11 +249,14 @@ sources:
           - name: lline
             description: '{{ doc("shared_column_lline") }}'
             tests:
-              - dbt_utils.accepted_range:
+              - accepted_range:
                   name: iasworld_oby_lline_between_1_and_100
                   min_value: 1
                   max_value: 100
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: lline should be between 1 and 100
           - name: loaded_at
             description: '{{ doc("shared_column_loaded_at") }}'
           - name: locmult
@@ -331,13 +346,19 @@ sources:
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_oby_seq_all_sequential_exist
                   group_by_columns:
                     - parid
                     - taxyr
                     - card
                     - lline
+                  additional_select_columns:
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: seq should be sequential
           - name: status
             description: '{{ doc("column_status") }}'
           - name: stories
@@ -349,6 +370,14 @@ sources:
             tests:
               - not_null:
                   name: iasworld_oby_taxyr_not_null
+                  additional_select_columns:
+                    - parid
+                    - card
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: taxyr should not be null
           - name: trans_id
             description: '{{ doc("column_trans_id") }}'
           - name: units
@@ -401,3 +430,14 @@ sources:
                 - card
                 - lline
                 - taxyr
+              additional_select_columns:
+                - column: who
+                  alias: who
+                  agg_func: array_agg
+                - column: wen
+                  alias: wen
+                  agg_func: array_agg
+              config: *unique-conditions
+              meta:
+                description: >
+                  oby should be unique by parid, card, lline, and taxyr

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -153,7 +153,6 @@ sources:
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: curmult

--- a/dbt/models/iasworld/schema/iasworld.owndat.yml
+++ b/dbt/models/iasworld/schema/iasworld.owndat.yml
@@ -76,7 +76,6 @@ sources:
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.owndat.yml
+++ b/dbt/models/iasworld/schema/iasworld.owndat.yml
@@ -73,6 +73,10 @@ sources:
                     - parid
                     - who
                     - wen
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat
@@ -158,15 +162,26 @@ sources:
             tests:
               - not_null:
                   name: iasworld_owndat_parid_not_null
-              - relationships:
-                  name: iasworld_owndat_parid_in_pardat_parid
-                  to: source('iasworld', 'pardat')
-                  field: parid
+                  additional_select_columns: &select-columns-no-parid
+                    - taxyr
+                    - who
+                    - wen
                   config: &unique-conditions
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND cur = 'Y'
                       AND deactivat IS NULL
+                  meta:
+                    description: parid should not be null
+              - relationships:
+                  name: iasworld_owndat_parid_in_pardat_parid
+                  to: source('iasworld', 'pardat')
+                  field: parid
+                  additional_select_columns: *select-columns-no-parid
+                  config: *unique-conditions
+                  meta:
+                    category: parid
+                    description: parid should be in pardat
           - name: partial
             description: '{{ doc("column_partial") }}'
           - name: pctown
@@ -184,11 +199,17 @@ sources:
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_owndat_seq_all_sequential_exist
                   group_by_columns:
                     - parid
                     - taxyr
+                  additional_select_columns:
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: seq should be sequential
           - name: site
             description: '{{ doc("column_site") }}'
           - name: skip_addr_validation
@@ -230,6 +251,16 @@ sources:
               combination_of_columns:
                 - parid
                 - taxyr
+              additional_select_columns:
+                - column: who
+                  alias: who
+                  agg_func: array_agg
+                - column: wen
+                  alias: wen
+                  agg_func: array_agg
+              config: *unique-conditions
+              meta:
+                description: owndat should be unique by parid and taxyr
           - no_extra_whitespace:
               name: iasworld_owndat_address_columns_no_extra_whitespace
               column_names:

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -100,6 +100,13 @@ sources:
               - accepted_values:
                   name: iasworld_pardat_cur_in_accepted_values
                   values: ['Y', 'D']
+                  additional_select_columns: *select-columns
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND deactivat IS NULL
+                  meta:
+                    description: cur should be 'Y' or 'D'
           - name: deactivat
             description: '{{ doc("column_deactivat") }}'
           - name: farminc
@@ -203,16 +210,21 @@ sources:
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
             tests:
-              - dbt_utils.sequential_values:
+              - sequential_values:
                   name: iasworld_pardat_seq_all_sequential_exist
                   group_by_columns:
                     - parid
                     - taxyr
+                  additional_select_columns:
+                    - who
+                    - wen
                   config: &unique-conditions
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND cur = 'Y'
                       AND deactivat IS NULL
+                  meta:
+                    description: seq should be sequential
           - name: skip_addr_validation
             description: '{{ doc("column_skip_addr_validation") }}'
           - name: splitno
@@ -301,6 +313,16 @@ sources:
               combination_of_columns:
                 - parid
                 - taxyr
+              additional_select_columns:
+                - column: who
+                  alias: who
+                  agg_func: array_agg
+                - column: wen
+                  alias: wen
+                  agg_func: array_agg
+              config: *unique-conditions
+              meta:
+                description: pardat should be unique by parid and taxyr
           - expression_is_true:
               name: iasworld_pardat_adrno_length_lte_5
               expression: LENGTH(CAST(adrno AS varchar)) <= 5

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -104,7 +104,6 @@ sources:
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.sales.yml
+++ b/dbt/models/iasworld/schema/iasworld.sales.yml
@@ -43,9 +43,7 @@ sources:
                     - who
                     - wen
                   config:
-                    where: |
-                      substr(saledt, 1, 4) >= '2011'
-                      AND deactivat IS NULL
+                    where: substr(saledt, 1, 4) >= '2011'
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat

--- a/dbt/models/iasworld/schema/iasworld.sales.yml
+++ b/dbt/models/iasworld/schema/iasworld.sales.yml
@@ -42,6 +42,10 @@ sources:
                     - parid
                     - who
                     - wen
+                  config:
+                    where: |
+                      substr(saledt, 1, 4) >= '2011'
+                      AND deactivat IS NULL
                   meta:
                     description: cur should be 'Y' or 'D'
           - name: deactivat
@@ -113,14 +117,18 @@ sources:
             tests:
               - not_null:
                   name: iasworld_sales_parid_not_null
+                  additional_select_columns: &select-columns-no-parid
+                    - substr(saledt, 1, 4) as taxyr
+                    - who
+                    - wen
+                  config: *unique-conditions
+                  meta:
+                    description: parid should not be null
               - relationships:
                   name: iasworld_sales_parid_in_pardat_parid
                   to: source('iasworld', 'pardat')
                   field: parid
-                  additional_select_columns:
-                    - "substr(saledt, 1, 4) as taxyr"
-                    - who
-                    - wen
+                  additional_select_columns: *select-columns-no-parid
                   config: *unique-conditions
                   meta:
                     category: parid
@@ -128,11 +136,14 @@ sources:
           - name: price
             description: '{{ doc("shared_column_sale_price") }}'
             tests:
-              - dbt_utils.accepted_range:
+              - accepted_range:
                   name: iasworld_sales_price_between_0_and_1b
                   min_value: 0
                   max_value: 1000000000
+                  additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    description: price should be between 0 and 1,000,000,000
           - name: recorddt
             description: Recording date
           - name: saledt
@@ -226,3 +237,6 @@ sources:
                 - saledt
                 - instruno
               config: *unique-conditions
+              meta:
+                category: incorrect_values
+                description: saledt should be before the current date

--- a/dbt/models/qc/schema.yml
+++ b/dbt/models/qc/schema.yml
@@ -189,35 +189,56 @@ models:
                 - who
                 - wen
               config: *time-filter
+              meta:
+                table_name: asmt
+                description: val01 should not be negative
       - name: val02
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val02_gte_0
+              meta:
+                table_name: asmt
+                description: val02 should not be negative
               <<: *test-non-negative
       - name: val03
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val03_gte_0
+              meta:
+                table_name: asmt
+                description: val03 should not be negative
               <<: *test-non-negative
       - name: val04
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val04_gte_0
+              meta:
+                table_name: asmt
+                description: val04 should not be negative
               <<: *test-non-negative
       - name: val05
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val05_gte_0
+              meta:
+                table_name: asmt
+                description: val05 should not be negative
               <<: *test-non-negative
       - name: val06
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val06_gte_0
+              meta:
+                table_name: asmt
+                description: val06 should not be negative
               <<: *test-non-negative
       - name: val07
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val07_gte_0
+              meta:
+                table_name: asmt
+                description: val07 should not be negative
               <<: *test-non-negative
       - name: val08
         tests:
@@ -231,24 +252,33 @@ models:
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val09_gte_0
+              meta:
+                table_name: asmt
+                description: val09 should not be negative
               <<: *test-non-negative
       - name: val10
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val10_gte_0
+              meta:
+                table_name: asmt
+                description: val10 should not be negative
               <<: *test-non-negative
       - name: val11
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val11_gte_0
-              <<: *test-non-negative
               meta:
                 table_name: asmt
                 description: val11 should not be negative
+              <<: *test-non-negative
       - name: val12
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val12_gte_0
+              meta:
+                table_name: asmt
+                description: val12 should not be negative
               <<: *test-non-negative
       - name: val13
         tests:
@@ -270,6 +300,9 @@ models:
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val15_gte_0
+              meta:
+                table_name: asmt
+                description: val15 should not be negative
               <<: *test-non-negative
       - name: val16
         tests:
@@ -283,11 +316,17 @@ models:
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val17_gte_0
+              meta:
+                table_name: asmt
+                description: val17 should not be negative
               <<: *test-non-negative
       - name: val18
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val18_gte_0
+              meta:
+                table_name: asmt
+                description: val18 should not be negative
               <<: *test-non-negative
       - name: val19
         tests:
@@ -317,196 +356,313 @@ models:
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val22_gte_0
+              meta:
+                table_name: asmt
+                description: val22 should not be negative
               <<: *test-non-negative
       - name: val23
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val23_gte_0
+              meta:
+                table_name: asmt
+                description: val23 should not be negative
               <<: *test-non-negative
       - name: val24
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val24_gte_0
+              meta:
+                table_name: asmt
+                description: val24 should not be negative
               <<: *test-non-negative
       - name: val25
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val25_gte_0
+              meta:
+                table_name: asmt
+                description: val25 should not be negative
               <<: *test-non-negative
       - name: val26
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val26_gte_0
+              meta:
+                table_name: asmt
+                description: val26 should not be negative
               <<: *test-non-negative
       - name: val27
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val27_gte_0
+              meta:
+                table_name: asmt
+                description: val27 should not be negative
               <<: *test-non-negative
       - name: val28
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val28_gte_0
+              meta:
+                table_name: asmt
+                description: val28 should not be negative
               <<: *test-non-negative
       - name: val29
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val29_gte_0
+              meta:
+                table_name: asmt
+                description: val29 should not be negative
               <<: *test-non-negative
       - name: val30
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val30_gte_0
+              meta:
+                table_name: asmt
+                description: val30 should not be negative
               <<: *test-non-negative
       - name: val31
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val31_gte_0
+              meta:
+                table_name: asmt
+                description: val31 should not be negative
               <<: *test-non-negative
       - name: val32
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val32_gte_0
+              meta:
+                table_name: asmt
+                description: val32 should not be negative
               <<: *test-non-negative
       - name: val33
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val33_gte_0
+              meta:
+                table_name: asmt
+                description: val33 should not be negative
               <<: *test-non-negative
       - name: val34
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val34_gte_0
+              meta:
+                table_name: asmt
+                description: val34 should not be negative
               <<: *test-non-negative
       - name: val35
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val35_gte_0
+              meta:
+                table_name: asmt
+                description: val35 should not be negative
               <<: *test-non-negative
       - name: val36
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val36_gte_0
+              meta:
+                table_name: asmt
+                description: val36 should not be negative
               <<: *test-non-negative
       - name: val37
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val37_gte_0
+              meta:
+                table_name: asmt
+                description: val37 should not be negative
               <<: *test-non-negative
       - name: val38
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val38_gte_0
+              meta:
+                table_name: asmt
+                description: val38 should not be negative
               <<: *test-non-negative
       - name: val39
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val39_gte_0
+              meta:
+                table_name: asmt
+                description: val39 should not be negative
               <<: *test-non-negative
       - name: val40
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val40_gte_0
+              meta:
+                table_name: asmt
+                description: val40 should not be negative
               <<: *test-non-negative
       - name: val41
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val41_gte_0
+              meta:
+                table_name: asmt
+                description: val41 should not be negative
               <<: *test-non-negative
       - name: val42
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val42_gte_0
+              meta:
+                table_name: asmt
+                description: val42 should not be negative
               <<: *test-non-negative
       - name: val43
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val43_gte_0
+              meta:
+                table_name: asmt
+                description: val43 should not be negative
               <<: *test-non-negative
       - name: val44
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val44_gte_0
+              meta:
+                table_name: asmt
+                description: val44 should not be negative
               <<: *test-non-negative
       - name: val45
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val45_gte_0
+              meta:
+                table_name: asmt
+                description: val45 should not be negative
               <<: *test-non-negative
       - name: val46
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val46_gte_0
+              meta:
+                table_name: asmt
+                description: val46 should not be negative
               <<: *test-non-negative
       - name: val47
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val47_gte_0
+              meta:
+                table_name: asmt
+                description: val47 should not be negative
               <<: *test-non-negative
       - name: val48
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val48_gte_0
+              meta:
+                table_name: asmt
+                description: val48 should not be negative
               <<: *test-non-negative
       - name: val49
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val49_gte_0
+              meta:
+                table_name: asmt
+                description: val49 should not be negative
               <<: *test-non-negative
       - name: val50
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val50_gte_0
+              meta:
+                table_name: asmt
+                description: val50 should not be negative
               <<: *test-non-negative
       - name: val51
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val51_gte_0
+              meta:
+                table_name: asmt
+                description: val51 should not be negative
               <<: *test-non-negative
       - name: val52
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val52_gte_0
+              meta:
+                table_name: asmt
+                description: val52 should not be negative
               <<: *test-non-negative
       - name: val53
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val53_gte_0
+              meta:
+                table_name: asmt
+                description: val53 should not be negative
               <<: *test-non-negative
       - name: val54
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val54_gte_0
+              meta:
+                table_name: asmt
+                description: val54 should not be negative
               <<: *test-non-negative
       - name: val55
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val55_gte_0
+              meta:
+                table_name: asmt
+                description: val55 should not be negative
               <<: *test-non-negative
       - name: val56
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val56_gte_0
+              meta:
+                table_name: asmt
+                description: val56 should not be negative
               <<: *test-non-negative
       - name: val57
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val57_gte_0
+              meta:
+                table_name: asmt
+                description: val57 should not be negative
               <<: *test-non-negative
       - name: val58
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val58_gte_0
+              meta:
+                table_name: asmt
+                description: val58 should not be negative
               <<: *test-non-negative
       - name: val59
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val59_gte_0
+              meta:
+                table_name: asmt
+                description: val59 should not be negative
               <<: *test-non-negative
       - name: val60
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val60_gte_0
+              meta:
+                table_name: asmt
+                description: val60 should not be negative
               <<: *test-non-negative
       - name: valapr1
         tests:
@@ -520,6 +676,9 @@ models:
                 description: valapr1 should not be null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valapr1_gte_0
+              meta:
+                table_name: asmt
+                description: valapr1 should not be negative
               <<: *test-non-negative
       - name: valapr2
         tests:
@@ -531,6 +690,9 @@ models:
               <<: *test-val-non-null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valapr2_gte_0
+              meta:
+                table_name: asmt
+                description: valapr2 should not be negative
               <<: *test-non-negative
       - name: valapr3
         tests:
@@ -542,6 +704,9 @@ models:
               <<: *test-val-non-null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valapr3_gte_0
+              meta:
+                table_name: asmt
+                description: valapr3 should not be negative
               <<: *test-non-negative
       - name: valasm1
         tests:
@@ -553,6 +718,9 @@ models:
               <<: *test-val-non-null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valasm1_gte_0
+              meta:
+                table_name: asmt
+                description: valasm1 should not be negative
               <<: *test-non-negative
       - name: valasm2
         tests:
@@ -564,6 +732,9 @@ models:
               <<: *test-val-non-null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valasm2_gte_0
+              meta:
+                table_name: asmt
+                description: valasm2 should not be negative
               <<: *test-non-negative
       - name: valasm3
         tests:
@@ -575,6 +746,9 @@ models:
               <<: *test-val-non-null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valasm3_gte_0
+              meta:
+                table_name: asmt
+                description: valasm3 should not be negative
               <<: *test-non-negative
 
   - name: qc.vw_change_in_high_low_value_sales

--- a/dbt/tests/generic/test_sequential_values.sql
+++ b/dbt/tests/generic/test_sequential_values.sql
@@ -1,0 +1,53 @@
+-- Override dbt_utils.sequential_values to support `additional_select_columns` parameter
+{% test sequential_values(
+    model,
+    column_name,
+    interval=1,
+    datepart=one,
+    group_by_columns=[],
+    additional_select_columns=[]
+) %}
+
+    {%- set previous_column_name = "previous_" ~ dbt_utils.slugify(column_name) -%}
+
+    {%- if group_by_columns | length() > 0 -%}
+        {%- set select_gb_cols = group_by_columns | join(",") -%}
+        {%- set partition_gb_cols = "partition by " + group_by_columns | join(",") -%}
+    {%- endif -%}
+
+    with
+        windowed as (
+
+            select
+                {{ select_gb_cols }},
+                {{ column_name }},
+                lag({{ column_name }}) over (
+                    {{ partition_gb_cols }} order by {{ column_name }}
+                ) as {{ previous_column_name }},
+                {{ format_additional_select_columns(additional_select_columns) }}
+            from {{ model }}
+        ),
+
+        validation_errors as (
+            select *
+            from windowed
+            {% if datepart %}
+                where
+                    not (
+                        cast({{ column_name }} as {{ dbt.type_timestamp() }}) = cast(
+                            {{ dbt.dateadd(datepart, interval, previous_column_name) }}
+                            as {{ dbt.type_timestamp() }}
+                        )
+                    )
+            {% else %}
+                where
+                    not (
+                        {{ column_name }} = {{ previous_column_name }} + {{ interval }}
+                    )
+            {% endif %}
+        )
+
+    select *
+    from validation_errors
+
+{% endtest %}


### PR DESCRIPTION
This PR adds `meta.description` and `additional_select_columns` attributes to all remaining dbt QC tests that are not fully configured following https://github.com/ccao-data/data-architecture/pull/281. This mostly represents non-failing tests, and I've confirmed via inspection of the workbook that the test output remains the same following this change. Note that since these attributes are only needed for outputting the QC test workbook, we only add them to tests that are configured with the `test_qc_*` tag and do not also have the `test_qc_exclude_from_workbook` tag, since these are the only tests that get output to the workbook.

Closes https://github.com/ccao-data/data-architecture/issues/344 and closes https://github.com/ccao-data/data-architecture/issues/263.