### PR TITLE
Add iasWorld colnames to descriptions of tests in qc, dweldat, comdat, and oby

### DIFF
--- a/dbt/models/iasworld/schema/iasworld.comdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.comdat.yml
@@ -74,7 +74,8 @@ sources:
                       AND deactivat IS NULL
                       AND calc_meth IS NOT NULL
                   meta:
-                    description: calc_meth should be 'E' if not null
+                    description: >
+                      calc_meth (Calculation Method) should be 'E' if not null
           - name: card
             description: '{{ doc("column_card") }}'
             tests:
@@ -203,7 +204,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_calc_rcnld (calculated full NMV) should not be 0
+                      external_calc_rcnld (Net Market Value) should not be 0
           - name: external_occpct
             description: '{{ doc("shared_column_external_occpct") }}'
             tests:
@@ -215,7 +216,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_occpct (occupancy percentage) should not be 0
+                      external_occpct (Occupancy %) should not be 0
           - name: external_propct
             description: '{{ doc("shared_column_external_propct") }}'
             tests:
@@ -227,7 +228,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_propct (proration percentage) should not be 0
+                      external_propct (Proration %) should not be 0
           - name: external_rcnld
             description: '{{ doc("shared_column_external_rcnld") }}'
             tests:
@@ -239,7 +240,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_rcnld (calculated full FMV) should not be 0
+                      external_rcnld (Full Market Value) should not be 0
           - name: gfact
             description: Grade factor
           - name: grade

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -65,7 +65,7 @@ sources:
                       AND deactivat IS NULL
                       AND class NOT IN ('201', '213', '218', '219', '220', '221', '224', '225', '236', '240', '241', '290', '294', '297')
                   meta:
-                    description: attic (attic type) should not be null
+                    description: attic (Attic Type) should not be null
               - accepted_values:
                   name: iasworld_dweldat_attic_in_accepted_values
                   values: ['1', '2', '3', '4', '5']
@@ -73,7 +73,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      attic (attic type) should be an integer between 1 and 5
+                      attic (Attic Type) should be an integer between 1 and 5
           - name: atticarea
             description: Attic area
           - name: atticval
@@ -98,7 +98,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: bsmt (basement type) should not be null
+                    description: bsmt (Basement Type) should not be null
               - accepted_values:
                   name: iasworld_dweldat_bsmt_in_accepted_values
                   values: ['1', '2', '3', '4', '5', '6', '7']
@@ -106,7 +106,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      bsmt (basement type) should be an integer between 1 and 7
+                      bsmt (Basement Type) should be an integer between 1 and 7
           - name: bsmtarea
             description: Unfinished basement area
           - name: bsmtcar
@@ -130,7 +130,8 @@ sources:
                       AND class NOT IN ('201', '213', '218', '219', '220', '221', '224', '225', '236', '240', '241', '290', '294', '297')
                       AND calc_meth IS NOT NULL
                   meta:
-                    description: calc_meth should be null or 'E'
+                    description: >
+                      calc_meth (Calculation Method) should be null or 'E'
           - name: card
             description: '{{ doc("column_card") }}'
             tests:
@@ -285,7 +286,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_calc_rcnld (calculated full NMV) should not be 0
+                      external_calc_rcnld (Net Market Value) should not be 0
           - name: external_occpct
             description: '{{ doc("shared_column_external_occpct") }}'
             tests:
@@ -297,7 +298,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_occpct (occupancy percentage) should not be 0
+                      external_occpct (Occupancy %) should not be 0
           - name: external_propct
             description: '{{ doc("shared_column_external_propct") }}'
             tests:
@@ -309,7 +310,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_propct (proration percentage) should not be 0
+                      external_propct (Proration %) should not be 0
           - name: external_rcnld
             description: '{{ doc("shared_column_external_rcnld") }}'
             tests:
@@ -321,7 +322,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_rcnld (calculated full FMV) should not be 0
+                      external_rcnld (Full Market Value) should not be 0
           - name: extwall
             description: '{{ doc("shared_column_char_ext_wall") }}'
             tests:
@@ -330,14 +331,14 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: extwall (exterior wall type) should not be null
+                    description: extwall (Exterior Construction) should not be null
               - accepted_values:
                   name: iasworld_dweldat_extwall_in_accepted_values
                   values: ['1', '2', '3', '4', '6', '7', '8', '9']
                   config: *unique-conditions
                   meta:
                     description: >
-                      extwall (exterior wall type) should be 1, 2, 3, 4, 6, 7, 8, or 9
+                      extwall (Exterior Construction) should be 1, 2, 3, 4, 6, 7, 8, or 9
           - name: extwall1
             description: Exterior wall code
           - name: extwall1pct
@@ -361,7 +362,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      fixbath (number of full bathrooms) should not be null
+                      fixbath (Number of Full Baths) should not be null
               - accepted_range:
                   name: iasworld_dweldat_fixbath_between_1_and_16
                   min_value: 1
@@ -370,7 +371,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      fixbath (number of full bathrooms) should be between 1 and 16
+                      fixbath (Number of Full Baths) should be between 1 and 16
           - name: fixbath1
             description: Number of full bathrooms on the first floor
           - name: fixbath2
@@ -408,7 +409,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      fixhalf (number of half baths) should not be null
+                      fixhalf (Number of Half Baths) should not be null
               - accepted_range:
                   name: iasworld_dweldat_fixhalf_between_0_and_6
                   min_value: 0
@@ -417,7 +418,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      fixhalf (number of half baths) should be between 0 and 6
+                      fixhalf (Number of Half Baths) should be between 0 and 6
           - name: fixhalf1
             description: Number of half baths on the first floor
           - name: fixhalf2
@@ -485,7 +486,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      heat (interior heat type) should not be null
+                      heat (Heating) should not be null
               - accepted_values:
                   name: iasworld_dweldat_heat_in_accepted_values
                   values: ['1', '2', '3', '4']
@@ -493,7 +494,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      heat (interior heat type) should be an integer between 1 and 4
+                      heat (Heating) should be an integer between 1 and 4
           - name: heatarea
             description: Heat area
           - name: heatsys
@@ -559,7 +560,8 @@ sources:
                       AND deactivat IS NULL
                   meta:
                     category: incorrect_values
-                    description: mktrsn should only be 5 if mktadj is not null
+                    description: >
+                      mktrsn (Reason for Override) should only be 5 if mktadj is not null
           - name: modover
             description: Residential override model
           - name: mvpattic
@@ -685,7 +687,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      rmbed (number of bedrooms) should not be null
+                      rmbed (Number of Bedrooms) should not be null
               - accepted_range:
                   name: iasworld_dweldat_rmbed_sf_between_1_and_15
                   min_value: 1
@@ -699,7 +701,7 @@ sources:
                       AND deactivat IS NULL
                   meta:
                     description: >
-                      rmbed (number of bedrooms) should be between 1 and 15
+                      rmbed (Number of Bedrooms) should be between 1 and 15
               - accepted_range:
                   name: iasworld_dweldat_rmbed_mf_between_1_and_24
                   min_value: 1
@@ -713,7 +715,7 @@ sources:
                       AND deactivat IS NULL
                   meta:
                     description: >
-                      rmbed (number of bedrooms) should be between 1 and 24
+                      rmbed (Number of Bedrooms) should be between 1 and 24
               - expression_is_true:
                   name: iasworld_dweldat_rmbed_lte_rmtot
                   expression: <= rmtot
@@ -728,7 +730,7 @@ sources:
                   meta:
                     category: relationships
                     description: >
-                      rmbed (number of bedrooms) should be <= rmtot (number of rooms)
+                      rmbed (Number of Bedrooms) should be <= rmtot (Number of Rooms)
           - name: rmbed1
             description: Number of bedrooms on the first floor
           - name: rmbed2
@@ -795,7 +797,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: rmtot (number of rooms) should not be null
+                    description: rmtot (Number of Rooms) should not be null
               - accepted_range:
                   name: iasworld_dweldat_rmtot_sf_between_1_and_40
                   min_value: 1
@@ -808,7 +810,7 @@ sources:
                       AND cur = 'Y'
                       AND deactivat IS NULL
                   meta:
-                    description: rmtot (number of rooms) should be between 1 and 40
+                    description: rmtot (Number of Rooms) should be between 1 and 40
               - accepted_range:
                   name: iasworld_dweldat_rmtot_sf_between_1_and_50
                   min_value: 1
@@ -821,7 +823,7 @@ sources:
                       AND cur = 'Y'
                       AND deactivat IS NULL
                   meta:
-                    description: rmtot (number of rooms) should be between 1 and 50
+                    description: rmtot (Number of Rooms) should be between 1 and 50
           - name: salekey
             description: '{{ doc("column_salekey") }}'
           - name: seq
@@ -847,7 +849,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: sfla should not be null
+                    description: sfla (Building Square Footage) should not be null
               - accepted_range:
                   name: iasworld_dweldat_sfla_sf_between_1_and_10000
                   min_value: 1
@@ -861,7 +863,7 @@ sources:
                       AND deactivat IS NULL
                   meta:
                     description: >
-                      sfla (bldg. square feet) should be between 1 and 10000
+                      sfla (Building Square Footage) should be between 1 and 10000
                       for single-family properties (excl. 208 or 209)
               - accepted_range:
                   name: iasworld_dweldat_sfla_mf_between_1_and_20000
@@ -876,7 +878,7 @@ sources:
                       AND deactivat IS NULL
                   meta:
                     description: >
-                      sfla (bldg. square feet) should be between 1 and 20000
+                      sfla (Building Square Footage) should be between 1 and 20000
                       for multi-family and large single-family
           - name: shfact
             description: Story height factor
@@ -902,7 +904,7 @@ sources:
                   config: *unique-conditions
                   additional_select_columns: *select-columns
                   meta:
-                    description: stories should not be null
+                    description: stories (Type of Residence) should not be null
               - expression_is_true:
                   name: iasworld_dweldat_stories_in_accepted_values
                   expression: 'IN (1.00, 2.00, 3.00, 4.00, 5.00, 9.90)'
@@ -911,7 +913,7 @@ sources:
                   meta:
                     category: incorrect_values
                     description: >
-                      stories (type of residence) should be one of 1.00, 2.00,
+                      stories (Type of Residence) should be one of 1.00, 2.00,
                       3.00, 4.00, 5.00, or 9.90
           - name: style
             description: Architectural style
@@ -969,8 +971,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: >
-                      user3 (property renovation indicator) should be '0' or '1'
+                    description: user3 (Renovated) should be '0' or '1'
           - name: user4
             description: '{{ doc("shared_column_char_tp_dsgn") }}'
             tests:
@@ -995,14 +996,14 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user5 (design plan) should not be null
+                    description: user5 (Plan of Design) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_tp_plan_in_accepted_values
                   values: ['0', '1', '2']
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user5 (design plan) should be '0', '1', or '2'
+                    description: user5 (Plan of Design) should be '0', '1', or '2'
           - name: user6
             description: '{{ doc("shared_column_char_attic_fnsh") }}'
             tests:
@@ -1011,14 +1012,14 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user6 (attic finish) should not be null
+                    description: user6 (Attic Finish) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_attic_fnsh_in_accepted_values
                   values: ['1', '2', '3']
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user6 (attic finish) should be '1', '2', or '3'
+                    description: user6 (Attic Finish) should be '1', '2', or '3'
           - name: user7
             description: '{{ doc("shared_column_char_air") }}'
             tests:
@@ -1027,14 +1028,14 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user7 (central air indicator) should not be null
+                    description: user7 (Central Air Conditioning) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_air_accepted_values
                   values: ['1', '2']
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user7 (central air indicator) should be '1' or '2'
+                    description: user7 (Central Air Conditioning) should be '1' or '2'
           - name: user12
             description: '{{ doc("shared_column_char_bsmt_fin") }}'
             tests:
@@ -1043,7 +1044,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user12 (basement finish) should not be null
+                    description: user12 (Basement Finished) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_bsmt_fin_accepted_values
                   values: ['1', '2', '3', '4', '5', '6']
@@ -1051,7 +1052,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      user12 (basement finish) should be an integer between 1 and 6
+                      user12 (Basement Finished) should be an integer between 1 and 6
           - name: user13
             description: '{{ doc("shared_column_char_roof_cnst") }}'
             tests:
@@ -1060,7 +1061,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user13 (roof material) should not be null
+                    description: user13 (Roof Construction) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_roof_cnst_accepted_values
                   values: ['1', '2', '3', '4', '5', '6']
@@ -1068,7 +1069,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      user13 (roof material) should be an integer between 1 and 6
+                      user13 (Roof Construction) should be an integer between 1 and 6
           - name: user14
             description: '{{ doc("shared_column_char_apts") }}'
             tests:
@@ -1082,9 +1083,7 @@ sources:
                       AND cur = 'Y'
                       AND deactivat IS NULL
                   meta:
-                    description: >
-                      user14 (number of apts. for class 211 and 212)
-                      should not be null
+                    description: user14 (Total Number of Units) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_apts_accepted_values
                   values: ['1', '2', '3', '4', '5', '6']
@@ -1097,8 +1096,8 @@ sources:
                       AND deactivat IS NULL
                   meta:
                     description: >
-                      user14 (number of apts. for class 211 and 212)
-                      should be an integer between 1 and 6
+                      user14 (Total Number of Units) should be an integer
+                      between 1 and 6
           - name: user15
             description: '{{ doc("shared_column_char_use") }}'
             tests:
@@ -1107,15 +1106,14 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: >
-                      user15 (single- or multi-family use) should not be null
+                    description: user15 (Use) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_use_accepted_values
                   values: ['1', '2']
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user15 (single- or multi-family use) should be '1' or '2'
+                    description: user15 (Use) should be '1' or '2'
           - name: user17
             description: Age. Deprecated, use `yrblt`
           - name: user20
@@ -1127,7 +1125,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      user20 (number of commercial units) should not be null
+                      user20 (No. of Commercial Units) should not be null
           - name: user24
             description: '{{ doc("shared_column_card_proration_rate") }}'
             tests:
@@ -1136,7 +1134,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user24 (proration rate) should not be null
+                    description: user24 (Proration %) should not be null
           - name: user30
             description: '{{ doc("shared_column_char_porch") }}'
             tests:
@@ -1145,14 +1143,14 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user30 (porch type) should not be null
+                    description: user30 (Porch) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_porch_accepted_values
                   values: ['0', '1', '2']
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user30 (porch type) should be '0', '1', or '2'
+                    description: user30 (Porch) should be '0', '1', or '2'
           - name: user31
             description: '{{ doc("shared_column_char_gar_att") }}'
             tests:
@@ -1161,16 +1159,14 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: >
-                      user31 (attached garage indicator) should not be null
+                    description: user31 (Garage Attached) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_gar_att_accepted_values
                   values: ['1', '2']
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: >
-                      user31 (attached garage indicator) should be '1' or '2'
+                    description: user31 (Garage Attached) should be '1' or '2'
           - name: user32
             description: '{{ doc("shared_column_char_gar_area") }}'
             tests:
@@ -1179,16 +1175,14 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: >
-                      user32 (garage area inclusion indicator) should not be null
+                    description: user32 (Garage in Area) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_gar_area_accepted_values
                   values: ['1', '2']
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: >
-                      user32 (garage area inclusion indicator) should be '1' or '2'
+                    description: user32 (Garage in Area) should be '1' or '2'
           - name: user33
             description: '{{ doc("shared_column_char_gar_size") }}'
             tests:
@@ -1197,7 +1191,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user33 (garage size) should not be null
+                    description: user33 (Garage Size) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_gar_size_accepted_values
                   values: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
@@ -1205,7 +1199,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      user33 (garage size) should be an integer between 1 and 10
+                      user33 (Garage Size) should be an integer between 1 and 10
           - name: user34
             description: '{{ doc("shared_column_char_gar_cnst") }}'
             tests:
@@ -1214,8 +1208,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: >
-                      user34 (garage ext. wall construction) should not be null
+                    description: user34 (Garage Construction) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_gar_cnst_accepted_values
                   values: ['1', '2', '3', '4']
@@ -1223,7 +1216,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      user34 (garage ext. wall construction) should be
+                      user34 (Garage Construction) should be
                       an integer between 1 and 4
                   tags:
                     # Currently too many failures for this signal to be useful
@@ -1246,7 +1239,7 @@ sources:
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: wbfp_o (number of fireplaces) should not be null
+                    description: wbfp_o (Number of Fireplaces) should not be null
               - accepted_range:
                   name: iasworld_dweldat_char_frpl_between_0_and_6
                   min_value: 0
@@ -1255,7 +1248,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      wbfp_o (number of fireplaces) should be between 0 and 6
+                      wbfp_o (Number of Fireplaces) should be between 0 and 6
           - name: wbfp_pf
             description: Wood burning fireplace - prefab
           - name: wbfp_pfx
@@ -1328,7 +1321,7 @@ sources:
               config: *unique-conditions
               meta:
                 category: incorrect_values
-                description: user24 (proration rate) should be between 0 and 100
+                description: user24 (Proration %) should be between 0 and 100
           - expression_is_true:
               name: iasworld_dweldat_char_ncu_between_0_and_5
               expression: 'CAST(user20 AS decimal) BETWEEN 0 AND 5'
@@ -1343,7 +1336,7 @@ sources:
               meta:
                 category: incorrect_values
                 description: >
-                  user20 (num. commercial units) should be an integer between 0 and 5
+                  user20 (No. of Commercial Units) should be an integer between 0 and 5
           - expression_is_true:
               name: iasworld_dweldat_bsmt_and_user12_match_234_class
               expression: bsmt = '3' and user12 = '1'
@@ -1365,5 +1358,6 @@ sources:
               meta:
                 category: incorrect_values
                 description: >
-                  bsmt must be 3 (partial basement) and user12 must be 1
-                  (finished basement) when class is 234 (split level)
+                  bsmt (Basement Type) must be 3 - PARTIAL and
+                  user12 (Basement Finished) must be 1 - FAMILY ROOM when
+                  class is 234 (split level)

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -62,7 +62,8 @@ sources:
                       AND deactivat IS NULL
                       AND calc_meth IS NOT NULL
                   meta:
-                    description: calc_meth should be 'E' if not null
+                    description: >
+                      calc_meth (Calculation Method) should be 'E' if not null
           - name: card
             description: '{{ doc("column_card") }}'
             tests:
@@ -188,7 +189,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_calc_rcnld (calculated full NMV) should not be 0
+                      external_calc_rcnld (Net Market Value) should not be 0
           - name: external_occpct
             description: '{{ doc("shared_column_external_occpct") }}'
             tests:
@@ -200,7 +201,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_occpct (occupancy percentage) should not be 0
+                      external_occpct (Occupancy %) should not be 0
           - name: external_propct
             description: '{{ doc("shared_column_external_propct") }}'
             tests:
@@ -212,7 +213,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_propct (proration percentage) should not be 0
+                      external_propct (Proration %) should not be 0
           - name: external_rcnld
             description: '{{ doc("shared_column_external_rcnld") }}'
             tests:
@@ -224,7 +225,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      external_rcnld (calculated full FMV) should not be 0
+                      external_rcnld (Full Market Value) should not be 0
           - name: funct
             description: Function used in computing this calcualtion
           - name: fundep

--- a/dbt/models/qc/schema.yml
+++ b/dbt/models/qc/schema.yml
@@ -27,7 +27,8 @@ models:
                   AND class NOT IN ('EX', 'RR')
               meta:
                 table_name: asmt
-                description: current year LAV should be >= 0 if class is not EX or RR
+                description: >
+                  cur_year_lav (ASMT LAND) should be >= 0 if class is not EX or RR
       - name: cur_year_bav
         tests:
           # Equivalent to Vacant Class, bldg value test from FP Checklist
@@ -56,7 +57,8 @@ models:
                   )
               meta:
                 table_name: asmt
-                description: current year BAV should be 0 for vacant classes
+                description: >
+                  cur_year_bav (ASMT BLDG) should be 0 for vacant classes
           # Equivalent to Improved class, no bldg value from FP Checklist
           - not_accepted_values:
               name: qc_vw_incorrect_asmt_value_cur_year_bav_impr_class_no_val
@@ -75,7 +77,8 @@ models:
                   )
               meta:
                 table_name: asmt
-                description: current year BAV should not be 0 for non-vacant classes
+                description: >
+                  cur_year_bav (ASMT BLDG) should not be 0 for non-vacant classes
       - name: cur_year_fav
         tests:
           # Equivalent to 0 Value test from FP Checklist
@@ -92,7 +95,8 @@ models:
                 - cur_year_bav
               meta:
                 table_name: asmt
-                description: current year FAV should be >=0 if class is not EX or RR
+                description: >
+                  cur_year_fav (ASMT TOTAL) should be >= 0 if class is not EX or RR
               <<: *incorrect-asmt-value-gt-0
       - name: class
         tests:
@@ -131,7 +135,9 @@ models:
           meta:
             table_name: asmt
             category: relationships
-            description: FMV should not increase more than $500k YoY
+            description: >
+              cur_year_fmv (ASMT TOTAL) should not increase more than $500k
+              over pri_year_fmv
       - expression_is_true:
           name: qc_vw_incorrect_asmt_value_no_yoy_dec_gt_1m
           expression: (cur_year_fmv - pri_year_fmv) >= -1000000
@@ -140,7 +146,9 @@ models:
           meta:
             table_name: asmt
             category: relationships
-            description: FMV should not decrease more than $1m YoY
+            description: >
+              cur_year_fmv (ASMT TOTAL) should not decrease more than $1m
+              over pri_year_fmv
 
   - name: qc.vw_incorrect_val_method
     description: '{{ doc("view_vw_incorrect_val_method") }}'
@@ -191,14 +199,14 @@ models:
               config: *time-filter
               meta:
                 table_name: asmt
-                description: val01 should not be negative
+                description: val01 (FARM LAND) should not be negative
       - name: val02
         tests:
           - accepted_range:
               name: qc_vw_neg_asmt_value_val02_gte_0
               meta:
                 table_name: asmt
-                description: val02 should not be negative
+                description: val02 (MKT LAND) should not be negative
               <<: *test-non-negative
       - name: val03
         tests:
@@ -206,7 +214,7 @@ models:
               name: qc_vw_neg_asmt_value_val03_gte_0
               meta:
                 table_name: asmt
-                description: val03 should not be negative
+                description: val03 (FARM BLDGS) should not be negative
               <<: *test-non-negative
       - name: val04
         tests:
@@ -214,7 +222,7 @@ models:
               name: qc_vw_neg_asmt_value_val04_gte_0
               meta:
                 table_name: asmt
-                description: val04 should not be negative
+                description: val04 (MKT BLDGS) should not be negative
               <<: *test-non-negative
       - name: val05
         tests:
@@ -222,7 +230,7 @@ models:
               name: qc_vw_neg_asmt_value_val05_gte_0
               meta:
                 table_name: asmt
-                description: val05 should not be negative
+                description: val05 (TOTAL MARKET) should not be negative
               <<: *test-non-negative
       - name: val06
         tests:
@@ -230,7 +238,7 @@ models:
               name: qc_vw_neg_asmt_value_val06_gte_0
               meta:
                 table_name: asmt
-                description: val06 should not be negative
+                description: val06 (ASSD MKT PREF LAND) should not be negative
               <<: *test-non-negative
       - name: val07
         tests:
@@ -238,7 +246,7 @@ models:
               name: qc_vw_neg_asmt_value_val07_gte_0
               meta:
                 table_name: asmt
-                description: val07 should not be negative
+                description: val07 (ASSD FARMLAND) should not be negative
               <<: *test-non-negative
       - name: val08
         tests:
@@ -246,7 +254,7 @@ models:
               name: qc_vw_neg_asmt_value_val08_gte_0
               meta:
                 table_name: asmt
-                description: val08 should not be negative
+                description: val08 (ASSD LAND) should not be negative
               <<: *test-non-negative
       - name: val09
         tests:
@@ -254,7 +262,7 @@ models:
               name: qc_vw_neg_asmt_value_val09_gte_0
               meta:
                 table_name: asmt
-                description: val09 should not be negative
+                description: val09 (DUAL VAL LAND) should not be negative
               <<: *test-non-negative
       - name: val10
         tests:
@@ -262,7 +270,7 @@ models:
               name: qc_vw_neg_asmt_value_val10_gte_0
               meta:
                 table_name: asmt
-                description: val10 should not be negative
+                description: val10 (ASSD FARM BLDGS) should not be negative
               <<: *test-non-negative
       - name: val11
         tests:
@@ -270,7 +278,7 @@ models:
               name: qc_vw_neg_asmt_value_val11_gte_0
               meta:
                 table_name: asmt
-                description: val11 should not be negative
+                description: val11 (ASSD BLDGS) should not be negative
               <<: *test-non-negative
       - name: val12
         tests:
@@ -278,7 +286,7 @@ models:
               name: qc_vw_neg_asmt_value_val12_gte_0
               meta:
                 table_name: asmt
-                description: val12 should not be negative
+                description: val12 (DUAL VAL IMPR) should not be negative
               <<: *test-non-negative
       - name: val13
         tests:
@@ -286,7 +294,7 @@ models:
               name: qc_vw_neg_asmt_value_val13_gte_0
               meta:
                 table_name: asmt
-                description: val13 should not be negative
+                description: val13 (TOTAL ASSESSED) should not be negative
               <<: *test-non-negative
       - name: val14
         tests:
@@ -310,7 +318,7 @@ models:
               name: qc_vw_neg_asmt_value_val16_gte_0
               meta:
                 table_name: asmt
-                description: val16 should not be negative
+                description: val16 (DEMOLITIONS ASSD) should not be negative
               <<: *test-non-negative
       - name: val17
         tests:
@@ -318,7 +326,7 @@ models:
               name: qc_vw_neg_asmt_value_val17_gte_0
               meta:
                 table_name: asmt
-                description: val17 should not be negative
+                description: val17 (STATE RPT OMITTED)  should not be negative
               <<: *test-non-negative
       - name: val18
         tests:
@@ -326,7 +334,7 @@ models:
               name: qc_vw_neg_asmt_value_val18_gte_0
               meta:
                 table_name: asmt
-                description: val18 should not be negative
+                description: val18 (LOCAL EQ MKT PREF LD) should not be negative
               <<: *test-non-negative
       - name: val19
         tests:
@@ -334,7 +342,7 @@ models:
               name: qc_vw_neg_asmt_value_val19_gte_0
               meta:
                 table_name: asmt
-                description: val19 should not be negative
+                description: val19 (LOCAL EQ FACT LAND) should not be negative
               <<: *test-non-negative
       - name: val20
         tests:
@@ -342,7 +350,7 @@ models:
               name: qc_vw_neg_asmt_value_val20_gte_0
               meta:
                 table_name: asmt
-                description: val20 should not be negative
+                description: val20 (LOCAL EQ FACT BLDG) should not be negative
               <<: *test-non-negative
       - name: val21
         tests:
@@ -350,7 +358,7 @@ models:
               name: qc_vw_neg_asmt_value_val21_gte_0
               meta:
                 table_name: asmt
-                description: val21 should not be negative
+                description: val21 (LOCALIZED ASSD L & B) should not be negative
               <<: *test-non-negative
       - name: val22
         tests:
@@ -358,7 +366,7 @@ models:
               name: qc_vw_neg_asmt_value_val22_gte_0
               meta:
                 table_name: asmt
-                description: val22 should not be negative
+                description: val22 (BOR DUAL VAL LAND) should not be negative
               <<: *test-non-negative
       - name: val23
         tests:
@@ -366,7 +374,7 @@ models:
               name: qc_vw_neg_asmt_value_val23_gte_0
               meta:
                 table_name: asmt
-                description: val23 should not be negative
+                description: val23 (BOR ASSD FARMLAND) should not be negative
               <<: *test-non-negative
       - name: val24
         tests:
@@ -374,7 +382,7 @@ models:
               name: qc_vw_neg_asmt_value_val24_gte_0
               meta:
                 table_name: asmt
-                description: val24 should not be negative
+                description: val24 (BOR ASSD LAND) should not be negative
               <<: *test-non-negative
       - name: val25
         tests:
@@ -382,7 +390,7 @@ models:
               name: qc_vw_neg_asmt_value_val25_gte_0
               meta:
                 table_name: asmt
-                description: val25 should not be negative
+                description: val25 (BOR ASSD FARM BLDGS) should not be negative
               <<: *test-non-negative
       - name: val26
         tests:
@@ -390,7 +398,7 @@ models:
               name: qc_vw_neg_asmt_value_val26_gte_0
               meta:
                 table_name: asmt
-                description: val26 should not be negative
+                description: val26 (BOR ASSESSED BLDGS) should not be negative
               <<: *test-non-negative
       - name: val27
         tests:
@@ -398,7 +406,7 @@ models:
               name: qc_vw_neg_asmt_value_val27_gte_0
               meta:
                 table_name: asmt
-                description: val27 should not be negative
+                description: val27 (BOR ASSESED TOTAL) should not be negative
               <<: *test-non-negative
       - name: val28
         tests:
@@ -406,7 +414,7 @@ models:
               name: qc_vw_neg_asmt_value_val28_gte_0
               meta:
                 table_name: asmt
-                description: val28 should not be negative
+                description: val28 (BOR TOT EXC AG) should not be negative
               <<: *test-non-negative
       - name: val29
         tests:
@@ -414,7 +422,7 @@ models:
               name: qc_vw_neg_asmt_value_val29_gte_0
               meta:
                 table_name: asmt
-                description: val29 should not be negative
+                description: val29 (ASSD TOT EXC AG) should not be negative
               <<: *test-non-negative
       - name: val30
         tests:
@@ -422,7 +430,7 @@ models:
               name: qc_vw_neg_asmt_value_val30_gte_0
               meta:
                 table_name: asmt
-                description: val30 should not be negative
+                description: val30 (HIE) should not be negative
               <<: *test-non-negative
       - name: val31
         tests:
@@ -430,7 +438,7 @@ models:
               name: qc_vw_neg_asmt_value_val31_gte_0
               meta:
                 table_name: asmt
-                description: val31 should not be negative
+                description: val31 (DVHE) should not be negative
               <<: *test-non-negative
       - name: val32
         tests:
@@ -438,7 +446,7 @@ models:
               name: qc_vw_neg_asmt_value_val32_gte_0
               meta:
                 table_name: asmt
-                description: val32 should not be negative
+                description: val32 (ASSD TOT -(HIE-DVHE)) should not be negative
               <<: *test-non-negative
       - name: val33
         tests:
@@ -446,7 +454,7 @@ models:
               name: qc_vw_neg_asmt_value_val33_gte_0
               meta:
                 table_name: asmt
-                description: val33 should not be negative
+                description: val33 (STATE EQ ASSD VALUE) should not be negative
               <<: *test-non-negative
       - name: val34
         tests:
@@ -454,7 +462,7 @@ models:
               name: qc_vw_neg_asmt_value_val34_gte_0
               meta:
                 table_name: asmt
-                description: val34 should not be negative
+                description: val34 (BOR FACT MKT PREF LD) should not be negative
               <<: *test-non-negative
       - name: val35
         tests:
@@ -462,7 +470,7 @@ models:
               name: qc_vw_neg_asmt_value_val35_gte_0
               meta:
                 table_name: asmt
-                description: val35 should not be negative
+                description: val35 (ASSD FARMLAND) should not be negative
               <<: *test-non-negative
       - name: val36
         tests:
@@ -470,7 +478,7 @@ models:
               name: qc_vw_neg_asmt_value_val36_gte_0
               meta:
                 table_name: asmt
-                description: val36 should not be negative
+                description: val36 (.ASSD FARM BUILDING) should not be negative
               <<: *test-non-negative
       - name: val37
         tests:
@@ -478,7 +486,7 @@ models:
               name: qc_vw_neg_asmt_value_val37_gte_0
               meta:
                 table_name: asmt
-                description: val37 should not be negative
+                description: val37 (STATE ASSD POLL CONT) should not be negative
               <<: *test-non-negative
       - name: val38
         tests:
@@ -486,7 +494,7 @@ models:
               name: qc_vw_neg_asmt_value_val38_gte_0
               meta:
                 table_name: asmt
-                description: val38 should not be negative
+                description: val38 (STATE ASSD RAILROADS) should not be negative
               <<: *test-non-negative
       - name: val39
         tests:
@@ -494,7 +502,7 @@ models:
               name: qc_vw_neg_asmt_value_val39_gte_0
               meta:
                 table_name: asmt
-                description: val39 should not be negative
+                description: val39 (BOR FACT LAND) should not be negative
               <<: *test-non-negative
       - name: val40
         tests:
@@ -502,7 +510,7 @@ models:
               name: qc_vw_neg_asmt_value_val40_gte_0
               meta:
                 table_name: asmt
-                description: val40 should not be negative
+                description: val40 (TOTAL ASSESSED VALUE) should not be negative
               <<: *test-non-negative
       - name: val41
         tests:
@@ -510,7 +518,7 @@ models:
               name: qc_vw_neg_asmt_value_val41_gte_0
               meta:
                 table_name: asmt
-                description: val41 should not be negative
+                description: val41 (BOR FACT BLDG) should not be negative
               <<: *test-non-negative
       - name: val42
         tests:
@@ -518,7 +526,7 @@ models:
               name: qc_vw_neg_asmt_value_val42_gte_0
               meta:
                 table_name: asmt
-                description: val42 should not be negative
+                description: val42 (40. .:) should not be negative
               <<: *test-non-negative
       - name: val43
         tests:
@@ -526,7 +534,7 @@ models:
               name: qc_vw_neg_asmt_value_val43_gte_0
               meta:
                 table_name: asmt
-                description: val43 should not be negative
+                description: val43 (HOMESTEADS) should not be negative
               <<: *test-non-negative
       - name: val44
         tests:
@@ -534,7 +542,7 @@ models:
               name: qc_vw_neg_asmt_value_val44_gte_0
               meta:
                 table_name: asmt
-                description: val44 should not be negative
+                description: val44 (SCAFHE) should not be negative
               <<: *test-non-negative
       - name: val45
         tests:
@@ -542,7 +550,7 @@ models:
               name: qc_vw_neg_asmt_value_val45_gte_0
               meta:
                 table_name: asmt
-                description: val45 should not be negative
+                description: val45 (DVSHE) should not be negative
               <<: *test-non-negative
       - name: val46
         tests:
@@ -550,7 +558,7 @@ models:
               name: qc_vw_neg_asmt_value_val46_gte_0
               meta:
                 table_name: asmt
-                description: val46 should not be negative
+                description: val46 (44. .:) should not be negative
               <<: *test-non-negative
       - name: val47
         tests:
@@ -558,7 +566,7 @@ models:
               name: qc_vw_neg_asmt_value_val47_gte_0
               meta:
                 table_name: asmt
-                description: val47 should not be negative
+                description: val47 (45. .:) should not be negative
               <<: *test-non-negative
       - name: val48
         tests:
@@ -566,7 +574,7 @@ models:
               name: qc_vw_neg_asmt_value_val48_gte_0
               meta:
                 table_name: asmt
-                description: val48 should not be negative
+                description: val48 (46. .:) should not be negative
               <<: *test-non-negative
       - name: val49
         tests:
@@ -574,7 +582,7 @@ models:
               name: qc_vw_neg_asmt_value_val49_gte_0
               meta:
                 table_name: asmt
-                description: val49 should not be negative
+                description: val49 (EXPIRED HIE) should not be negative
               <<: *test-non-negative
       - name: val50
         tests:
@@ -582,7 +590,7 @@ models:
               name: qc_vw_neg_asmt_value_val50_gte_0
               meta:
                 table_name: asmt
-                description: val50 should not be negative
+                description: val50 (TAXABLE EAV) should not be negative
               <<: *test-non-negative
       - name: val51
         tests:
@@ -590,7 +598,7 @@ models:
               name: qc_vw_neg_asmt_value_val51_gte_0
               meta:
                 table_name: asmt
-                description: val51 should not be negative
+                description: val51 (EXPIRED INCENTIVES) should not be negative
               <<: *test-non-negative
       - name: val52
         tests:
@@ -598,7 +606,7 @@ models:
               name: qc_vw_neg_asmt_value_val52_gte_0
               meta:
                 table_name: asmt
-                description: val52 should not be negative
+                description: val52 (50. .:) should not be negative
               <<: *test-non-negative
       - name: val53
         tests:
@@ -606,7 +614,7 @@ models:
               name: qc_vw_neg_asmt_value_val53_gte_0
               meta:
                 table_name: asmt
-                description: val53 should not be negative
+                description: val53 (51. .:) should not be negative
               <<: *test-non-negative
       - name: val54
         tests:
@@ -614,7 +622,7 @@ models:
               name: qc_vw_neg_asmt_value_val54_gte_0
               meta:
                 table_name: asmt
-                description: val54 should not be negative
+                description: val54 (52. .:) should not be negative
               <<: *test-non-negative
       - name: val55
         tests:
@@ -622,7 +630,7 @@ models:
               name: qc_vw_neg_asmt_value_val55_gte_0
               meta:
                 table_name: asmt
-                description: val55 should not be negative
+                description: val55 (53. .:) should not be negative
               <<: *test-non-negative
       - name: val56
         tests:
@@ -638,7 +646,7 @@ models:
               name: qc_vw_neg_asmt_value_val57_gte_0
               meta:
                 table_name: asmt
-                description: val57 should not be negative
+                description: val57 (OMIT TAXABLE EAV) should not be negative
               <<: *test-non-negative
       - name: val58
         tests:
@@ -646,7 +654,7 @@ models:
               name: qc_vw_neg_asmt_value_val58_gte_0
               meta:
                 table_name: asmt
-                description: val58 should not be negative
+                description: val58 (ROLLBACK TAX EAV) should not be negative
               <<: *test-non-negative
       - name: val59
         tests:
@@ -662,7 +670,7 @@ models:
               name: qc_vw_neg_asmt_value_val60_gte_0
               meta:
                 table_name: asmt
-                description: val60 should not be negative
+                description: val60 (NEW PROPERTY) should not be negative
               <<: *test-non-negative
       - name: valapr1
         tests:
@@ -673,12 +681,12 @@ models:
                 where: taxyr >= '2023'
               meta:
                 table_name: asmt
-                description: valapr1 should not be null
+                description: valapr1 (MKT LAND) should not be null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valapr1_gte_0
               meta:
                 table_name: asmt
-                description: valapr1 should not be negative
+                description: valapr1 (MKT LAND) should not be negative
               <<: *test-non-negative
       - name: valapr2
         tests:
@@ -686,13 +694,13 @@ models:
               name: qc_vw_neg_asmt_value_valapr2_not_null
               meta:
                 table_name: asmt
-                description: valapr2 should not be null
+                description: valapr2 (MKT BLDG) should not be null
               <<: *test-val-non-null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valapr2_gte_0
               meta:
                 table_name: asmt
-                description: valapr2 should not be negative
+                description: valapr2 (MKT BLDG) should not be negative
               <<: *test-non-negative
       - name: valapr3
         tests:
@@ -700,13 +708,13 @@ models:
               name: qc_vw_neg_asmt_value_valapr3_not_null
               meta:
                 table_name: asmt
-                description: valapr3 should not be null
+                description: valapr3 (TOTAL) should not be null
               <<: *test-val-non-null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valapr3_gte_0
               meta:
                 table_name: asmt
-                description: valapr3 should not be negative
+                description: valapr3 (TOTAL) should not be negative
               <<: *test-non-negative
       - name: valasm1
         tests:
@@ -714,13 +722,13 @@ models:
               name: qc_vw_neg_asmt_value_valasm1_not_null
               meta:
                 table_name: asmt
-                description: valasm1 should not be null
+                description: valasm1 (ASMT LAND) should not be null
               <<: *test-val-non-null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valasm1_gte_0
               meta:
                 table_name: asmt
-                description: valasm1 should not be negative
+                description: valasm1 (ASMT LAND) should not be negative
               <<: *test-non-negative
       - name: valasm2
         tests:
@@ -728,13 +736,13 @@ models:
               name: qc_vw_neg_asmt_value_valasm2_not_null
               meta:
                 table_name: asmt
-                description: valasm2 should not be null
+                description: valasm2 (ASMT BLDG) should not be null
               <<: *test-val-non-null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valasm2_gte_0
               meta:
                 table_name: asmt
-                description: valasm2 should not be negative
+                description: valasm2 (ASMT BLDG) should not be negative
               <<: *test-non-negative
       - name: valasm3
         tests:
@@ -742,13 +750,13 @@ models:
               name: qc_vw_neg_asmt_value_valasm3_not_null
               meta:
                 table_name: asmt
-                description: valasm3 should not be null
+                description: valasm3 (ASMT TOTAL) should not be null
               <<: *test-val-non-null
           - accepted_range:
               name: qc_vw_neg_asmt_value_valasm3_gte_0
               meta:
                 table_name: asmt
-                description: valasm3 should not be negative
+                description: valasm3 (ASMT TOTAL) should not be negative
               <<: *test-non-negative
 
   - name: qc.vw_change_in_high_low_value_sales


### PR DESCRIPTION
This PR is a fast follow on https://github.com/ccao-data/data-architecture/pull/351 to make the `config.description` attributes easier to read for tests in the `qc`, `dweldat`, `comdat`, and `oby` models. The more opaque fields on these models now include a hint indicating the iasWorld name of the field in the `config.description` attribute which gets templated into the dbt test failure workbook. This should make it a little bit easier for workbook users to act on problems in iasWorld when they are reported in the failure workbook.

Closes https://github.com/ccao-data/data-architecture/issues/354.