### PR TITLE
Upgrade `dbt-athena-community` to `1.7.1`

### DIFF
--- a/dbt/package-lock.yml
+++ b/dbt/package-lock.yml
@@ -1,0 +1,4 @@
+packages:
+- package: dbt-labs/dbt_utils
+  version: 1.1.1
+sha1_hash: a158c48c59c2bb7d729d2a4e215aabe5bb4f3353

--- a/dbt/requirements.txt
+++ b/dbt/requirements.txt
@@ -1,1 +1,1 @@
-dbt-athena-community~=1.6.1
+dbt-athena-community==1.7.1


### PR DESCRIPTION
This PR upgrades the `dbt-athena-community` package (released by the https://github.com/dbt-athena/dbt-athena/ repo) from `1.6.4` to `1.7.1`, enabling support for the dbt `1.7.*` line.

Note that while `1.7.2` is [currently available](https://github.com/dbt-athena/dbt-athena/releases) for `dbt-athena-community`, I ran into a bug that is preventing it from working with our configuration (https://github.com/dbt-athena/dbt-athena/issues/607). For now, I'm pinning to the second-most recent version, since there don't seem to be any important bugfixes in `1.7.2` according to [the changelog](https://github.com/dbt-athena/dbt-athena/releases/tag/v1.7.2) and I want to unblock us on upgrading to dbt `1.7.*`. I'll upgrade again to `1.7.2` when https://github.com/dbt-athena/dbt-athena/issues/607 is resolved.