### PR TITLE
Refactor `row_values_match_after_join` and `res_class_matches_pardat` for join flexibility

### DIFF
--- a/dbt/macros/format_additional_select_columns.sql
+++ b/dbt/macros/format_additional_select_columns.sql
@@ -1,4 +1,4 @@
--- Format a list of strings or objects representing columns that should be
+-- Format a list of strings or dicts representing columns that should be
 -- selected in a test, such that the columns can be templated into a SELECT
 -- statement.
 --
@@ -8,9 +8,11 @@
 --
 -- * `column` (required string): The name of the column to select
 -- * `alias` (optional string): The alias to use for the column
--- (defaults to `column` or `{agg_func}_{column}`)
+--   (defaults to `{agg_func}_{column}` if `agg_func` is set and `column`
+--   otherwise)
 -- * `agg_func` (optional string): An aggregation function to use to
--- select the column (defaults to no aggregation)
+--   select the column (defaults to no aggregation)
+--
 {% macro format_additional_select_columns(additional_select_columns) %}
     -- Pass execution off to a helper function with a configurable error
     -- handler, to make it possible to unit test exceptions

--- a/dbt/macros/format_additional_select_columns.sql
+++ b/dbt/macros/format_additional_select_columns.sql
@@ -1,3 +1,5 @@
+-- fmt: off
+--
 -- Format a list of strings or dicts representing columns that should be
 -- selected in a test, such that the columns can be templated into a SELECT
 -- statement.
@@ -6,13 +8,16 @@
 -- be selected as-is. If instead the element is a dictionary, it can contain
 -- the following key-value pairs:
 --
--- * `column` (required string): The name of the column to select
--- * `alias` (optional string): The alias to use for the column
--- (defaults to `{agg_func}_{column}` if `agg_func` is set and `column`
--- otherwise)
--- * `agg_func` (optional string): An aggregation function to use to
--- select the column (defaults to no aggregation)
+--    * `column` (required string): The name of the column to select
 --
+--    * `alias` (optional string): The alias to use for the column
+--      (defaults to `{agg_func}_{column}` if `agg_func` is set and `column`
+--      otherwise)
+--
+--    * `agg_func` (optional string): An aggregation function to use to
+--      select the column (defaults to no aggregation)
+--
+-- fmt: on
 {% macro format_additional_select_columns(additional_select_columns) %}
     -- Pass execution off to a helper function with a configurable error
     -- handler, to make it possible to unit test exceptions

--- a/dbt/macros/format_additional_select_columns.sql
+++ b/dbt/macros/format_additional_select_columns.sql
@@ -8,10 +8,10 @@
 --
 -- * `column` (required string): The name of the column to select
 -- * `alias` (optional string): The alias to use for the column
---   (defaults to `{agg_func}_{column}` if `agg_func` is set and `column`
---   otherwise)
+-- (defaults to `{agg_func}_{column}` if `agg_func` is set and `column`
+-- otherwise)
 -- * `agg_func` (optional string): An aggregation function to use to
---   select the column (defaults to no aggregation)
+-- select the column (defaults to no aggregation)
 --
 {% macro format_additional_select_columns(additional_select_columns) %}
     -- Pass execution off to a helper function with a configurable error

--- a/dbt/models/tax/schema.yml
+++ b/dbt/models/tax/schema.yml
@@ -23,26 +23,6 @@ sources:
 
       - name: pin
         description: '{{ doc("table_pin") }}'
-        columns:
-          - name: av_mailed
-            description: '{{ doc("shared_column_mailed_tot") }}'
-            tests:
-              - row_values_match_after_join:
-                  name: tax_pin_av_mailed_matches_asmt_all_valasm3
-                  column_alias: av_mailed
-                  external_model: source("iasworld", "asmt_all")
-                  external_column_name: valasm3
-                  external_column_alias: valasm3
-                  join_condition: |
-                    ON model.pin = external_model.parid
-                    AND model.year = external_model.taxyr
-                    AND external_model.procname = 'CCAOVALUE'
-                    AND external_model.rolltype != 'RR'
-                    AND external_model.deactivat IS NULL
-                    AND external_model.valclass IS NULL
-                  group_by:
-                    - pin
-                    - year
 
       - name: pin_geometry_raw
         description: '{{ doc("table_pin_geometry_raw") }}'

--- a/dbt/models/tax/schema.yml
+++ b/dbt/models/tax/schema.yml
@@ -23,6 +23,26 @@ sources:
 
       - name: pin
         description: '{{ doc("table_pin") }}'
+        columns:
+          - name: av_mailed
+            description: '{{ doc("shared_column_mailed_tot") }}'
+            tests:
+              - row_values_match_after_join:
+                  name: tax_pin_av_mailed_matches_asmt_all_valasm3
+                  column_alias: av_mailed
+                  external_model: source("iasworld", "asmt_all")
+                  external_column_name: valasm3
+                  external_column_alias: valasm3
+                  join_condition: |
+                    ON model.pin = external_model.parid
+                    AND model.year = external_model.taxyr
+                    AND external_model.procname = 'CCAOVALUE'
+                    AND external_model.rolltype != 'RR'
+                    AND external_model.deactivat IS NULL
+                    AND external_model.valclass IS NULL
+                  group_by:
+                    - pin
+                    - year
 
       - name: pin_geometry_raw
         description: '{{ doc("table_pin_geometry_raw") }}'

--- a/dbt/tests/generic/test_res_class_matches_pardat.sql
+++ b/dbt/tests/generic/test_res_class_matches_pardat.sql
@@ -5,21 +5,21 @@
 --
 -- Optional parameters:
 --
---   * major_class_only (bool): Compare only the first digit of classes. When
---         set to False, compare the first three digits instead.
---   * parid_column_name (str): The name of the column on the base model that
---         corresponds to `parid`, in case the model uses a different name scheme.
---   * taxyr_column_name (str): The name of the column on the base model that
---         corresponds to `taxyr`, in case the model uses a different name scheme.
---   * additional_select_columns (dict): Standard parameter for selecting
---         additional columns from the base model for use in reporting failures.
---         `model.{column_name}` and `pardat.class` are already selected by
---         default and do not need to be included using this parameter.
---         See the `format_additional_select_columns` macro for more information.
---         Note that while this parameter can often be either a string or a dict,
---         a dict is required for this test and it must contain the `alias`
---         and `agg_func` parameters given that results are grouped by `parid`
---         and `taxyr`.
+-- * major_class_only (bool): Compare only the first digit of classes. When
+-- set to False, compare the first three digits instead.
+-- * parid_column_name (str): The name of the column on the base model that
+-- corresponds to `parid`, in case the model uses a different name scheme.
+-- * taxyr_column_name (str): The name of the column on the base model that
+-- corresponds to `taxyr`, in case the model uses a different name scheme.
+-- * additional_select_columns (dict): Standard parameter for selecting
+-- additional columns from the base model for use in reporting failures.
+-- `model.{column_name}` and `pardat.class` are already selected by
+-- default and do not need to be included using this parameter.
+-- See the `format_additional_select_columns` macro for more information.
+-- Note that while this parameter can often be either a string or a dict,
+-- a dict is required for this test and it must contain the `alias`
+-- and `agg_func` parameters given that results are grouped by `parid`
+-- and `taxyr`.
 --
 {% test res_class_matches_pardat(
     model,
@@ -90,8 +90,7 @@
         on filtered_model.{{ parid_column_name }} = pardat.parid
         and filtered_model.{{ taxyr_column_name }} = pardat.taxyr
     group by
-        filtered_model.{{ parid_column_name }},
-        filtered_model.{{ taxyr_column_name }}
+        filtered_model.{{ parid_column_name }}, filtered_model.{{ taxyr_column_name }}
     having
         sum(
             case

--- a/dbt/tests/generic/test_res_class_matches_pardat.sql
+++ b/dbt/tests/generic/test_res_class_matches_pardat.sql
@@ -3,17 +3,31 @@
 -- filters for residential parcels by anti-joining the model against `comdat`
 -- using parid and taxyr; as a result, it filters out mixed-use parcels as well.
 --
--- By default, the test will compare the first 3 digits of each set of classes;
--- if `major_class_only=true`, however, the test will compare the first digit
--- only.
+-- Optional parameters:
 --
--- Since the output is grouped by (parid, taxyr), additional columns that would
--- normally be selected via `additional_select_columns` need to be selected
--- with one of two aggregation methods: `select_columns_aggregated_with_array`
--- (which uses the `array_agg()` function to select the columns) or
--- `select_columns_aggregated_with_max` (which uses the `max()` function).
+--   * major_class_only (bool): Compare only the first digit of classes. When
+--         set to False, compare the first three digits instead.
+--   * parid_column_name (str): The name of the column on the base model that
+--         corresponds to `parid`, in case the model uses a different name scheme.
+--   * taxyr_column_name (str): The name of the column on the base model that
+--         corresponds to `taxyr`, in case the model uses a different name scheme.
+--   * additional_select_columns (dict): Standard parameter for selecting
+--         additional columns from the base model for use in reporting failures.
+--         `model.{column_name}` and `pardat.class` are already selected by
+--         default and do not need to be included using this parameter.
+--         See the `format_additional_select_columns` macro for more information.
+--         Note that while this parameter can often be either a string or a dict,
+--         a dict is required for this test and it must contain the `alias`
+--         and `agg_func` parameters given that results are grouped by `parid`
+--         and `taxyr`.
+--
 {% test res_class_matches_pardat(
-    model, column_name, major_class_only=false, additional_select_columns=[]
+    model,
+    column_name,
+    major_class_only=false,
+    parid_column_name="parid",
+    taxyr_column_name="taxyr",
+    additional_select_columns=[]
 ) %}
     {#-
         Process `additional_select_columns` to add the necessary prefix for
@@ -55,8 +69,8 @@
                     from {{ source("iasworld", "comdat") }}
                     where comdat.cur = 'Y' and comdat.deactivat is null
                 ) as comdat
-                on model.parid = comdat.parid
-                and model.taxyr = comdat.taxyr
+                on model.{{ parid_column_name }} = comdat.parid
+                and model.{{ taxyr_column_name }} = comdat.taxyr
             where comdat.parid is null
         )
 
@@ -73,9 +87,11 @@
             from {{ source("iasworld", "pardat") }}
             where cur = 'Y' and deactivat is null
         ) as pardat
-        on pardat.parid = filtered_model.parid
-        and pardat.taxyr = filtered_model.taxyr
-    group by filtered_model.parid, filtered_model.taxyr
+        on filtered_model.{{ parid_column_name }} = pardat.parid
+        and filtered_model.{{ taxyr_column_name }} = pardat.taxyr
+    group by
+        filtered_model.{{ parid_column_name }},
+        filtered_model.{{ taxyr_column_name }}
     having
         sum(
             case

--- a/dbt/tests/generic/test_res_class_matches_pardat.sql
+++ b/dbt/tests/generic/test_res_class_matches_pardat.sql
@@ -1,3 +1,5 @@
+-- fmt: off
+--
 -- For all residential parcels in a given model, test that there is at least one
 -- class code that matches a class code for that parcel in pardat. The test
 -- filters for residential parcels by anti-joining the model against `comdat`
@@ -5,22 +7,26 @@
 --
 -- Optional parameters:
 --
--- * major_class_only (bool): Compare only the first digit of classes. When
--- set to False, compare the first three digits instead.
--- * parid_column_name (str): The name of the column on the base model that
--- corresponds to `parid`, in case the model uses a different name scheme.
--- * taxyr_column_name (str): The name of the column on the base model that
--- corresponds to `taxyr`, in case the model uses a different name scheme.
--- * additional_select_columns (dict): Standard parameter for selecting
--- additional columns from the base model for use in reporting failures.
--- `model.{column_name}` and `pardat.class` are already selected by
--- default and do not need to be included using this parameter.
--- See the `format_additional_select_columns` macro for more information.
--- Note that while this parameter can often be either a string or a dict,
--- a dict is required for this test and it must contain the `alias`
--- and `agg_func` parameters given that results are grouped by `parid`
--- and `taxyr`.
+--    * major_class_only (bool): Compare only the first digit of classes. When
+--    set to False, compare the first three digits instead.
 --
+--    * parid_column_name (str): The name of the column on the base model that
+--    corresponds to `parid`, in case the model uses a different name scheme.
+--
+--    * taxyr_column_name (str): The name of the column on the base model that
+--    corresponds to `taxyr`, in case the model uses a different name scheme.
+--
+--    * additional_select_columns (dict): Standard parameter for selecting
+--    additional columns from the base model for use in reporting failures.
+--    `model.{column_name}` and `pardat.class` are already selected by
+--    default and do not need to be included using this parameter.
+--    See the `format_additional_select_columns` macro for more information.
+--    Note that while this parameter can often be either a string or a dict,
+--    a dict is required for this test and it must contain the `alias`
+--    and `agg_func` parameters given that results are grouped by `parid`
+--    and `taxyr`.
+--
+-- fmt: on
 {% test res_class_matches_pardat(
     model,
     column_name,

--- a/dbt/tests/generic/test_row_values_match_after_join.sql
+++ b/dbt/tests/generic/test_row_values_match_after_join.sql
@@ -2,6 +2,43 @@
 -- a subset of the values in the joined table, i.e. if the class of PINA
 -- from tableA is '212' and the class of PINA from tableB is '211' and '212',
 -- then tableA matches (returns no rows).
+--
+-- Required parameters:
+--
+--   * external_model (str): The name of the model to join to.
+--   * external_column_name (str): The name of the column in `external_model`
+--         to join to.
+--   * join_condition (str): The ON (or USING) portion of a JOIN clause,
+--         represented as a string. Note that in the case where ON is used,
+--         columns in the base model should be formatted like `model.{column}`
+--         while columns in the external model should be formatted like
+--         `external_model.{column}`, e.g. `ON model.pin = external_model.parid`.
+--         This is not necessary in the case of USING, since USING does not
+--         refer to tablenames directly.
+--   * group_by (list of str): The columns from the base model to pass to the
+--         GROUP BY function used in the test query. Unlike `join_condition`,
+--         these column names do not have to be prefixed with `model.*`, since
+--         they are assumed to come from the base model for the test and not the
+--         external model.
+--
+-- Optional parameters:
+--
+--   * column_alias (str): An alias to use when selecting the column from the
+--         base model for output. An alias is required in this case because
+--         the column must be aggregated. Defaults to "model_col".
+--   * external_column_alias (str): An alias to use when selecting the column
+--         from the external model for output. Defaults to "external_model_col".
+--   * additional_select_columns (dict): Standard parameter for selecting
+--         additional columns from the base model for use in reporting failures.
+--         `model.{column_name}`, `external_model.{external_column_name`}`, and
+--         the columns specified in the `group_by` parameter are already selected
+--         by default and do not need to be included using this parameter.
+--         See the `format_additional_select_columns` macro for more information.
+--         Note that while this parameter can often be either a string or a dict,
+--         a dict is required for this test and it must contain the `alias`
+--         and `agg_func` parameters given that results are grouped by the
+--         columns specified in `group_by`.
+--
 {% test row_values_match_after_join(
     model,
     column_name,

--- a/dbt/tests/generic/test_row_values_match_after_join.sql
+++ b/dbt/tests/generic/test_row_values_match_after_join.sql
@@ -5,39 +5,39 @@
 --
 -- Required parameters:
 --
---   * external_model (str): The name of the model to join to.
---   * external_column_name (str): The name of the column in `external_model`
---         to join to.
---   * join_condition (str): The ON (or USING) portion of a JOIN clause,
---         represented as a string. Note that in the case where ON is used,
---         columns in the base model should be formatted like `model.{column}`
---         while columns in the external model should be formatted like
---         `external_model.{column}`, e.g. `ON model.pin = external_model.parid`.
---         This is not necessary in the case of USING, since USING does not
---         refer to tablenames directly.
---   * group_by (list of str): The columns from the base model to pass to the
---         GROUP BY function used in the test query. Unlike `join_condition`,
---         these column names do not have to be prefixed with `model.*`, since
---         they are assumed to come from the base model for the test and not the
---         external model.
+-- * external_model (str): The name of the model to join to.
+-- * external_column_name (str): The name of the column in `external_model`
+-- to join to.
+-- * join_condition (str): The ON (or USING) portion of a JOIN clause,
+-- represented as a string. Note that in the case where ON is used,
+-- columns in the base model should be formatted like `model.{column}`
+-- while columns in the external model should be formatted like
+-- `external_model.{column}`, e.g. `ON model.pin = external_model.parid`.
+-- This is not necessary in the case of USING, since USING does not
+-- refer to tablenames directly.
+-- * group_by (list of str): The columns from the base model to pass to the
+-- GROUP BY function used in the test query. Unlike `join_condition`,
+-- these column names do not have to be prefixed with `model.*`, since
+-- they are assumed to come from the base model for the test and not the
+-- external model.
 --
 -- Optional parameters:
 --
---   * column_alias (str): An alias to use when selecting the column from the
---         base model for output. An alias is required in this case because
---         the column must be aggregated. Defaults to "model_col".
---   * external_column_alias (str): An alias to use when selecting the column
---         from the external model for output. Defaults to "external_model_col".
---   * additional_select_columns (dict): Standard parameter for selecting
---         additional columns from the base model for use in reporting failures.
---         `model.{column_name}`, `external_model.{external_column_name`}`, and
---         the columns specified in the `group_by` parameter are already selected
---         by default and do not need to be included using this parameter.
---         See the `format_additional_select_columns` macro for more information.
---         Note that while this parameter can often be either a string or a dict,
---         a dict is required for this test and it must contain the `alias`
---         and `agg_func` parameters given that results are grouped by the
---         columns specified in `group_by`.
+-- * column_alias (str): An alias to use when selecting the column from the
+-- base model for output. An alias is required in this case because
+-- the column must be aggregated. Defaults to "model_col".
+-- * external_column_alias (str): An alias to use when selecting the column
+-- from the external model for output. Defaults to "external_model_col".
+-- * additional_select_columns (dict): Standard parameter for selecting
+-- additional columns from the base model for use in reporting failures.
+-- `model.{column_name}`, `external_model.{external_column_name`}`, and
+-- the columns specified in the `group_by` parameter are already selected
+-- by default and do not need to be included using this parameter.
+-- See the `format_additional_select_columns` macro for more information.
+-- Note that while this parameter can often be either a string or a dict,
+-- a dict is required for this test and it must contain the `alias`
+-- and `agg_func` parameters given that results are grouped by the
+-- columns specified in `group_by`.
 --
 {% test row_values_match_after_join(
     model,
@@ -65,9 +65,13 @@
     {%- else -%} {%- set model_col = "model." ~ column_name -%}
     {%- endif -%}
 
-    {%- if "." in external_column_name -%} {%- set external_model_col = external_column_name -%}
+    {%- if "." in external_column_name -%}
+        {%- set external_model_col = external_column_name -%}
+
     {%- else -%}
+
         {%- set external_model_col = "external_model." ~ external_column_name -%}
+
     {%- endif -%}
 
     select
@@ -78,8 +82,7 @@
         array_agg({{ model_col }}) as {{ column_alias }},
         array_agg({{ external_model_col }}) as {{ external_column_alias }}
     from {{ external_model }} as external_model
-    join (select * from {{ model }}) as model
-        {{ join_condition }}
+    join (select * from {{ model }}) as model {{ join_condition }}
     group by {{ group_by_csv }}
     having
         sum(case when {{ external_model_col }} = {{ model_col }} then 1 else 0 end) = 0

--- a/dbt/tests/generic/test_row_values_match_after_join.sql
+++ b/dbt/tests/generic/test_row_values_match_after_join.sql
@@ -23,6 +23,8 @@
 --
 -- Optional parameters:
 --
+-- * join_type(str): The type of join to use, e.g. "inner join" or "left join".
+-- Defaults to "inner join".
 -- * column_alias (str): An alias to use when selecting the column from the
 -- base model for output. An alias is required in this case because
 -- the column must be aggregated. Defaults to "model_col".
@@ -46,6 +48,7 @@
     external_column_name,
     join_condition,
     group_by,
+    join_type="inner join",
     column_alias="model_col",
     external_column_alias="external_model_col",
     additional_select_columns=[]
@@ -81,8 +84,9 @@
         {% endif %}
         array_agg({{ model_col }}) as {{ column_alias }},
         array_agg({{ external_model_col }}) as {{ external_column_alias }}
-    from {{ external_model }} as external_model
-    join (select * from {{ model }}) as model {{ join_condition }}
+    from
+        {{ external_model }} as external_model
+        {{ join_type }} (select * from {{ model }}) as model {{ join_condition }}
     group by {{ group_by_csv }}
     having
         sum(case when {{ external_model_col }} = {{ model_col }} then 1 else 0 end) = 0

--- a/dbt/tests/generic/test_row_values_match_after_join.sql
+++ b/dbt/tests/generic/test_row_values_match_after_join.sql
@@ -1,3 +1,5 @@
+-- fmt: off
+--
 -- Test that row values match after joining two tables. Row values can be
 -- a subset of the values in the joined table, i.e. if the class of PINA
 -- from tableA is '212' and the class of PINA from tableB is '211' and '212',
@@ -5,42 +7,49 @@
 --
 -- Required parameters:
 --
--- * external_model (str): The name of the model to join to.
--- * external_column_name (str): The name of the column in `external_model`
--- to join to.
--- * join_condition (str): The ON (or USING) portion of a JOIN clause,
--- represented as a string. Note that in the case where ON is used,
--- columns in the base model should be formatted like `model.{column}`
--- while columns in the external model should be formatted like
--- `external_model.{column}`, e.g. `ON model.pin = external_model.parid`.
--- This is not necessary in the case of USING, since USING does not
--- refer to tablenames directly.
--- * group_by (list of str): The columns from the base model to pass to the
--- GROUP BY function used in the test query. Unlike `join_condition`,
--- these column names do not have to be prefixed with `model.*`, since
--- they are assumed to come from the base model for the test and not the
--- external model.
+--    * external_model (str): The name of the model to join to.
+--
+--    * external_column_name (str): The name of the column in `external_model`
+--    to join to.
+--
+--    * join_condition (str): The ON (or USING) portion of a JOIN clause,
+--    represented as a string. Note that in the case where ON is used,
+--    columns in the base model should be formatted like `model.{column}`
+--    while columns in the external model should be formatted like
+--    `external_model.{column}`, e.g. `ON model.pin = external_model.parid`.
+--    This is not necessary in the case of USING, since USING does not
+--    refer to tablenames directly.
+--
+--    * group_by (list of str): The columns from the base model to pass to the
+--    GROUP BY function used in the test query. Unlike `join_condition`,
+--    these column names do not have to be prefixed with `model.*`, since
+--    they are assumed to come from the base model for the test and not the
+--    external model.
 --
 -- Optional parameters:
 --
--- * join_type(str): The type of join to use, e.g. "inner join" or "left join".
--- Defaults to "inner join".
--- * column_alias (str): An alias to use when selecting the column from the
--- base model for output. An alias is required in this case because
--- the column must be aggregated. Defaults to "model_col".
--- * external_column_alias (str): An alias to use when selecting the column
--- from the external model for output. Defaults to "external_model_col".
--- * additional_select_columns (dict): Standard parameter for selecting
--- additional columns from the base model for use in reporting failures.
--- `model.{column_name}`, `external_model.{external_column_name`}`, and
--- the columns specified in the `group_by` parameter are already selected
--- by default and do not need to be included using this parameter.
--- See the `format_additional_select_columns` macro for more information.
--- Note that while this parameter can often be either a string or a dict,
--- a dict is required for this test and it must contain the `alias`
--- and `agg_func` parameters given that results are grouped by the
--- columns specified in `group_by`.
+--    * join_type(str): The type of join to use, e.g. "inner join" or
+--    "left join". Defaults to "inner join".
 --
+--    * column_alias (str): An alias to use when selecting the column from the
+--    base model for output. An alias is required in this case because
+--    the column must be aggregated. Defaults to "model_col".
+--
+--    * external_column_alias (str): An alias to use when selecting the column
+--    from the external model for output. Defaults to "external_model_col".
+--
+--    * additional_select_columns (dict): Standard parameter for selecting
+--    additional columns from the base model for use in reporting failures.
+--    `model.{column_name}`, `external_model.{external_column_name`}`, and
+--    the columns specified in the `group_by` parameter are already selected
+--    by default and do not need to be included using this parameter.
+--    See the `format_additional_select_columns` macro for more information.
+--    Note that while this parameter can often be either a string or a dict,
+--    a dict is required for this test and it must contain the `alias`
+--    and `agg_func` parameters given that results are grouped by the
+--    columns specified in `group_by`.
+--
+-- fmt: on
 {% test row_values_match_after_join(
     model,
     column_name,


### PR DESCRIPTION
We would like to use the `row_values_match_after_join` and `res_class_matches_pardat` generics to implement https://github.com/ccao-data/ptaxsim/issues/31, but the generics as they exist now are too rigid to support the kinds of joins we need to do in those tests. In particular, neither test currently supports base models whose `parid` and `taxyr` columns have different names (e.g. `pin` or `year`), and `row_values_match_after_join` doesn't support left or outer joins.

This PR makes some tweaks to the two generics to support base models whose name schemes do not include `parid` and `taxyr`, and adds a `join_type` parameter to `row_values_match_after_join`. The changes are backwards-compatible in the case of `res_class_matches_pardat`, but breaking in the case of `row_values_match_after_join`; this is fine since the latter test is not yet in use anywhere in the codebase.

In the process of implementing these changes, I also beefed up the docs for these two generics (along with the `format_additional_select_columns` macro, which the generic docs reference) in order to make them easier to use by a dbt novice. I also implemented tests that use the new forms of these generics in order to test the changes, but I'm not including them here since I would like the implementer of https://github.com/ccao-data/ptaxsim/issues/31 to figure them out as an exercise.