### PR TITLE
Add class checks and other data validation prior to final db export

### DIFF
--- a/dbt/models/tax/schema.yml
+++ b/dbt/models/tax/schema.yml
@@ -23,7 +23,49 @@ sources:
 
       - name: pin
         description: '{{ doc("table_pin") }}'
-
+          columns:  
+            - name: tax_code_num
+              description: '{{ doc("shared_column_tax_code")}}'
+              tests:
+                - row_values_match_after_join:
+                  name: pin_tax_dist_matches_iasworld_legdat
+                  external_model: source('iasworld', 'legdat')
+                  external_column_name: taxdist
+                  column_alias: tax_code_num
+                  external_column_alias: taxdist
+                  group_by: year, pin
+                  additional_select_columns: 
+                    - column: pin AS parid
+                      agg_func: max
+                    - column: year AS taxyr
+                      agg_func: max
+                  join_condition:
+                    ON  model.pin = external_model.parid
+                    AND model.year = external_model.taxyr
+                    AND external_model.cur = 'Y'
+                    AND external_model.deactivat IS NULL
+            - name: class
+              description: '{{ doc("shared_column_char_class")}}'
+              tests:
+                - res_class_matches_pardat:
+                    name: tax_pin_class_equals_iasworld_pardat
+                    parid_column_name: pin
+                    taxyr_column_name: year
+                    additional_select_column: year
+                      agg_func: max
+                - relationships:
+                    name: tax_pin_all_class_in_ccao_class_dict
+                    to: source('ccao', 'class_dict')
+                    field: class_code
+                    additional_select_columns: &select-columns
+                      - year
+                    config:
+                      where:
+                        CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                    meta:
+                      category: class_mismatch_or_issue
+                      description: class code must be valid
+    
       - name: pin_geometry_raw
         description: '{{ doc("table_pin_geometry_raw") }}'
 

--- a/dbt/models/tax/schema.yml
+++ b/dbt/models/tax/schema.yml
@@ -23,48 +23,52 @@ sources:
 
       - name: pin
         description: '{{ doc("table_pin") }}'
-          columns:  
-            - name: tax_code_num
-              description: '{{ doc("shared_column_tax_code")}}'
-              tests:
-                - row_values_match_after_join:
+        columns:  
+          - name: tax_code_num
+            description: '{{ doc("shared_column_tax_code")}}'
+            tests:
+              - row_values_match_after_join:
                   name: pin_tax_dist_matches_iasworld_legdat
                   external_model: source('iasworld', 'legdat')
                   external_column_name: taxdist
                   column_alias: tax_code_num
                   external_column_alias: taxdist
-                  group_by: year, pin
-                  additional_select_columns: 
-                    - column: pin AS parid
-                      agg_func: max
-                    - column: year AS taxyr
-                      agg_func: max
+                  group_by: 
+                    - year
+                    - pin
                   join_condition:
                     ON  model.pin = external_model.parid
                     AND model.year = external_model.taxyr
                     AND external_model.cur = 'Y'
                     AND external_model.deactivat IS NULL
-            - name: class
-              description: '{{ doc("shared_column_char_class")}}'
-              tests:
-                - res_class_matches_pardat:
-                    name: tax_pin_class_equals_iasworld_pardat
-                    parid_column_name: pin
-                    taxyr_column_name: year
-                    additional_select_column: year
-                      agg_func: max
-                - relationships:
-                    name: tax_pin_all_class_in_ccao_class_dict
-                    to: source('ccao', 'class_dict')
-                    field: class_code
-                    additional_select_columns: &select-columns
-                      - year
-                    config:
-                      where:
-                        CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                    meta:
-                      category: class_mismatch_or_issue
-                      description: class code must be valid
+                  config:
+                    where:
+                      CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+          - name: class
+            description: '{{ doc("shared_column_char_class")}}'
+            tests:
+              - res_class_matches_pardat:
+                  name: tax_pin_class_equals_iasworld_pardat
+                  parid_column_name: pin
+                  taxyr_column_name: year
+                  additional_select_columns:
+                    - agg_func: max
+                      column: year
+                  config:
+                    where:
+                      CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+              - relationships:
+                  name: tax_pin_all_class_in_ccao_class_dict
+                  to: source('ccao', 'class_dict')
+                  field: class_code
+                  additional_select_columns: &select-columns
+                    - year
+                  config:
+                    where:
+                      CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                  meta:
+                    category: class_mismatch_or_issue
+                    description: class code must be valid
     
       - name: pin_geometry_raw
         description: '{{ doc("table_pin_geometry_raw") }}'

--- a/dbt/models/tax/schema.yml
+++ b/dbt/models/tax/schema.yml
@@ -45,8 +45,7 @@ sources:
                     where:
                       CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                   meta:
-                    category: class_mismatch_or_issue
-                    description: class code must be valid
+                    description: tax_code_num should match legdat.taxdist
           - name: class
             description: '{{ doc("shared_column_char_class")}}'
             tests:
@@ -61,8 +60,7 @@ sources:
                     where:
                       CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                   meta:
-                    category: class_mismatch_or_issue
-                    description: class code must be valid
+                    description: at least one class should match pardat class
               - relationships:
                   name: tax_pin_all_class_in_ccao_class_dict
                   to: source('ccao', 'class_dict')

--- a/dbt/models/tax/schema.yml
+++ b/dbt/models/tax/schema.yml
@@ -44,6 +44,9 @@ sources:
                   config:
                     where:
                       CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                  meta:
+                    category: class_mismatch_or_issue
+                    description: class code must be valid
           - name: class
             description: '{{ doc("shared_column_char_class")}}'
             tests:
@@ -57,6 +60,9 @@ sources:
                   config:
                     where:
                       CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                  meta:
+                    category: class_mismatch_or_issue
+                    description: class code must be valid
               - relationships:
                   name: tax_pin_all_class_in_ccao_class_dict
                   to: source('ccao', 'class_dict')

--- a/dbt/models/tax/schema.yml
+++ b/dbt/models/tax/schema.yml
@@ -44,6 +44,7 @@ sources:
                   config:
                     where:
                       CAST(year AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                    severity: warn
                   meta:
                     description: tax_code_num should match legdat.taxdist
           - name: class


### PR DESCRIPTION
This PR creates 3 of the 4 dbt tests requested in the following [issue ](https://github.com/ccao-data/ptaxsim/issues/31). The fourth is on hold, due to the fact that there are known valuation discrepancies between iasWorld and PTaxSim. Thus, we may want to include a buffer on the matching function.  

I can't link the issue in the development sections since it's in the PTaxSim repository.