### PR TITLE
Add selector for `test-dbt-models` workflow and set its indirect selection to "cautious"

### DIFF
--- a/.github/workflows/test_dbt_models.yaml
+++ b/.github/workflows/test_dbt_models.yaml
@@ -31,10 +31,7 @@ jobs:
           # dbt doesn't differentiate between test failures and errors, but we
           # need to since we expect failures. Do this by capturing the output
           # and checking its contents to look for errors
-          if output=$(dbt test --target "$TARGET" \
-                               --select tag:test_qc_* \
-                               --exclude tag:test_qc_exclude_from_workbook \
-                               --store-failures); then
+          if output=$(dbt test --target "$TARGET" --selector qc_tests --store-failures); then
             echo "$output"
           else
             status_code="$?"

--- a/dbt/models/tax/schema.yml
+++ b/dbt/models/tax/schema.yml
@@ -23,7 +23,7 @@ sources:
 
       - name: pin
         description: '{{ doc("table_pin") }}'
-        columns:  
+        columns:
           - name: tax_code_num
             description: '{{ doc("shared_column_tax_code")}}'
             tests:
@@ -33,7 +33,7 @@ sources:
                   external_column_name: taxdist
                   column_alias: tax_code_num
                   external_column_alias: taxdist
-                  group_by: 
+                  group_by:
                     - year
                     - pin
                   join_condition:
@@ -74,7 +74,7 @@ sources:
                   meta:
                     category: class_mismatch_or_issue
                     description: class code must be valid
-    
+
       - name: pin_geometry_raw
         description: '{{ doc("table_pin_geometry_raw") }}'
 

--- a/dbt/selectors.yml
+++ b/dbt/selectors.yml
@@ -1,0 +1,14 @@
+selectors:
+  - name: qc_tests
+    description: Selector for running QC tests on iasWorld tables
+    definition:
+      union:
+        - method: tag
+          value: "test_qc_*"
+          # Only run tests that exclusively reference selected nodes. Useful
+          # for avoiding an edge case where a test that is not selected can
+          # run because it references a model that _is_ selected.
+          indirect_selection: cautious
+        - exclude:
+          - method: tag
+            value: test_qc_exclude_from_workbook

--- a/dbt/selectors.yml
+++ b/dbt/selectors.yml
@@ -6,8 +6,9 @@ selectors:
         - method: tag
           value: "test_qc_*"
           # Only run tests that exclusively reference selected nodes. Useful
-          # for avoiding an edge case where a test that is not selected can
-          # run because it references a model that _is_ selected.
+          # for avoiding an edge case where a test whose base model is not
+          # selected can run because it has an argument that references a model
+          # that _is_ selected.
           indirect_selection: cautious
         - exclude:
           - method: tag


### PR DESCRIPTION
This PR fixes a bug in the `test-dbt-models` workflow revealed by the [latest workflow run](https://github.com/ccao-data/data-architecture/actions/runs/8629528053/job/23653918137). The [indirect selection](https://docs.getdbt.com/reference/node-selection/test-selection-examples#indirect-selection) for our tests is set to "eager" by default, which means:

> By default, runs tests if any of the parent nodes are selected, regardless of whether all dependencies are met. This includes ANY tests that reference the selected nodes.

As a result, tests that are defined on a non-selected model will be run if they reference a selected model in an argument. This causes `test-dbt-models` to run `tax.pin` tests that reference `legdat` and `pardat` in their arguments:

https://github.com/ccao-data/data-architecture/blob/9e821802f2e964e4e6fff6fd04685d9137f4abf3/dbt/models/tax/schema.yml#L30-L64

This is a problem since the failure workbook code can only parse tests defined on models in the `iasworld` schema, so it raises an error when it tries to parse tests defined on `tax.pin`.

In order to fix this bug, this PR sets the indirect selection to "cautious" for this workflow, which means:

> Restricts tests to only those that exclusively reference selected nodes. Tests will only be executed if all the nodes they depend on are selected, which prevents tests from running if one or more of its parent nodes are unselected...

In the process, we define a [YAML selector](https://docs.getdbt.com/reference/node-selection/yaml-selectors) for this particular selection string, to make it easier to read and reuse.

Evidence that the workflow succeeds here: https://github.com/ccao-data/data-architecture/actions/runs/8634848786/job/23671719425