### PR TITLE
Small edits to dbt tests based on feedback

### DIFF
--- a/.github/scripts/transform_dbt_test_results.py
+++ b/.github/scripts/transform_dbt_test_results.py
@@ -103,6 +103,7 @@ DOCS_URL_FIELD = "docs_url"
 TAXYR_FIELD = "taxyr"
 PARID_FIELD = "parid"
 CARD_FIELD = "card"
+LAND_LINE_FIELD = "lline"
 TOWNSHIP_FIELD = "township_code"
 CLASS_FIELD = "class"
 WHO_FIELD = "who"
@@ -274,6 +275,7 @@ class TestCategory:
         TAXYR_FIELD,
         PARID_FIELD,
         CARD_FIELD,
+        LAND_LINE_FIELD,
         CLASS_FIELD,
         TOWNSHIP_FIELD,
         WHO_FIELD,

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -30,7 +30,7 @@ vars:
   # this should be the current year, since errors in past data cannot usually
   # be amended once records are closed. Set as an integer for compatibility
   # with comparison operators and SQL's BETWEEN
-  test_qc_year_start: 2023
+  test_qc_year_start: 2024
 
   # End year for testing data using test_qc_* tagged dbt tests. Typically set
   # to a date in the future, but can also be use to select specific time

--- a/dbt/models/default/schema/default.vw_pin_value.yml
+++ b/dbt/models/default/schema/default.vw_pin_value.yml
@@ -62,35 +62,35 @@ models:
           name: default_vw_pin_value_mailed_class_not_null
           column_name: mailed_class
           config:
-            where: CAST(year AS int) < {{ var('test_qc_year_start') }}
+            where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
             error_if: ">289" # as of 2024-03-15
       - not_null:
           name: default_vw_pin_value_certified_class_not_null
           column_name: certified_class
           config:
-            where: CAST(year AS int) < {{ var('test_qc_year_start') }}
+            where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
             error_if: ">13" # as of 2024-03-15
       - not_null:
           name: default_vw_pin_value_board_class_not_null
           column_name: board_class
           config:
-            where: CAST(year AS int) < {{ var('test_qc_year_start') }}
+            where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
             error_if: ">1260" # as of 2024-03-15
       - not_null:
           name: default_vw_pin_value_mailed_tot_not_null
           column_name: mailed_tot
           config:
-            where: CAST(year AS int) < {{ var('test_qc_year_start') }}
+            where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
             error_if: ">310" # as of 2024-03-15
       - not_null:
           name: default_vw_pin_value_certified_tot_not_null
           column_name: certified_tot
           config:
-            where: CAST(year AS int) < {{ var('test_qc_year_start') }}
+            where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
             error_if: ">13" # as of 2024-03-15
       - not_null:
           name: default_vw_pin_value_board_tot_not_null
           column_name: board_tot
           config:
-            where: CAST(year AS int) < {{ var('test_qc_year_start') }}
+            where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
             error_if: ">1260" # as of 2024-03-15

--- a/dbt/models/default/schema/default.vw_pin_value.yml
+++ b/dbt/models/default/schema/default.vw_pin_value.yml
@@ -63,34 +63,34 @@ models:
           column_name: mailed_class
           config:
             where: CAST(year AS int) < {{ var('test_qc_year_start') }}
-            error_if: ">289" # as of 2024-03-15
+            error_if: ">289"
       - not_null:
           name: default_vw_pin_value_certified_class_not_null
           column_name: certified_class
           config:
             where: CAST(year AS int) < {{ var('test_qc_year_start') }}
-            error_if: ">15" # as of 2024-03-15
+            error_if: ">15"
       - not_null:
           name: default_vw_pin_value_board_class_not_null
           column_name: board_class
           config:
             where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
-            error_if: ">1260" # as of 2024-03-15
+            error_if: ">1260"
       - not_null:
           name: default_vw_pin_value_mailed_tot_not_null
           column_name: mailed_tot
           config:
             where: CAST(year AS int) < {{ var('test_qc_year_start') }}
-            error_if: ">310" # as of 2024-03-15
+            error_if: ">310"
       - not_null:
           name: default_vw_pin_value_certified_tot_not_null
           column_name: certified_tot
           config:
             where: CAST(year AS int) < {{ var('test_qc_year_start') }}
-            error_if: ">15" # as of 2024-03-15
+            error_if: ">15"
       - not_null:
           name: default_vw_pin_value_board_tot_not_null
           column_name: board_tot
           config:
             where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
-            error_if: ">1260" # as of 2024-03-15
+            error_if: ">1260"

--- a/dbt/models/default/schema/default.vw_pin_value.yml
+++ b/dbt/models/default/schema/default.vw_pin_value.yml
@@ -62,14 +62,14 @@ models:
           name: default_vw_pin_value_mailed_class_not_null
           column_name: mailed_class
           config:
-            where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
+            where: CAST(year AS int) < {{ var('test_qc_year_start') }}
             error_if: ">289" # as of 2024-03-15
       - not_null:
           name: default_vw_pin_value_certified_class_not_null
           column_name: certified_class
           config:
-            where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
-            error_if: ">13" # as of 2024-03-15
+            where: CAST(year AS int) < {{ var('test_qc_year_start') }}
+            error_if: ">15" # as of 2024-03-15
       - not_null:
           name: default_vw_pin_value_board_class_not_null
           column_name: board_class
@@ -80,14 +80,14 @@ models:
           name: default_vw_pin_value_mailed_tot_not_null
           column_name: mailed_tot
           config:
-            where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
+            where: CAST(year AS int) < {{ var('test_qc_year_start') }}
             error_if: ">310" # as of 2024-03-15
       - not_null:
           name: default_vw_pin_value_certified_tot_not_null
           column_name: certified_tot
           config:
-            where: CAST(year AS int) < {{ var('test_qc_year_start') }} - 1
-            error_if: ">13" # as of 2024-03-15
+            where: CAST(year AS int) < {{ var('test_qc_year_start') }}
+            error_if: ">15" # as of 2024-03-15
       - not_null:
           name: default_vw_pin_value_board_tot_not_null
           column_name: board_tot

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -897,13 +897,13 @@ sources:
                       WHEN class = '206' THEN 4999
                       WHEN class = '207' THEN 2000
                       WHEN class = '208' THEN 4999
-                      WHEN class = '209' THEN 20000
+                      WHEN class = '209' THEN 50000
                       WHEN class = '210' THEN 10000
-                      WHEN class = '211' THEN 20000
-                      WHEN class = '212' THEN 20000
+                      WHEN class = '211' THEN 40000
+                      WHEN class = '212' THEN 40000
                       WHEN class = '234' THEN 10000
                       WHEN class = '278' THEN 3800
-                      WHEN class = '295' THEN 10000
+                      WHEN class = '295' THEN 20000
                       ELSE 20000
                     END
                   additional_select_columns:

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -869,44 +869,10 @@ sources:
                   meta:
                     description: sfla (Building Square Footage) should not be null
               - accepted_range:
-                  name: iasworld_dweldat_sfla_matches_class_definition
-                  min_value: |
-                    CASE
-                      WHEN class = '202' THEN 1
-                      WHEN class = '203' THEN 1000
-                      WHEN class = '204' THEN 1801
-                      WHEN class = '205' THEN 1
-                      WHEN class = '206' THEN 2201
-                      WHEN class = '207' THEN 1
-                      WHEN class = '208' THEN 3801
-                      WHEN class = '209' THEN 5000
-                      WHEN class = '210' THEN 1
-                      WHEN class = '211' THEN 1
-                      WHEN class = '212' THEN 1
-                      WHEN class = '234' THEN 1
-                      WHEN class = '278' THEN 2001
-                      WHEN class = '295' THEN 1
-                      ELSE 1
-                    END
-                  max_value: |
-                    CASE
-                      WHEN class = '202' THEN 999
-                      WHEN class = '203' THEN 1800
-                      WHEN class = '204' THEN 10000
-                      WHEN class = '205' THEN 2200
-                      WHEN class = '206' THEN 4999
-                      WHEN class = '207' THEN 2000
-                      WHEN class = '208' THEN 4999
-                      WHEN class = '209' THEN 50000
-                      WHEN class = '210' THEN 10000
-                      WHEN class = '211' THEN 40000
-                      WHEN class = '212' THEN 40000
-                      WHEN class = '234' THEN 10000
-                      WHEN class = '278' THEN 3800
-                      WHEN class = '295' THEN 20000
-                      ELSE 20000
-                    END
-                  additional_select_columns:
+                  name: iasworld_dweldat_sfla_between_1_and_999_for_class_202
+                  min_value: 1
+                  max_value: 999
+                  additional_select_columns: &select-columns-with-class
                     - taxyr
                     - parid
                     - card
@@ -916,31 +882,208 @@ sources:
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND class IN (
-                        '202', '203', '204', '205', '206', '207', '208', '209',
-                        '210', '211', '212', '234', '278', '295'
-                      )
                       AND cur = 'Y'
                       AND deactivat IS NULL
+                      AND class = '202'
                   meta:
                     description: >
-                      sfla (Building Square Footage) should match the class
-                      definition for class 2 regression properties
+                      sfla (Building Square Footage) should be between
+                      1 and 999 for class 202 cards
               - accepted_range:
-                  name: iasworld_dweldat_sfla_mf_between_1_and_20000
-                  min_value: 1
-                  max_value: 20000
-                  additional_select_columns: *select-columns
+                  name: iasworld_dweldat_sfla_between_1000_and_1800_for_class_203
+                  min_value: 1000
+                  max_value: 1800
+                  additional_select_columns: *select-columns-with-class
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND class IN ('208', '209', '211', '212')
                       AND cur = 'Y'
                       AND deactivat IS NULL
+                      AND class = '203'
                   meta:
                     description: >
-                      sfla (Building Square Footage) should be between 1 and 20000
-                      for multi-family and large single-family
+                      sfla (Building Square Footage) should be between
+                      1000 and 1800 for class 203 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_1801_and_25000_for_class_204
+                  min_value: 1801
+                  max_value: 25000
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '204'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      1801 and 25000 for class 204 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_1_and_2200_for_class_205
+                  min_value: 1
+                  max_value: 2200
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '205'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      1 and 2200 for class 205 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_2201_and_4999_for_class_206
+                  min_value: 2201
+                  max_value: 4999
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '206'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      2201 and 4999 for class 206 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_1_and_2000_for_class_207
+                  min_value: 1
+                  max_value: 2000
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '207'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      1 and 2000 for class 207 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_3801_and_4999_for_class_208
+                  min_value: 3801
+                  max_value: 4999
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '208'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      3801 and 4999 for class 208 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_5000_and_50000_for_class_209
+                  min_value: 5000
+                  max_value: 50000
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '209'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      5000 and 50000 for class 209 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_1_and_10000_for_class_210
+                  min_value: 1
+                  max_value: 10000
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '210'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      1 and 10000 for class 210 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_1_and_40000_for_class_211
+                  min_value: 1
+                  max_value: 40000
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '211'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      1 and 40000 for class 211 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_1_and_20000_for_class_212
+                  min_value: 1
+                  max_value: 20000
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '212'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      1 and 20000 for class 212 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_1_and_10000_for_class_234
+                  min_value: 1
+                  max_value: 10000
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '234'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      1 and 10000 for class 234 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_2001_and_3800_for_class_278
+                  min_value: 2001
+                  max_value: 3800
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '278'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      2001 and 3800 for class 278 cards
+              - accepted_range:
+                  name: iasworld_dweldat_sfla_between_1_and_20000_for_class_295
+                  min_value: 1
+                  max_value: 20000
+                  additional_select_columns: *select-columns-with-class
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '295'
+                  meta:
+                    description: >
+                      sfla (Building Square Footage) should be between
+                      1 and 20000 for class 295 cards
           - name: shfact
             description: Story height factor
           - name: sidpct

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -364,14 +364,30 @@ sources:
                     description: >
                       fixbath (Number of Full Baths) should not be null
               - accepted_range:
-                  name: iasworld_dweldat_fixbath_between_1_and_16
+                  name: iasworld_dweldat_fixbath_matches_number_of_units
                   min_value: 1
-                  max_value: 16
-                  additional_select_columns: *select-columns
+                  max_value: |
+                    CASE
+                      WHEN user14 IS NULL OR user14 = '0' OR user14 = '6' THEN 7
+                      WHEN user14 = '1' THEN 14
+                      WHEN user14 = '2' THEN 21
+                      WHEN user14 = '3' THEN 28
+                      WHEN user14 = '4' THEN 35
+                      WHEN user14 = '5' THEN 42
+                      ELSE 7
+                    END
+                  additional_select_columns: &select-columns-with-num-units
+                    - taxyr
+                    - parid
+                    - card
+                    - who
+                    - wen
+                    - user14
                   config: *unique-conditions
                   meta:
                     description: >
-                      fixbath (Number of Full Baths) should be between 1 and 16
+                      fixbath (Number of Full Baths) should be <= 7 times the
+                      number of units (user14)
           - name: fixbath1
             description: Number of full bathrooms on the first floor
           - name: fixbath2
@@ -422,15 +438,9 @@ sources:
                       WHEN user14 = '3' THEN 20
                       WHEN user14 = '4' THEN 25
                       WHEN user14 = '5' THEN 30
-                      ELSE 6
+                      ELSE 5
                     END
-                  additional_select_columns: &select-columns-with-num-units
-                    - taxyr
-                    - parid
-                    - card
-                    - who
-                    - wen
-                    - user14
+                  additional_select_columns: *select-columns-with-num-units
                   config: *unique-conditions
                   meta:
                     description: >

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -869,7 +869,7 @@ sources:
                   meta:
                     description: sfla (Building Square Footage) should not be null
               - accepted_range:
-                  name: iasworld_dweldat_sfla_between_1_and_10000
+                  name: iasworld_dweldat_sfla_matches_class_definition
                   min_value: |
                     CASE
                       WHEN class = '202' THEN 1

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -907,14 +907,14 @@ sources:
                     description: stories (Type of Residence) should not be null
               - expression_is_true:
                   name: iasworld_dweldat_stories_in_accepted_values
-                  expression: 'IN (1.00, 2.00, 3.00, 4.00, 5.00, 9.90)'
+                  expression: 'IN (1.00, 2.00, 3.00, 4.00, 5.00, 6.00, 7.00, 8.00, 9.00, 9.90)'
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
                     category: incorrect_values
                     description: >
                       stories (Type of Residence) should be one of 1.00, 2.00,
-                      3.00, 4.00, 5.00, or 9.90
+                      3.00, 4.00, 5.00, 6.00, 7.00, 8.00, 9.00, or 9.90
           - name: style
             description: Architectural style
           - name: subtval

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -403,22 +403,39 @@ sources:
           - name: fixhalf
             description: '{{ doc("shared_column_char_hbath") }}'
             tests:
-              - not_null:
-                  name: iasworld_dweldat_fixhalf_not_null
-                  additional_select_columns: *select-columns
-                  config: *unique-conditions
-                  meta:
-                    description: >
-                      fixhalf (Number of Half Baths) should not be null
               - accepted_range:
-                  name: iasworld_dweldat_fixhalf_between_0_and_6
+                  name: iasworld_dweldat_fixhalf_gte_0
                   min_value: 0
-                  max_value: 6
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
                     description: >
-                      fixhalf (Number of Half Baths) should be between 0 and 6
+                      fixhalf (Number of Half Baths) should be >= 0
+              - accepted_range:
+                  name: iasworld_dweldat_fixhalf_matches_number_of_units
+                  min_value: 0
+                  max_value: |
+                    CASE
+                      WHEN user14 IS NULL OR user14 = '0' OR user14 = '6' THEN 5
+                      WHEN user14 = '1' THEN 10
+                      WHEN user14 = '2' THEN 15
+                      WHEN user14 = '3' THEN 20
+                      WHEN user14 = '4' THEN 25
+                      WHEN user14 = '5' THEN 30
+                      ELSE 6
+                    END
+                  additional_select_columns: &select-columns-with-num-units
+                    - taxyr
+                    - parid
+                    - card
+                    - who
+                    - wen
+                    - user14
+                  config: *unique-conditions
+                  meta:
+                    description: >
+                      fixhalf (Number of Half Baths) should be <= 5 times the
+                      number of units (user14)
           - name: fixhalf1
             description: Number of half baths on the first floor
           - name: fixhalf2
@@ -689,33 +706,24 @@ sources:
                     description: >
                       rmbed (Number of Bedrooms) should not be null
               - accepted_range:
-                  name: iasworld_dweldat_rmbed_sf_between_1_and_15
+                  name: iasworld_dweldat_rmbed_matches_number_of_units
                   min_value: 1
-                  max_value: 15
-                  additional_select_columns: *select-columns
-                  config:
-                    where: |
-                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND class NOT IN ('211', '212')
-                      AND cur = 'Y'
-                      AND deactivat IS NULL
+                  max_value: |
+                    CASE
+                      WHEN user14 IS NULL OR user14 = '0' OR user14 = '6' THEN 8
+                      WHEN user14 = '1' THEN 16
+                      WHEN user14 = '2' THEN 24
+                      WHEN user14 = '3' THEN 32
+                      WHEN user14 = '4' THEN 40
+                      WHEN user14 = '5' THEN 48
+                      ELSE 8
+                    END
+                  additional_select_columns: *select-columns-with-num-units
+                  config: *unique-conditions
                   meta:
                     description: >
-                      rmbed (Number of Bedrooms) should be between 1 and 15
-              - accepted_range:
-                  name: iasworld_dweldat_rmbed_mf_between_1_and_24
-                  min_value: 1
-                  max_value: 24
-                  additional_select_columns: *select-columns
-                  config:
-                    where: |
-                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND class IN ('211', '212')
-                      AND cur = 'Y'
-                      AND deactivat IS NULL
-                  meta:
-                    description: >
-                      rmbed (Number of Bedrooms) should be between 1 and 24
+                      rmbed (Number of Bedrooms) should be <= 8 times the
+                      number of units (user14)
               - expression_is_true:
                   name: iasworld_dweldat_rmbed_lte_rmtot
                   expression: <= rmtot
@@ -851,20 +859,63 @@ sources:
                   meta:
                     description: sfla (Building Square Footage) should not be null
               - accepted_range:
-                  name: iasworld_dweldat_sfla_sf_between_1_and_10000
-                  min_value: 1
-                  max_value: 10000
-                  additional_select_columns: *select-columns
+                  name: iasworld_dweldat_sfla_between_1_and_10000
+                  min_value: |
+                    CASE
+                      WHEN class = '202' THEN 1
+                      WHEN class = '203' THEN 1000
+                      WHEN class = '204' THEN 1801
+                      WHEN class = '205' THEN 1
+                      WHEN class = '206' THEN 2201
+                      WHEN class = '207' THEN 1
+                      WHEN class = '208' THEN 3801
+                      WHEN class = '209' THEN 5000
+                      WHEN class = '210' THEN 1
+                      WHEN class = '211' THEN 1
+                      WHEN class = '212' THEN 1
+                      WHEN class = '234' THEN 1
+                      WHEN class = '278' THEN 2001
+                      WHEN class = '295' THEN 1
+                      ELSE 1
+                    END
+                  max_value: |
+                    CASE
+                      WHEN class = '202' THEN 999
+                      WHEN class = '203' THEN 1800
+                      WHEN class = '204' THEN 10000
+                      WHEN class = '205' THEN 2200
+                      WHEN class = '206' THEN 4999
+                      WHEN class = '207' THEN 2000
+                      WHEN class = '208' THEN 4999
+                      WHEN class = '209' THEN 20000
+                      WHEN class = '210' THEN 10000
+                      WHEN class = '211' THEN 20000
+                      WHEN class = '212' THEN 20000
+                      WHEN class = '234' THEN 10000
+                      WHEN class = '278' THEN 3800
+                      WHEN class = '295' THEN 10000
+                      ELSE 20000
+                    END
+                  additional_select_columns:
+                    - taxyr
+                    - parid
+                    - card
+                    - class
+                    - who
+                    - wen
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND class NOT IN ('208', '209', '211', '212', '236', '297')
+                      AND class IN (
+                        '202', '203', '204', '205', '206', '207', '208', '209',
+                        '210', '211', '212', '234', '278', '295'
+                      )
                       AND cur = 'Y'
                       AND deactivat IS NULL
                   meta:
                     description: >
-                      sfla (Building Square Footage) should be between 1 and 10000
-                      for single-family properties (excl. 208 or 209)
+                      sfla (Building Square Footage) should match the class
+                      definition for class 2 regression properties
               - accepted_range:
                   name: iasworld_dweldat_sfla_mf_between_1_and_20000
                   min_value: 1
@@ -974,20 +1025,6 @@ sources:
                     description: user3 (Renovated) should be '0' or '1'
           - name: user4
             description: '{{ doc("shared_column_char_tp_dsgn") }}'
-            tests:
-              - not_null:
-                  name: iasworld_dweldat_char_tp_dsgn_not_null
-                  additional_select_columns: *select-columns
-                  config: *unique-conditions
-                  meta:
-                    description: user4 should not be null
-              - accepted_values:
-                  name: iasworld_dweldat_char_tp_dsgn_in_accepted_values
-                  values: ['0', '1', '2', '3']
-                  additional_select_columns: *select-columns
-                  config: *unique-conditions
-                  meta:
-                    description: user4 should be an integer between 0 and 3
           - name: user5
             description: '{{ doc("shared_column_char_tp_plan") }}'
             tests:
@@ -1126,24 +1163,19 @@ sources:
                   meta:
                     description: >
                       user20 (No. of Commercial Units) should not be null
-          - name: user24
-            description: '{{ doc("shared_column_card_proration_rate") }}'
-            tests:
-              - not_null:
-                  name: iasworld_dweldat_card_proration_rate_not_null
+              - accepted_values:
+                  name: iasworld_dweldat_char_ncu_between_0_and_5
+                  values: ['0', '1', '2', '3', '4', '5']
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
-                    description: user24 (Proration %) should not be null
+                    description: >
+                      user20 (No. of Commercial Units) should be an integer between 0 and 5
+          - name: user24
+            description: '{{ doc("shared_column_card_proration_rate") }}'
           - name: user30
             description: '{{ doc("shared_column_char_porch") }}'
             tests:
-              - not_null:
-                  name: iasworld_dweldat_char_porch_not_null
-                  additional_select_columns: *select-columns
-                  config: *unique-conditions
-                  meta:
-                    description: user30 (Porch) should not be null
               - accepted_values:
                   name: iasworld_dweldat_char_porch_accepted_values
                   values: ['0', '1', '2']
@@ -1156,10 +1188,24 @@ sources:
             tests:
               - not_null:
                   name: iasworld_dweldat_char_gar_att_not_null
-                  additional_select_columns: *select-columns
-                  config: *unique-conditions
+                  additional_select_columns: &select-columns-with-garage-size
+                    - taxyr
+                    - parid
+                    - card
+                    - who
+                    - wen
+                    - user33
+                  config: &unique-conditions-with-garage-size
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class NOT IN ('201', '213', '218', '219', '220', '221', '224', '225', '236', '240', '241', '290', '294', '297')
+                      AND user33 != '7'
                   meta:
-                    description: user31 (Garage Attached) should not be null
+                    description: >
+                      user31 (Garage Attached) should not be null
+                      if user33 (Garage Size) is not 7 (NONE)
               - accepted_values:
                   name: iasworld_dweldat_char_gar_att_accepted_values
                   values: ['1', '2']
@@ -1172,10 +1218,12 @@ sources:
             tests:
               - not_null:
                   name: iasworld_dweldat_char_gar_area_not_null
-                  additional_select_columns: *select-columns
-                  config: *unique-conditions
+                  additional_select_columns: *select-columns-with-garage-size
+                  config: *unique-conditions-with-garage-size
                   meta:
-                    description: user32 (Garage in Area) should not be null
+                    description: >
+                      user32 (Garage in Area) should not be null
+                      if user33 (Garage Size) is not 7 (NONE)
               - accepted_values:
                   name: iasworld_dweldat_char_gar_area_accepted_values
                   values: ['1', '2']
@@ -1205,10 +1253,27 @@ sources:
             tests:
               - not_null:
                   name: iasworld_dweldat_char_gar_cnst_not_null
-                  additional_select_columns: *select-columns
-                  config: *unique-conditions
+                  additional_select_columns: *select-columns-with-garage-size
+                  config: *unique-conditions-with-garage-size
                   meta:
-                    description: user34 (Garage Construction) should not be null
+                    description: >
+                      user34 (Garage Construction) should not be null
+                      if user33 (Garage Size) is not 7 (NONE)
+              - is_null:
+                  name: iasworld_dweldat_char_gar_cnst_null_if_gar_size_is_null
+                  additional_select_columns: *select-columns-with-garage-size
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class NOT IN ('201', '213', '218', '219', '220', '221', '224', '225', '236', '240', '241', '290', '294', '297')
+                      AND user33 = '7'
+                      AND user34 != '0'
+                  meta:
+                    description: >
+                      user34 (Garage Construction) should be null or 0
+                      if user33 (Garage Size) is 7 (NONE)
               - accepted_values:
                   name: iasworld_dweldat_char_gar_cnst_accepted_values
                   values: ['1', '2', '3', '4']
@@ -1234,12 +1299,6 @@ sources:
           - name: wbfp_o
             description: '{{ doc("shared_column_char_frpl") }}'
             tests:
-              - not_null:
-                  name: iasworld_dweldat_char_frpl_not_null
-                  additional_select_columns: *select-columns
-                  config: *unique-conditions
-                  meta:
-                    description: wbfp_o (Number of Fireplaces) should not be null
               - accepted_range:
                   name: iasworld_dweldat_char_frpl_between_0_and_6
                   min_value: 0
@@ -1322,21 +1381,6 @@ sources:
               meta:
                 category: incorrect_values
                 description: user24 (Proration %) should be between 0 and 100
-          - expression_is_true:
-              name: iasworld_dweldat_char_ncu_between_0_and_5
-              expression: 'CAST(user20 AS decimal) BETWEEN 0 AND 5'
-              additional_select_columns:
-                - parid
-                - taxyr
-                - card
-                - who
-                - wen
-                - user20
-              config: *unique-conditions
-              meta:
-                category: incorrect_values
-                description: >
-                  user20 (No. of Commercial Units) should be an integer between 0 and 5
           - expression_is_true:
               name: iasworld_dweldat_bsmt_and_user12_match_234_class
               expression: bsmt = '3' and user12 = '1'

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1120,7 +1120,9 @@ sources:
                       AND cur = 'Y'
                       AND deactivat IS NULL
                   meta:
-                    description: user14 (Total Number of Units) should not be null
+                    description: >
+                      user14 (Total Number of Units) should not be null
+                      for class 211 and 212 properties
               - accepted_values:
                   name: iasworld_dweldat_char_apts_accepted_values
                   values: ['1', '2', '3', '4', '5', '6']
@@ -1134,7 +1136,7 @@ sources:
                   meta:
                     description: >
                       user14 (Total Number of Units) should be an integer
-                      between 1 and 6
+                      between 1 and 6 for class 211 and 212 properties
           - name: user15
             description: '{{ doc("shared_column_char_use") }}'
             tests:

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -24,7 +24,7 @@ sources:
                   additional_select_columns:
                     - taxyr
                     - parid
-                    - card
+                    - lline
                     - who
                     - wen
                     - sf
@@ -50,7 +50,7 @@ sources:
                   additional_select_columns: &select-columns
                     - taxyr
                     - parid
-                    - card
+                    - lline
                     - who
                     - wen
                   config: *unique-conditions
@@ -188,7 +188,6 @@ sources:
                     - parid
                     - taxyr
                   additional_select_columns:
-                    - card
                     - who
                     - wen
                   config: *unique-conditions
@@ -247,7 +246,7 @@ sources:
                   name: iasworld_land_parid_not_null
                   additional_select_columns: &select-columns-no-parid
                     - taxyr
-                    - card
+                    - lline
                     - who
                     - wen
                   config: *unique-conditions
@@ -372,9 +371,6 @@ sources:
                 - lline
                 - taxyr
               additional_select_columns:
-                - column: card
-                  alias: card
-                  agg_func: array_agg
                 - column: who
                   alias: who
                   agg_func: array_agg

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -99,6 +99,8 @@ sources:
                       agg_func: max
                     - column: parid
                       agg_func: max
+                    - column: lline
+                      agg_func: array_agg
                     - column: who
                       agg_func: max
                     - column: wen

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -793,7 +793,16 @@ Possible values for this variable are:
 - `3` = 3 story or more (`3STRY+`)
 - `4` = Split level (`SPLT`)
 - `5` = 1.5 story (`1.5STRY`)
+- `6` = 1.6 story (`1.5STRY`)
+- `7` = 1.7 story (`1.5STRY`)
+- `8` = 1.8 story (`1.5STRY`)
+- `9` = 1.9 story (`1.5STRY`)
 - `9.9` = Missing (`MSSNG`)
+
+Note that while `6`, `7`, `8`, and `9` indicate specific values between 1 and
+2 stories, we currently collapse them to a single `1.5STRY` value since these
+intermediate values are rare and currently do not have enough signal to be
+useful for modeling.
 {% enddocs %}
 
 ## char_unit_sf

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -570,7 +570,8 @@ Defined as bathrooms with a bath or shower. If this value is missing, the defaul
 {% docs shared_column_char_frpl %}
 Number of fireplaces.
 
-Counted as the number of flues one can see from the outside of the building
+Counted as the number of flues one can see from the outside of the building.
+Note that either 0 or null can indicate no fireplaces.
 {% enddocs %}
 
 ## char_gar1_area / char_gar2_area
@@ -649,7 +650,8 @@ Possible values for this variable are:
 {% docs shared_column_char_hbath %}
 Number of half baths.
 
-Defined as bathrooms without a shower or bathtub
+Defined as bathrooms without a shower or bathtub. Note that either 0 or
+null can indicate no half baths.
 {% enddocs %}
 
 ## char_land_sf
@@ -679,6 +681,7 @@ Porch type.
 
 Possible values for this variable are:
 
+- `null` = None
 - `0` = None (`NONE`)
 - `1` = Frame enclosed (`FRAM`)
 - `2` = Masonry enclosed (`MSRY`)

--- a/dbt/tests/generic/test_is_null.sql
+++ b/dbt/tests/generic/test_is_null.sql
@@ -1,0 +1,13 @@
+-- Confirm that a column is null. Essentially, the opposite of the `not_null`
+-- test.
+{% test is_null(model, column_name, additional_select_columns=[]) %}
+
+    select
+        {% if additional_select_columns -%}
+            {{ format_additional_select_columns(additional_select_columns) }},
+        {%- endif %}
+        {{ column_name }}
+    from {{ model }}
+    where {{ column_name }} is not null
+
+{% endtest %}


### PR DESCRIPTION
This PR makes a number of small edits to our dbt tests as described in https://github.com/ccao-data/data-architecture/issues/371. See that issue for a full list of the changes.

There are a few changes from the list that I haven't made yet. I'm curious to get your take:

* Update `iasworld_oby_card_between_1_and_100` to exclude condos, and see if the results are accurate (i.e., make sure that there are no non-condo buildings where card >100 makes sense)
    * These query results make me doubt that the failures are related to condos with large numbers of cards:

```sql
select oby.class, failures.*
from z_dev_jecochr_test_failure.iasworld_oby_card_between_1_and_100 failures
join iasworld.oby oby
    on oby.parid = failures.parid
    and oby.taxyr = failures.taxyr
    and oby.cur = 'Y'
    and oby.deactivat is null
```

* Move `iasworld_dweldat_card_proration_rate_not_null` from `dweldat.user24` to `dweldat.external_propct` and adjust its filters so that it only checks for prorated PINs (i.e. PINs with tiebacks)
    * I tried a few different ways of joining `dweldat` to `pardat` and filtering for only PINs with tiebacks but none of them seemed to produce a result set that made sense to me. I'm wondering if maybe my interpretation of the suggestion is incorrect; it seems a bit weird to be comparing a proration rate set on the dwelling level against a tieback set at the parcel level, which is making me think that perhaps I'm getting two different types of proration mixed up. Let me know if I'm misunderstanding the suggestion, and if not (meaning that the join is indeed just very complex) I can split this out into a separate issue and kick it over to you.   
* Adjust `iasworld_dweldat_char_ncu_between_0_and_5` to filter for 212s
    * These query results are making me think that this test is actually finding useful things:

```sql
select * from z_dev_jecochr_test_failure.iasworld_dweldat_char_ncu_between_0_and_5
```