### PR TITLE
Add new test to make sure tieback pins don't contain hyphens

### DIFF
--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -261,11 +261,12 @@ sources:
             description: '{{ doc("shared_column_tieback_key_pin") }}'
             tests:
               - expression_is_true: 
-                  name: iasworld_pardat+tieback_does_not_contain_hyphen
+                  name: iasworld_pardat_tieback_does_not_contain_hyphen
                   expression: |
                     not like '%-%'
-                  meta:
-                    description: tieback should not have any hyphens                  
+                  additional_select_columns: 
+                    - parid
+                    - taxyr
           - name: tiebkcd
             description: Tieback code
           - name: tiebldgpct

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -259,6 +259,11 @@ sources:
             description: '{{ doc("shared_column_year") }}'
           - name: tieback
             description: '{{ doc("shared_column_tieback_key_pin") }}'
+            tests:
+              - expression_is_true: 
+                  name: iasworld_pardat_does_not_contain_hyphen
+                  expression: |
+                    not like '%-%'
           - name: tiebkcd
             description: Tieback code
           - name: tiebldgpct

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -262,8 +262,7 @@ sources:
             tests:
               - expression_is_true: 
                   name: iasworld_pardat_tieback_does_not_contain_hyphen
-                  expression: |
-                    not like '%-%'
+                  expression: not like '%-%'
                   additional_select_columns: 
                     - parid
                     - taxyr

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -263,9 +263,8 @@ sources:
               - expression_is_true: 
                   name: iasworld_pardat_tieback_does_not_contain_hyphen
                   expression: not like '%-%'
-                  additional_select_columns: 
-                    - parid
-                    - taxyr
+                  additional_select_columns: *select-columns
+                  config: *unique-conditions
           - name: tiebkcd
             description: Tieback code
           - name: tiebldgpct

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -264,6 +264,8 @@ sources:
                   name: iasworld_pardat_does_not_contain_hyphen
                   expression: |
                     not like '%-%'
+                  meta:
+                    description: tieback should not have any -                  
           - name: tiebkcd
             description: Tieback code
           - name: tiebldgpct

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -265,6 +265,9 @@ sources:
                   expression: not like '%-%'
                   additional_select_columns: *select-columns
                   config: *unique-conditions
+                  meta:
+                    category: incorrect_values
+                    description: tieback should not contain hyphens
           - name: tiebkcd
             description: Tieback code
           - name: tiebldgpct

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -261,11 +261,11 @@ sources:
             description: '{{ doc("shared_column_tieback_key_pin") }}'
             tests:
               - expression_is_true: 
-                  name: iasworld_pardat_does_not_contain_hyphen
+                  name: iasworld_pardat+tieback_does_not_contain_hyphen
                   expression: |
                     not like '%-%'
                   meta:
-                    description: tieback should not have any -                  
+                    description: tieback should not have any hyphens                  
           - name: tiebkcd
             description: Tieback code
           - name: tiebldgpct


### PR DESCRIPTION
This test results in a failure with 3024 results.