### PR TITLE
Tweak dbt data docs sidebar

### DIFF
--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -45,7 +45,8 @@ jobs:
         run: |
           dbt docs generate --target prod
           # Editing index.html to inject a custom stylesheet and change the site metadata
-          sed -i 's|<head>|<head>\n\t<link rel="stylesheet" href="./assets/ccao-style.css" />|' target/index.html
+          sed -i 's|</head>|\t<link rel="stylesheet" href="./assets/ccao-style.css" />\n</head>|' target/index.html
+          sed -i 's|</head>|\t<script src="./assets/ccao-script.js"></script>\n</head>|' target/index.html
           sed -i 's|<title>dbt Docs</title>|<title>CCAO Data Catalog</title>|' target/index.html
           sed -i 's|content="dbt Docs"|content="CCAO Data Catalog"|' target/index.html
           sed -i 's|content="documentation for dbt"|content="Cook County Assessor'\''s Office data documentation"|' target/index.html

--- a/dbt/assets/ccao-script.js
+++ b/dbt/assets/ccao-script.js
@@ -1,18 +1,17 @@
 // Drops the useless "Group" tab from dbt docs
-var groupTab = document.querySelector('[ng-class="{active: (nav_selected == \'group\')}"]');
+const groupTab = document.querySelector('[ng-class="{active: (nav_selected == \'group\')}"]');
 if (groupTab) {
-    groupTab.parentNode.remove()
+  groupTab.parentNode.remove();
 }
 
 // Open the "Database" tab and "awsdatacatalog" database by default
-var databaseTab = document.querySelector('[ng-class="{active: (nav_selected == \'database\')}"]');
+const databaseTab = document.querySelector('[ng-class="{active: (nav_selected == \'database\')}"]');
 if (databaseTab) {
-    databaseTab.click();
+  databaseTab.click();
 }
-var targetTable = Array
-    .from(document.querySelectorAll('span.filename-normal'))
-    .find(span => span.textContent.trim() === 'awsdatacatalog');
+const targetTable = Array
+  .from(document.querySelectorAll('span.filename-normal'))
+  .find(span => span.textContent.trim() === 'awsdatacatalog');
 if (targetTable) {
-    targetTable.click();
+  targetTable.click();
 }
-

--- a/dbt/assets/ccao-script.js
+++ b/dbt/assets/ccao-script.js
@@ -1,0 +1,18 @@
+// Drops the useless "Group" tab from dbt docs
+var groupTab = document.querySelector('[ng-class="{active: (nav_selected == \'group\')}"]');
+if (groupTab) {
+    groupTab.parentNode.remove()
+}
+
+// Open the "Database" tab and "awsdatacatalog" database by default
+var databaseTab = document.querySelector('[ng-class="{active: (nav_selected == \'database\')}"]');
+if (databaseTab) {
+    databaseTab.click();
+}
+var targetTable = Array
+    .from(document.querySelectorAll('span.filename-normal'))
+    .find(span => span.textContent.trim() === 'awsdatacatalog');
+if (targetTable) {
+    targetTable.click();
+}
+

--- a/dbt/assets/ccao-script.js
+++ b/dbt/assets/ccao-script.js
@@ -1,17 +1,17 @@
 // Drops the useless "Group" tab from dbt docs
-const groupTab = document.querySelector('[ng-class="{active: (nav_selected == \'group\')}"]');
+const groupTab = document.querySelector('[ng-class="{active: (nav_selected == \'group\')}"]')
 if (groupTab) {
-  groupTab.parentNode.remove();
+  groupTab.parentNode.remove()
 }
 
 // Open the "Database" tab and "awsdatacatalog" database by default
-const databaseTab = document.querySelector('[ng-class="{active: (nav_selected == \'database\')}"]');
+const databaseTab = document.querySelector('[ng-class="{active: (nav_selected == \'database\')}"]')
 if (databaseTab) {
-  databaseTab.click();
+  databaseTab.click()
 }
 const targetTable = Array
   .from(document.querySelectorAll('span.filename-normal'))
-  .find(span => span.textContent.trim() === 'awsdatacatalog');
+  .find(span => span.textContent.trim() === 'awsdatacatalog')
 if (targetTable) {
-  targetTable.click();
+  targetTable.click()
 }


### PR DESCRIPTION
I got sufficiently annoyed with the dbt docs sidebar that I took a minute to tweak it. Here we:

- Remove the useless "Group" tab
- Open the "Database" tab and "awsdatacatalog" DB by default
