### PR TITLE
Define a dbt test to ensure that exempt pardat parcels are also exempt in all related tables

### DIFF
--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -46,7 +46,7 @@ jobs:
           dbt docs generate --target prod
           # Editing index.html to inject a custom stylesheet and change the site metadata
           sed -i 's|</head>|\t<link rel="stylesheet" href="./assets/ccao-style.css" />\n</head>|' target/index.html
-          sed -i 's|</head>|\t<script src="./assets/ccao-script.js"></script>\n</head>|' target/index.html
+          sed -i 's|</head>|\t<script defer src="./assets/ccao-script.js"></script>\n</head>|' target/index.html
           sed -i 's|<title>dbt Docs</title>|<title>CCAO Data Catalog</title>|' target/index.html
           sed -i 's|content="dbt Docs"|content="CCAO Data Catalog"|' target/index.html
           sed -i 's|content="documentation for dbt"|content="Cook County Assessor'\''s Office data documentation"|' target/index.html

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -37,6 +37,29 @@ sources:
                   meta:
                     category: class_mismatch_or_issue
                     description: class code must be valid
+              - row_values_match_after_join:
+                  name: iasworld_asmt_all_exempt_pardat_exempt
+                  external_model: source('iasworld', 'pardat')
+                  external_column_name: class
+                  column_alias: class
+                  external_column_alias: class
+                  group_by:
+                    - taxyr
+                    - parid                    
+                  join_condition:
+                    On model.parid = external_model.parid
+                    AND model.taxyr = external_model.taxyr
+                    AND external_model.cur = 'Y'
+                    AND external_model.deactivat IS NULL
+                  where:
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND rolltype != 'RR'
+                      AND deactivat IS NULL
+                      AND valclass IS NULL
+                      AND class IN ('EX')
+                  meta:
+                    category: class_mismatch_or_issue
+                    description: exempt values in land must be exempt
               - res_class_matches_pardat:
                   name: iasworld_asmt_all_class_matches_pardat_class
                   additional_select_columns:

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -37,29 +37,30 @@ sources:
                   meta:
                     category: class_mismatch_or_issue
                     description: class code must be valid
-              - row_values_match_after_join:
-                  name: iasworld_asmt_all_exempt_pardat_exempt
-                  external_model: source('iasworld', 'pardat')
-                  external_column_name: class
-                  column_alias: class
-                  external_column_alias: class
-                  group_by:
-                    - taxyr
-                    - parid                    
-                  join_condition:
-                    On model.parid = external_model.parid
-                    AND model.taxyr = external_model.taxyr
-                    AND external_model.cur = 'Y'
-                    AND external_model.deactivat IS NULL
-                  where:
+              - res_class_matches_pardat:
+                  name: iasworld_asmt_all_ex_matches_pardat_class_ex
+                  major_class_only: false
+                  join_type: inner
+                  additional_select_columns:
+                    - column: taxyr
+                      agg_func: max
+                    - column: parid
+                      agg_func: max
+                    - column: who
+                      agg_func: max
+                    - column: wen
+                      agg_func: max
+                  additional_pardat_filter: AND class = 'EX'
+                  config:
+                    where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND NOT REGEXP_LIKE(class, '[0-9]{3}[A|B]')
                       AND rolltype != 'RR'
                       AND deactivat IS NULL
                       AND valclass IS NULL
-                      AND class IN ('EX')
                   meta:
-                    category: class_mismatch_or_issue
-                    description: exempt values in land must be exempt
+                    description: >
+                      Exempt parcels in pardat should be exempt in land
               - res_class_matches_pardat:
                   name: iasworld_asmt_all_class_matches_pardat_class
                   additional_select_columns:

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -59,7 +59,6 @@ sources:
                     description: at least one class should match pardat class
               - res_class_matches_pardat:
                   name: iasworld_asmt_all_ex_matches_pardat_class_ex
-                  major_class_only: false
                   join_type: inner
                   additional_select_columns: *select-columns-aggregated
                   additional_pardat_filter: AND class = 'EX'

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -54,7 +54,6 @@ sources:
                   config:
                     where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND NOT REGEXP_LIKE(class, '[0-9]{3}[A|B]')
                       AND rolltype != 'RR'
                       AND deactivat IS NULL
                       AND valclass IS NULL

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -38,31 +38,8 @@ sources:
                     category: class_mismatch_or_issue
                     description: class code must be valid
               - res_class_matches_pardat:
-                  name: iasworld_asmt_all_ex_matches_pardat_class_ex
-                  major_class_only: false
-                  join_type: inner
-                  additional_select_columns:
-                    - column: taxyr
-                      agg_func: max
-                    - column: parid
-                      agg_func: max
-                    - column: who
-                      agg_func: max
-                    - column: wen
-                      agg_func: max
-                  additional_pardat_filter: AND class = 'EX'
-                  config:
-                    where: |
-                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND rolltype != 'RR'
-                      AND deactivat IS NULL
-                      AND valclass IS NULL
-                  meta:
-                    description: >
-                      Exempt parcels in pardat should be exempt in land
-              - res_class_matches_pardat:
                   name: iasworld_asmt_all_class_matches_pardat_class
-                  additional_select_columns:
+                  additional_select_columns: &select-columns-aggregated
                     - column: taxyr
                       agg_func: max
                     - column: parid
@@ -80,6 +57,16 @@ sources:
                       AND valclass IS NULL
                   meta:
                     description: at least one class should match pardat class
+              - res_class_matches_pardat:
+                  name: iasworld_asmt_all_ex_matches_pardat_class_ex
+                  major_class_only: false
+                  join_type: inner
+                  additional_select_columns: *select-columns-aggregated
+                  additional_pardat_filter: AND class = 'EX'
+                  config: *unique-conditions
+                  meta:
+                    description: >
+                      Exempt parcels in pardat should be exempt in asmt all
           - name: cur
             description: '{{ doc("column_cur") }}'
             tests:

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -65,7 +65,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      Exempt parcels in pardat should be exempt in asmt all
+                      class should be EX if pardat class is EX
           - name: cur
             description: '{{ doc("column_cur") }}'
             tests:

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -58,7 +58,7 @@ sources:
                   meta:
                     description: at least one class should match pardat class
               - res_class_matches_pardat:
-                  name: iasworld_asmt_all_ex_matches_pardat_class_ex
+                  name: iasworld_asmt_all_class_ex_matches_pardat_class_ex
                   join_type: inner
                   additional_select_columns: *select-columns-aggregated
                   additional_pardat_filter: AND class = 'EX'

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -94,7 +94,7 @@ sources:
               - res_class_matches_pardat:
                   name: iasworld_land_class_matches_pardat_class
                   major_class_only: true
-                  additional_select_columns:
+                  additional_select_columns: &select-columns-aggregated
                     - column: taxyr
                       agg_func: max
                     - column: parid
@@ -116,21 +116,9 @@ sources:
                   name: iasworld_land_ex_matches_pardat_class_ex
                   major_class_only: false
                   join_type: inner
-                  additional_select_columns:
-                    - column: taxyr
-                      agg_func: max
-                    - column: parid
-                      agg_func: max
-                    - column: who
-                      agg_func: max
-                    - column: wen
-                      agg_func: max
+                  additional_select_columns: *select-columns-aggregated
                   additional_pardat_filter: AND class = 'EX'
-                  config:
-                    where: |
-                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND cur = 'Y'
-                      AND deactivat IS NULL
+                  config: *unique-conditions
                   meta:
                     description: >
                       Exempt parcels in pardat should be exempt in land

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -113,7 +113,7 @@ sources:
                     description: >
                       at least one major class (first digit) should match pardat class
               - res_class_matches_pardat:
-                  name: iasworld_land_ex_matches_pardat_class_ex
+                  name: iasworld_land_class_ex_matches_pardat_class_ex
                   major_class_only: false
                   join_type: inner
                   additional_select_columns: *select-columns-aggregated
@@ -121,7 +121,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      Exempt parcels in pardat should be exempt in land
+                      class should be EX if pardat class is EX
           - name: code
             description: Code
           - name: comres

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -115,6 +115,7 @@ sources:
               - res_class_matches_pardat:
                   name: iasworld_land_ex_matches_pardat_class_ex
                   major_class_only: false
+                  join_type: inner
                   additional_select_columns:
                     - column: taxyr
                       agg_func: max
@@ -132,7 +133,7 @@ sources:
                       AND deactivat IS NULL
                   meta:
                     description: >
-                      at least one major class (first digit) should match pardat class
+                      Exempt parcels in pardat should be exempt in land
           - name: code
             description: Code
           - name: comres

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -112,26 +112,27 @@ sources:
                   meta:
                     description: >
                       at least one major class (first digit) should match pardat class
-              - row_values_match_after_join:
-                  name: iasworld_land_exempt_pardat_exempt
-                  external_model: source('iasworld', 'pardat')
-                  external_column_name: class
-                  column_alias: class
-                  external_column_alias: class
-                  group_by:
-                    - taxyr
-                    - parid                    
-                  join_condition:
-                    On model.parid = external_model.parid
-                    AND model.taxyr = external_model.taxyr
-                    AND external_model.cur = 'Y'
-                    AND external_model.deactivat IS NULL
-                  where:
+              - res_class_matches_pardat:
+                  name: iasworld_land_ex_matches_pardat_class_ex
+                  major_class_only: false
+                  additional_select_columns:
+                    - column: taxyr
+                      agg_func: max
+                    - column: parid
+                      agg_func: max
+                    - column: who
+                      agg_func: max
+                    - column: wen
+                      agg_func: max
+                  additional_pardat_filter: AND class = 'EX'
+                  config:
+                    where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND class IN ('EX')
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
                   meta:
-                    category: class_mismatch_or_issue
-                    description: exempt values in land must be exempt
+                    description: >
+                      at least one major class (first digit) should match pardat class
           - name: code
             description: Code
           - name: comres

--- a/dbt/models/iasworld/schema/iasworld.land.yml
+++ b/dbt/models/iasworld/schema/iasworld.land.yml
@@ -112,6 +112,26 @@ sources:
                   meta:
                     description: >
                       at least one major class (first digit) should match pardat class
+              - row_values_match_after_join:
+                  name: iasworld_land_exempt_pardat_exempt
+                  external_model: source('iasworld', 'pardat')
+                  external_column_name: class
+                  column_alias: class
+                  external_column_alias: class
+                  group_by:
+                    - taxyr
+                    - parid                    
+                  join_condition:
+                    On model.parid = external_model.parid
+                    AND model.taxyr = external_model.taxyr
+                    AND external_model.cur = 'Y'
+                    AND external_model.deactivat IS NULL
+                  where:
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND class IN ('EX')
+                  meta:
+                    category: class_mismatch_or_issue
+                    description: exempt values in land must be exempt
           - name: code
             description: Code
           - name: comres

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -125,7 +125,7 @@ sources:
                     description: >
                       at least one major class (first digit) should match pardat class
               - res_class_matches_pardat:
-                  name: iasworld_oby_class_matches_pardat_class_ex
+                  name: iasworld_oby_class_ex_matches_pardat_class_ex
                   major_class_only: false
                   join_type: inner
                   additional_select_columns: *select-columns-aggregated

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -124,26 +124,28 @@ sources:
                   meta:
                     description: >
                       at least one major class (first digit) should match pardat class
-              - row_values_match_after_join:
-                  name: iasworld_oby_exempt_pardat_exempt
-                  external_model: source('iasworld', 'pardat')
-                  external_column_name: class
-                  column_alias: class
-                  external_column_alias: class
-                  group_by:
-                    - taxyr
-                    - parid                    
-                  join_condition:
-                    On model.parid = external_model.parid
-                    AND model.taxyr = external_model.taxyr
-                    AND external_model.cur = 'Y'
-                    AND external_model.deactivat IS NULL
-                  where:
+              - res_class_matches_pardat:
+                  name: iasworld_oby_matches_pardat_class_ex
+                  major_class_only: false
+                  join_type: inner
+                  additional_select_columns:
+                    - column: taxyr
+                      agg_func: max
+                    - column: parid
+                      agg_func: max
+                    - column: who
+                      agg_func: max
+                    - column: wen
+                      agg_func: max
+                  additional_pardat_filter: AND class = 'EX'
+                  config:
+                    where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND class IN ('EX')
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
                   meta:
-                    category: class_mismatch_or_issue
-                    description: exempt values in land must be exempt
+                    description: >
+                      Exempt parcels in pardat should be exempt in land
           - name: cline
             description: Condominium line
           - name: cndcmplx

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -109,7 +109,7 @@ sources:
               - res_class_matches_pardat:
                   name: iasworld_oby_class_matches_pardat_class
                   major_class_only: true
-                  additional_select_columns:
+                  additional_select_columns: &select-columns-aggregated
                     - column: card
                       agg_func: array_agg
                     - column: taxyr
@@ -128,21 +128,9 @@ sources:
                   name: iasworld_oby_matches_pardat_class_ex
                   major_class_only: false
                   join_type: inner
-                  additional_select_columns:
-                    - column: taxyr
-                      agg_func: max
-                    - column: parid
-                      agg_func: max
-                    - column: who
-                      agg_func: max
-                    - column: wen
-                      agg_func: max
+                  additional_select_columns: *select-columns-aggregated
                   additional_pardat_filter: AND class = 'EX'
-                  config:
-                    where: |
-                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
-                      AND cur = 'Y'
-                      AND deactivat IS NULL
+                  config: *unique-conditions
                   meta:
                     description: >
                       Exempt parcels in pardat should be exempt in land

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -125,7 +125,7 @@ sources:
                     description: >
                       at least one major class (first digit) should match pardat class
               - res_class_matches_pardat:
-                  name: iasworld_oby_matches_pardat_class_ex
+                  name: iasworld_oby_class_matches_pardat_class_ex
                   major_class_only: false
                   join_type: inner
                   additional_select_columns: *select-columns-aggregated
@@ -133,7 +133,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: >
-                      Exempt parcels in pardat should be exempt in land
+                      class should be EX if pardat class is EX
           - name: cline
             description: Condominium line
           - name: cndcmplx

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -124,6 +124,26 @@ sources:
                   meta:
                     description: >
                       at least one major class (first digit) should match pardat class
+              - row_values_match_after_join:
+                  name: iasworld_oby_exempt_pardat_exempt
+                  external_model: source('iasworld', 'pardat')
+                  external_column_name: class
+                  column_alias: class
+                  external_column_alias: class
+                  group_by:
+                    - taxyr
+                    - parid                    
+                  join_condition:
+                    On model.parid = external_model.parid
+                    AND model.taxyr = external_model.taxyr
+                    AND external_model.cur = 'Y'
+                    AND external_model.deactivat IS NULL
+                  where:
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND class IN ('EX')
+                  meta:
+                    category: class_mismatch_or_issue
+                    description: exempt values in land must be exempt
           - name: cline
             description: Condominium line
           - name: cndcmplx


### PR DESCRIPTION
This produces three tests, one for asmt_all, oby, and land, each of which tests that all values in pardat which are exempt, are exempt in the tested tables. 
It fails in two occasions, land (14 failures) and oby (3), while passing in asmt_all.