### PR TITLE
Add test for nbhd code with mismatched township

### DIFF
--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -167,6 +167,30 @@ sources:
             description: Jurisdictions (Municipalities) used as part of Folio number (BCA)
           - name: nbhd
             description: '{{ doc("shared_column_nbhd_code") }}'
+            tests:
+            - row_values_match_after_join:
+                name: iasworld_pardat_nbhd_matches_legdat_township
+                external_model: source('iasworld', 'legdat')
+                external_column_name: user1
+                column_alias: nbhd_code
+                external_column_alias: township_code
+                group_by:
+                  - parid
+                  - taxyr
+                join_condition:
+                  ON  substr(model.nbhd, 1, 2) != external_model.user1
+                  AND model.parid = external_model.parid
+                  AND model.taxyr = external_model.taxyr
+                  AND model.cur = 'Y'
+                  AND model.deactivat IS NULL
+                  AND external_model.cur = 'Y'
+                  AND external_model.deactivat IS NULL
+                config:
+                  where:
+                    CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                meta:
+                  category: relationships
+                  description: nbhd code first 2 digits should match legdat.user1 (township code)
           - name: nbhdie
             description: Neighborhood income valuation
           - name: nonfarminc

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -183,13 +183,9 @@ sources:
                   ON  substr(model.nbhd, 1, 2) != external_model.user1
                   AND model.parid = external_model.parid
                   AND model.taxyr = external_model.taxyr
-                  AND model.cur = 'Y'
-                  AND model.deactivat IS NULL
                   AND external_model.cur = 'Y'
                   AND external_model.deactivat IS NULL
-                config:
-                  where:
-                    CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                config: *unique-conditions
                 meta:
                   category: relationships
                   description: nbhd code first 2 digits should match legdat.user1 (township code)

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -174,9 +174,11 @@ sources:
                 external_column_name: user1
                 column_alias: nbhd_code
                 external_column_alias: township_code
-                group_by:
-                  - parid
-                  - taxyr
+                additional_select_columns:
+                  - model.taxyr
+                  - model.parid
+                  - model.who
+                  - model.wen
                 join_condition:
                   ON  substr(model.nbhd, 1, 2) != external_model.user1
                   AND model.parid = external_model.parid

--- a/dbt/tests/generic/test_row_values_match_after_join.sql
+++ b/dbt/tests/generic/test_row_values_match_after_join.sql
@@ -107,6 +107,8 @@
     group by {{ group_by_csv }}
     having
         sum(case when {{ external_model_col }} = {{ model_col }} then 1 else 0 end) = 0
+    {%- else %}
+    where {{ external_model_col }} != {{ model_col }}
     {%- endif %}
 
 {% endtest %}

--- a/dbt/tests/generic/test_row_values_match_after_join.sql
+++ b/dbt/tests/generic/test_row_values_match_after_join.sql
@@ -20,13 +20,13 @@
 --    This is not necessary in the case of USING, since USING does not
 --    refer to tablenames directly.
 --
---    * group_by (list of str): The columns from the base model to pass to the
---    GROUP BY function used in the test query. Unlike `join_condition`,
---    these column names do not have to be prefixed with `model.*`, since
---    they are assumed to come from the base model for the test and not the
---    external model.
---
 -- Optional parameters:
+--
+--    * group_by (optional list of str): The columns from the base model to
+--    pass to the GROUP BY function used in the test query. Unlike
+--    `join_condition`, these column names do not have to be prefixed with
+--    `model.*`, since they are assumed to come from the base model for the
+--    test and not the external model.
 --
 --    * join_type(str): The type of join to use, e.g. "inner" or "left".
 --    Defaults to "inner".
@@ -40,7 +40,7 @@
 --
 --    * additional_select_columns (dict): Standard parameter for selecting
 --    additional columns from the base model for use in reporting failures.
---    `model.{column_name}`, `external_model.{external_column_name`}`, and
+--    `model.{column_name}`, `external_model.{external_column_name}`, and
 --    the columns specified in the `group_by` parameter are already selected
 --    by default and do not need to be included using this parameter.
 --    See the `format_additional_select_columns` macro for more information.
@@ -87,18 +87,26 @@
     {%- endif -%}
 
     select
-        {{ group_by_csv }},
+        {%- if group_by is defined %}
+            {{ group_by_csv }},
+            array_agg({{ model_col }}) as {{ column_alias }},
+            array_agg({{ external_model_col }}) as {{ external_column_alias }}
+        {%- else %}
+            {{ model_col }} as {{ column_alias }},
+            {{ external_model_col }} as {{ external_column_alias }}
+        {%- endif %}
         {% if additional_select_columns_csv -%}
-            {{ additional_select_columns_csv }},
+            , {{ additional_select_columns_csv }}
         {% endif %}
-        array_agg({{ model_col }}) as {{ column_alias }},
-        array_agg({{ external_model_col }}) as {{ external_column_alias }}
     from
         {{ external_model }} as external_model
     {{ join_type }} join -- fmt: off
         (select * from {{ model }}) as model {{ join_condition }}
+
+    {%- if group_by is defined %}
     group by {{ group_by_csv }}
     having
         sum(case when {{ external_model_col }} = {{ model_col }} then 1 else 0 end) = 0
+    {%- endif %}
 
 {% endtest %}


### PR DESCRIPTION
This PR adds a iasWorld QC test for neighborhood codes that don't match their township, pursuant to the research in #275.

Closes #275.