### PR TITLE
Adjust `mktadj` tests to reflect the switch to `external_occpct`and new `5B` code

### DIFF
--- a/dbt/models/iasworld/columns.md
+++ b/dbt/models/iasworld/columns.md
@@ -225,8 +225,11 @@ Condition/Desirability/Utility code
 {% docs column_chgrsn %}
 Reason code for change of value.
 
-`4` = Regular reduction (lasts until next triennial reassessment)
-`5` = One year only market value relief (occupancy/vacancy reduction)
+Possible values for this variable are:
+
+- `4` = Regular reduction (lasts until next triennial reassessment)
+- `5` = One year only market value relief (occupancy/vacancy reduction)
+- `5B` = One year only market value relief, issued by the Board of Review
 {% enddocs %}
 
 ## cityname
@@ -460,10 +463,11 @@ Marital status
 ## mktadj
 
 {% docs column_mktadj %}
-Percent good override.
+Percent good override, deprecated in 2024.
 
 Typically used to denote a 1-year percentage discount due to vacancy
-or similar temporary situations.
+or similar temporary situations. For 2023 data, check `external_occpct`
+as well. For 2024 on, use `external_occpct` instead.
 {% enddocs %}
 
 ## nccalc

--- a/dbt/models/iasworld/schema/iasworld.comdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.comdat.yml
@@ -101,21 +101,30 @@ sources:
           - name: chgrsn
             description: '{{ doc("column_chgrsn") }}'
             tests:
-              - expression_is_true:
-                  name: iasworld_comdat_chgrsn_eq_5_mktadj_not_null
-                  expression: |
-                    != '5' OR mktadj IS NOT NULL
+              - accepted_values:
+                  name: iasworld_comdat_chgrsn_eq_5_or_5b_when_external_occpct_or_mktadj_not_null
+                  values:
+                    - '5'
+                    - 5B
                   additional_select_columns:
                     - parid
                     - taxyr
                     - card
                     - who
                     - wen
+                    - external_occpct
                     - mktadj
-                  config: *unique-conditions
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND (external_occpct IS NOT NULL OR mktadj IS NOT NULL)
                   meta:
-                    category: incorrect_values
-                    description: chgrsn should only be 5 if mktadj is not null
+                    description: >
+                      chgrsn (Reason for Change) should be 5 or 5B
+                      if external_occpct (Occupancy % [current]) or
+                      mktadj (Occupancy % [deprecated]) is not null
           - name: class
             description: '{{ doc("shared_column_class") }}'
             tests:
@@ -217,6 +226,28 @@ sources:
                   meta:
                     description: >
                       external_occpct (Occupancy %) should not be 0
+              - not_null:
+                  name: iasworld_comdat_external_occpct_not_null_when_chgrsn_eq_5_or_5b_and_mktadj_is_null
+                  additional_select_columns:
+                    - taxyr
+                    - parid
+                    - card
+                    - who
+                    - wen
+                    - chgrsn
+                    - mktadj
+                  config:
+                    where:
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND chgrsn IN ('5', '5B')
+                      AND mktadj IS NULL
+                  meta:
+                    description: >
+                      external_occpct (Occupancy % [current]) should not be null if
+                      chgrsn (Reason for Change) is 5 or 5B and
+                      mktadj (Occupancy % [deprecated]) is null
           - name: external_propct
             description: '{{ doc("shared_column_external_propct") }}'
             tests:
@@ -257,6 +288,29 @@ sources:
             description: '{{ doc("shared_column_loaded_at") }}'
           - name: mktadj
             description: '{{ doc("column_mktadj") }}'
+            tests:
+              - not_null:
+                  name: iasworld_comdat_mktadj_not_null_when_chgrsn_eq_5_or_5b_and_external_occpct_is_null
+                  additional_select_columns:
+                    - taxyr
+                    - parid
+                    - card
+                    - who
+                    - wen
+                    - chgrsn
+                    - external_occpct
+                  config:
+                    where:
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND chgrsn IN ('5', '5B')
+                      AND external_occpct IS NULL
+                  meta:
+                    description: >
+                      mktadj (Occupancy % [deprecated]) should not be null if
+                      chgrsn (Reason for Change) is 5 or 5B and
+                      external_occpct (Occupancy % [current]) is null
           - name: mktrsn
             description: Reason for market adjustment
           - name: msarea

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -334,7 +334,7 @@ sources:
                   meta:
                     description: >
                       external_occpct (Occupancy % [current]) should not be null if
-                      mktadj (Reason for Override) is 5 or 5B and
+                      mktrsn (Reason for Override) is 5 or 5B and
                       mktadj (Occupancy % [deprecated]) is null
           - name: external_propct
             description: '{{ doc("shared_column_external_propct") }}'
@@ -624,7 +624,7 @@ sources:
                   meta:
                     description: >
                       mktadj (Occupancy % [deprecated]) should not be null if
-                      mktadj (Reason for Override) is 5 or 5B and
+                      mktrsn (Reason for Override) is 5 or 5B and
                       external_occpct (Occupancy % [current]) is null
           - name: mktrsn
             description: '{{ doc("column_chgrsn") }}'

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -630,7 +630,7 @@ sources:
             description: '{{ doc("column_chgrsn") }}'
             tests:
               - accepted_values:
-                  name: iasworld_dweldat_mktrsn_eq_5_or_5b_when_mktadj_or_external_occpct_not_null
+                  name: iasworld_dweldat_mktrsn_eq_5_or_5b_when_external_occpct_or_mktadj_not_null
                   values:
                     - '5'
                     - 5B
@@ -640,19 +640,19 @@ sources:
                     - card
                     - who
                     - wen
-                    - mktadj
                     - external_occpct
+                    - mktadj
                   config:
-                    where:
+                    where: |
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND cur = 'Y'
                       AND deactivat IS NULL
-                      AND (mktadj IS NOT NULL OR external_occpct IS NOT NULL)
+                      AND (external_occpct IS NOT NULL OR mktadj IS NOT NULL)
                   meta:
                     description: >
                       mktrsn (Reason for Override) should be 5 or 5B
-                      if mktadj (Occupancy % [deprecated]) or external_occpct
-                      (Occupancy % [current]) is not null
+                      if external_occpct (Occupancy % [current]) or
+                      mktadj (Occupancy % [deprecated]) is not null
           - name: modover
             description: Residential override model
           - name: mvpattic

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -314,6 +314,28 @@ sources:
                   meta:
                     description: >
                       external_occpct (Occupancy %) should not be 0
+              - not_null:
+                  name: iasworld_dweldat_external_occpct_not_null_when_mktrsn_eq_5_or_5b_and_mktadj_is_null
+                  additional_select_columns:
+                    - taxyr
+                    - parid
+                    - card
+                    - who
+                    - wen
+                    - mktrsn
+                    - mktadj
+                  config:
+                    where:
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND mktrsn IN ('5', '5B')
+                      AND mktadj IS NULL
+                  meta:
+                    description: >
+                      external_occpct (Occupancy % [current]) should not be null if
+                      mktadj (Reason for Override) is 5 or 5B and
+                      mktadj (Occupancy % [deprecated]) is null
           - name: external_propct
             description: '{{ doc("shared_column_external_propct") }}'
             tests:
@@ -581,13 +603,37 @@ sources:
             description: Main section ground floor area
           - name: mktadj
             description: '{{ doc("column_mktadj") }}'
+            tests:
+              - not_null:
+                  name: iasworld_dweldat_mktadj_not_null_when_mktrsn_eq_5_or_5b_and_external_occpct_is_null
+                  additional_select_columns:
+                    - taxyr
+                    - parid
+                    - card
+                    - who
+                    - wen
+                    - mktrsn
+                    - external_occpct
+                  config:
+                    where:
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND mktrsn IN ('5', '5B')
+                      AND external_occpct IS NULL
+                  meta:
+                    description: >
+                      mktadj (Occupancy % [deprecated]) should not be null if
+                      mktadj (Reason for Override) is 5 or 5B and
+                      external_occpct (Occupancy % [current]) is null
           - name: mktrsn
             description: '{{ doc("column_chgrsn") }}'
             tests:
-              - expression_is_true:
-                  name: iasworld_dweldat_mktrsn_eq_5_mktadj_not_null
-                  expression: |
-                    != '5' OR mktadj IS NOT NULL
+              - accepted_values:
+                  name: iasworld_dweldat_mktrsn_eq_5_or_5b_when_mktadj_or_external_occpct_not_null
+                  values:
+                    - '5'
+                    - 5B
                   additional_select_columns:
                     - taxyr
                     - parid
@@ -595,15 +641,18 @@ sources:
                     - who
                     - wen
                     - mktadj
+                    - external_occpct
                   config:
-                    where: |
+                    where:
                       CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
                       AND cur = 'Y'
                       AND deactivat IS NULL
+                      AND (mktadj IS NOT NULL OR external_occpct IS NOT NULL)
                   meta:
-                    category: incorrect_values
                     description: >
-                      mktrsn (Reason for Override) should only be 5 if mktadj is not null
+                      mktrsn (Reason for Override) should be 5 or 5B
+                      if mktadj (Occupancy % [deprecated]) or external_occpct
+                      (Occupancy % [current]) is not null
           - name: modover
             description: Residential override model
           - name: mvpattic

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -80,21 +80,30 @@ sources:
           - name: chgrsn
             description: '{{ doc("column_chgrsn") }}'
             tests:
-              - expression_is_true:
-                  name: iasworld_oby_chgrsn_eq_5_mktadj_not_null
-                  expression: |
-                    != '5' OR mktadj IS NOT NULL
+              - accepted_values:
+                  name: iasworld_oby_chgrsn_eq_5_or_5b_when_external_occpct_or_mktadj_not_null
+                  values:
+                    - '5'
+                    - 5B
                   additional_select_columns:
-                    - taxyr
                     - parid
+                    - taxyr
                     - card
                     - who
                     - wen
+                    - external_occpct
                     - mktadj
-                  config: *unique-conditions
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND (external_occpct IS NOT NULL OR mktadj IS NOT NULL)
                   meta:
-                    category: incorrect_values
-                    description: chgrsn should only be 5 if mktadj is not null
+                    description: >
+                      chgrsn (Reason for Change) should be 5 or 5B
+                      if external_occpct (Occupancy % [current]) or
+                      mktadj (Occupancy % [deprecated]) is not null
           - name: class
             description: '{{ doc("shared_column_class") }}'
             tests:
@@ -202,6 +211,28 @@ sources:
                   meta:
                     description: >
                       external_occpct (Occupancy %) should not be 0
+              - not_null:
+                  name: iasworld_oby_external_occpct_not_null_when_chgrsn_eq_5_or_5b_and_mktadj_is_null
+                  additional_select_columns:
+                    - taxyr
+                    - parid
+                    - card
+                    - who
+                    - wen
+                    - chgrsn
+                    - mktadj
+                  config:
+                    where:
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND chgrsn IN ('5', '5B')
+                      AND mktadj IS NULL
+                  meta:
+                    description: >
+                      external_occpct (Occupancy % [current]) should not be null if
+                      chgrsn (Reason for Change) is 5 or 5B and
+                      mktadj (Occupancy % [deprecated]) is null
           - name: external_propct
             description: '{{ doc("shared_column_external_propct") }}'
             tests:
@@ -279,6 +310,29 @@ sources:
             description: Miles for railroads
           - name: mktadj
             description: '{{ doc("column_mktadj") }}'
+            tests:
+              - not_null:
+                  name: iasworld_oby_mktadj_not_null_when_chgrsn_eq_5_or_5b_and_external_occpct_is_null
+                  additional_select_columns:
+                    - taxyr
+                    - parid
+                    - card
+                    - who
+                    - wen
+                    - chgrsn
+                    - external_occpct
+                  config:
+                    where:
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND chgrsn IN ('5', '5B')
+                      AND external_occpct IS NULL
+                  meta:
+                    description: >
+                      mktadj (Occupancy % [deprecated]) should not be null if
+                      chgrsn (Reason for Change) is 5 or 5B and
+                      external_occpct (Occupancy % [current]) is null
           - name: msclass
             description: Class identifier for Occupancy (CODE) from Marshall Swift
           - name: msrank


### PR DESCRIPTION
In 2023, we began migrating from the `mktadj` column to the `external_occpct` column on `dweldat`, `comdat`, and `oby`. Prior to 2023, only `mktadj` should be populated in cases of fractional occupancy; in 2023, either `mktadj` or `external_occpct` (but not both) can be populated, representing the time when the fields were in transition; and starting in 2024, only `external_occpct` should be populated.

At the same time, we recently added `"5B"` as a valid option for `chgrsn` and `mktrsn` to help differentiate between 1-year reductions issued by our office and the board of review.

This PR adjusts our tests for the `mktadj`, `mktrsn`, and `chgrsn` columns on `dweldat`, `comdat`, and `oby` to reflect these two changes.

Closes #399.

Run the tests to ensure they execute properly:

```
dbt test --select \
    iasworld_comdat_chgrsn_eq_5_or_5b_when_external_occpct_or_mktadj_not_null \
    iasworld_comdat_external_occpct_not_null_when_chgrsn_eq_5_or_5b_and_mktadj_is_null \
    iasworld_comdat_mktadj_not_null_when_chgrsn_eq_5_or_5b_and_external_occpct_is_null \
    iasworld_dweldat_external_occpct_not_null_when_mktrsn_eq_5_or_5b_and_mktadj_is_null \
    iasworld_dweldat_mktadj_not_null_when_mktrsn_eq_5_or_5b_and_external_occpct_is_null \
    iasworld_dweldat_mktrsn_eq_5_or_5b_when_external_occpct_or_mktadj_not_null \
    iasworld_oby_chgrsn_eq_5_or_5b_when_external_occpct_or_mktadj_not_null \
    iasworld_oby_external_occpct_not_null_when_chgrsn_eq_5_or_5b_and_mktadj_is_null \
    iasworld_oby_mktadj_not_null_when_chgrsn_eq_5_or_5b_and_external_occpct_is_null
```