### PR TITLE
Refactor pre-commit to use composite action

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run pre-commit checks
-        uses: ccao-data/actions/pre-commit@create-composite-pre-commit-action
+        uses: ccao-data/actions/pre-commit@main

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,29 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Setup python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-
-      - name: Install pre-commit
-        run: python -m pip install pre-commit
-        shell: bash
-
-      - name: Freeze dependencies
-        run: python -m pip freeze --local
-        shell: bash
-
-      - name: Cache pre-commit environment
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pre-commit
-            ~/.cache/R
-          key: pre-commit-3-${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Run pre-commit
-        run: pre-commit run --show-diff-on-failure --color=always --all-files
-        shell: bash
+      - name: Run pre-commit checks
+        uses: ccao-data/actions/pre-commit@create-composite-pre-commit-action


### PR DESCRIPTION
This PR refactors the `.github/workflows/pre-commit.yaml` to use the `action.yaml` in the actions repo. However, there are key difference that makes it so that it isn't a 1:1 replacement. I'm not sure how to incorporate these differences, mostly because I am not familiar with the exact use case. I could build these into the `action.yaml`, or perhaps try to get some sort of conditional logic going.