### PR TITLE
Add a test to dweldat to make sure yrblt matches the class code

### DIFF
--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1512,7 +1512,7 @@ sources:
               - accepted_range:
                   name: iasworld_dweldat_yrblt_between_1850_and_now
                   min_value: 1850
-                  max_value: cast(year(current_date) as integer)
+                  max_value: cast(year(current_date) as decimal)
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1517,6 +1517,90 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: yrblt should be between 1850 and now
+                  name: iasworld_dweldat_yrblt_205_more_than_62_years_old
+                  min_value: 1850
+                  max_value: cast(year(current_date) as decimal) - 62
+                  additional_select_columns: *select-columns
+                  config: 
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '205'
+                  meta:
+                    description: 205 should be > 62 years old
+                  name: iasworld_dweldat_yrblt_206_more_than_62_years_old
+                  min_value: 1850
+                  max_value: cast(year(current_date) as decimal) - 62
+                  additional_select_columns: *select-columns
+                  config: 
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '206'
+                  meta:
+                    description: 206 should be > 62 years old
+                  name: iasworld_dweldat_yrblt_207_less_than_62_years_old
+                  min_value: cast(year(current_date) as decimal) - 62
+                  max_value: cast(year(current_date) as decimal)
+                  additional_select_columns: *select-columns
+                  config: 
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '207'
+                  meta:
+                    description: 207 should be <= 62 years old
+                  name: iasworld_dweldat_yrblt_208_less_than_62_years_old
+                  min_value: cast(year(current_date) as decimal) - 62
+                  max_value: cast(year(current_date) as decimal)
+                  additional_select_columns: *select-columns
+                  config: 
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '208'
+                  meta:
+                    description: 208 should be <= 62 years old
+                  name: iasworld_dweldat_yrblt_210_more_than_62_years_old
+                  min_value: 1850
+                  max_value: cast(year(current_date) as decimal) - 62
+                  additional_select_columns: *select-columns
+                  config: 
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '210'
+                  meta:
+                    description: 210 should be > 62 years old
+                  name: iasworld_dweldat_yrblt_278_less_than_62_years_old
+                  min_value: cast(year(current_date) as decimal) - 62
+                  max_value: cast(year(current_date) as decimal)
+                  additional_select_columns: *select-columns
+                  config: 
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '278'
+                  meta:
+                    description: 278 should be < 62 years old
+                  name: iasworld_dweldat_yrblt_295_less_than_62_years_old
+                  min_value: cast(year(current_date) as decimal) - 62
+                  max_value: cast(year(current_date) as decimal)
+                  additional_select_columns: *select-columns
+                  config: 
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('test_qc_year_start') }} AND {{ var('test_qc_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND class = '295'
+                  meta:
+                    description: 295 should be <= 62 years old
           - name: yrremod
             description: Year remodeled
 

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1519,7 +1519,6 @@ sources:
                     description: yrblt should be between 1850 and now
               - accepted_range:
                   name: iasworld_dweldat_yrblt_205_more_than_62_years_old
-                  min_value: 1850
                   max_value: cast(year(current_date) as decimal) - 62
                   additional_select_columns: *select-columns
                   config: 

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1532,7 +1532,6 @@ sources:
                     description: 205s should be > 62 years old
               - accepted_range:
                   name: iasworld_dweldat_yrblt_206_more_than_62_years_old
-                  min_value: 1850
                   max_value: cast(year(current_date) as decimal) - 62
                   additional_select_columns: *select-columns
                   config: 

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1519,7 +1519,7 @@ sources:
                     description: yrblt should be between 1850 and now
               - accepted_range:
                   name: iasworld_dweldat_yrblt_205_more_than_62_years_old
-                  max_value: cast(year(current_date) as decimal) - 62
+                  max_value: cast(year(current_date) as decimal) - 63
                   additional_select_columns: *select-columns
                   config: 
                     where: |
@@ -1531,7 +1531,7 @@ sources:
                     description: yrblt should be > 62 years old when class is 205
               - accepted_range:
                   name: iasworld_dweldat_yrblt_206_more_than_62_years_old
-                  max_value: cast(year(current_date) as decimal) - 62
+                  max_value: cast(year(current_date) as integer) - 63
                   additional_select_columns: *select-columns
                   config: 
                     where: |
@@ -1540,10 +1540,10 @@ sources:
                       AND deactivat IS NULL
                       AND class = '206'
                   meta:
-                    description: 206s should be > 62 years old
+                    description: yrblt should be > 62 years old when class is 206
               - accepted_range:
                   name: iasworld_dweldat_yrblt_207_less_than_62_years_old
-                  min_value: cast(year(current_date) as decimal) - 62
+                  min_value: cast(year(current_date) as integer) - 62
                   additional_select_columns: *select-columns
                   config: 
                     where: |
@@ -1552,11 +1552,10 @@ sources:
                       AND deactivat IS NULL
                       AND class = '207'
                   meta:
-                    description: 207s should be <= 62 years old
+                    description: yrblt should be <= 62 years old when class is 207
               - accepted_range:
                   name: iasworld_dweldat_yrblt_208_less_than_62_years_old
-                  min_value: cast(year(current_date) as decimal) - 62
-                  max_value: cast(year(current_date) as decimal)
+                  min_value: cast(year(current_date) as integer) - 62
                   additional_select_columns: *select-columns
                   config: 
                     where: |
@@ -1565,11 +1564,10 @@ sources:
                       AND deactivat IS NULL
                       AND class = '208'
                   meta:
-                    description: 208s should be <= 62 years old
+                    description: yrblt should be <= 62 years old when class is 208
               - accepted_range:
                   name: iasworld_dweldat_yrblt_210_more_than_62_years_old
-                  min_value: 1850
-                  max_value: cast(year(current_date) as decimal) - 62
+                  max_value: cast(year(current_date) as integer) - 63
                   additional_select_columns: *select-columns
                   config: 
                     where: |
@@ -1578,11 +1576,10 @@ sources:
                       AND deactivat IS NULL
                       AND class = '210'
                   meta:
-                    description: 210 should be > 62 years old
+                    description: yrblt should be > 62 years old when class is 210
               - accepted_range:
                   name: iasworld_dweldat_yrblt_278_less_than_62_years_old
-                  min_value: cast(year(current_date) as decimal) - 62
-                  max_value: cast(year(current_date) as decimal)
+                  min_value: cast(year(current_date) as integer) - 62
                   additional_select_columns: *select-columns
                   config: 
                     where: |
@@ -1591,11 +1588,10 @@ sources:
                       AND deactivat IS NULL
                       AND class = '278'
                   meta:
-                    description: 278s should be < 62 years old
+                    description: yrblt should be < 62 years old when class is 278
               - accepted_range:
                   name: iasworld_dweldat_yrblt_295_less_than_62_years_old
-                  min_value: cast(year(current_date) as decimal) - 62
-                  max_value: cast(year(current_date) as decimal)
+                  min_value: cast(year(current_date) as integer) - 62
                   additional_select_columns: *select-columns
                   config: 
                     where: |
@@ -1604,7 +1600,7 @@ sources:
                       AND deactivat IS NULL
                       AND class = '295'
                   meta:
-                    description: 295s should be <= 62 years old
+                    description: yrblt should be <= 62 years old when class is 295
           - name: yrremod
             description: Year remodeled
 

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1512,14 +1512,14 @@ sources:
               - accepted_range:
                   name: iasworld_dweldat_yrblt_between_1850_and_now
                   min_value: 1850
-                  max_value: cast(year(current_date) as decimal)
+                  max_value: cast(year(current_date) as integer)
                   additional_select_columns: *select-columns
                   config: *unique-conditions
                   meta:
                     description: yrblt should be between 1850 and now
               - accepted_range:
                   name: iasworld_dweldat_yrblt_205_more_than_62_years_old
-                  max_value: cast(year(current_date) as decimal) - 63
+                  max_value: cast(year(current_date) as integer) - 63
                   additional_select_columns: *select-columns
                   config: 
                     where: |

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1529,7 +1529,7 @@ sources:
                       AND deactivat IS NULL
                       AND class = '205'
                   meta:
-                    description: 205s should be > 62 years old
+                    description: yrblt should be > 62 years old when class is 205
               - accepted_range:
                   name: iasworld_dweldat_yrblt_206_more_than_62_years_old
                   max_value: cast(year(current_date) as decimal) - 62

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1588,7 +1588,7 @@ sources:
                       AND deactivat IS NULL
                       AND class = '278'
                   meta:
-                    description: yrblt should be < 62 years old when class is 278
+                    description: yrblt should be <= 62 years old when class is 278
               - accepted_range:
                   name: iasworld_dweldat_yrblt_295_less_than_62_years_old
                   min_value: cast(year(current_date) as integer) - 62

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1546,7 +1546,6 @@ sources:
               - accepted_range:
                   name: iasworld_dweldat_yrblt_207_less_than_62_years_old
                   min_value: cast(year(current_date) as decimal) - 62
-                  max_value: cast(year(current_date) as decimal)
                   additional_select_columns: *select-columns
                   config: 
                     where: |

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1517,6 +1517,7 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: yrblt should be between 1850 and now
+              - accepted_range:
                   name: iasworld_dweldat_yrblt_205_more_than_62_years_old
                   min_value: 1850
                   max_value: cast(year(current_date) as decimal) - 62
@@ -1529,6 +1530,7 @@ sources:
                       AND class = '205'
                   meta:
                     description: 205 should be > 62 years old
+              - accepted_range:
                   name: iasworld_dweldat_yrblt_206_more_than_62_years_old
                   min_value: 1850
                   max_value: cast(year(current_date) as decimal) - 62
@@ -1541,6 +1543,7 @@ sources:
                       AND class = '206'
                   meta:
                     description: 206 should be > 62 years old
+              - accepted_range:
                   name: iasworld_dweldat_yrblt_207_less_than_62_years_old
                   min_value: cast(year(current_date) as decimal) - 62
                   max_value: cast(year(current_date) as decimal)
@@ -1553,6 +1556,7 @@ sources:
                       AND class = '207'
                   meta:
                     description: 207 should be <= 62 years old
+              - accepted_range:
                   name: iasworld_dweldat_yrblt_208_less_than_62_years_old
                   min_value: cast(year(current_date) as decimal) - 62
                   max_value: cast(year(current_date) as decimal)
@@ -1565,6 +1569,7 @@ sources:
                       AND class = '208'
                   meta:
                     description: 208 should be <= 62 years old
+              - accepted_range:
                   name: iasworld_dweldat_yrblt_210_more_than_62_years_old
                   min_value: 1850
                   max_value: cast(year(current_date) as decimal) - 62
@@ -1577,6 +1582,7 @@ sources:
                       AND class = '210'
                   meta:
                     description: 210 should be > 62 years old
+              - accepted_range:
                   name: iasworld_dweldat_yrblt_278_less_than_62_years_old
                   min_value: cast(year(current_date) as decimal) - 62
                   max_value: cast(year(current_date) as decimal)
@@ -1589,6 +1595,7 @@ sources:
                       AND class = '278'
                   meta:
                     description: 278 should be < 62 years old
+              - accepted_range:
                   name: iasworld_dweldat_yrblt_295_less_than_62_years_old
                   min_value: cast(year(current_date) as decimal) - 62
                   max_value: cast(year(current_date) as decimal)

--- a/dbt/models/iasworld/schema/iasworld.dweldat.yml
+++ b/dbt/models/iasworld/schema/iasworld.dweldat.yml
@@ -1529,7 +1529,7 @@ sources:
                       AND deactivat IS NULL
                       AND class = '205'
                   meta:
-                    description: 205 should be > 62 years old
+                    description: 205s should be > 62 years old
               - accepted_range:
                   name: iasworld_dweldat_yrblt_206_more_than_62_years_old
                   min_value: 1850
@@ -1542,7 +1542,7 @@ sources:
                       AND deactivat IS NULL
                       AND class = '206'
                   meta:
-                    description: 206 should be > 62 years old
+                    description: 206s should be > 62 years old
               - accepted_range:
                   name: iasworld_dweldat_yrblt_207_less_than_62_years_old
                   min_value: cast(year(current_date) as decimal) - 62
@@ -1555,7 +1555,7 @@ sources:
                       AND deactivat IS NULL
                       AND class = '207'
                   meta:
-                    description: 207 should be <= 62 years old
+                    description: 207s should be <= 62 years old
               - accepted_range:
                   name: iasworld_dweldat_yrblt_208_less_than_62_years_old
                   min_value: cast(year(current_date) as decimal) - 62
@@ -1568,7 +1568,7 @@ sources:
                       AND deactivat IS NULL
                       AND class = '208'
                   meta:
-                    description: 208 should be <= 62 years old
+                    description: 208s should be <= 62 years old
               - accepted_range:
                   name: iasworld_dweldat_yrblt_210_more_than_62_years_old
                   min_value: 1850
@@ -1594,7 +1594,7 @@ sources:
                       AND deactivat IS NULL
                       AND class = '278'
                   meta:
-                    description: 278 should be < 62 years old
+                    description: 278s should be < 62 years old
               - accepted_range:
                   name: iasworld_dweldat_yrblt_295_less_than_62_years_old
                   min_value: cast(year(current_date) as decimal) - 62
@@ -1607,7 +1607,7 @@ sources:
                       AND deactivat IS NULL
                       AND class = '295'
                   meta:
-                    description: 295 should be <= 62 years old
+                    description: 295s should be <= 62 years old
           - name: yrremod
             description: Year remodeled
 


### PR DESCRIPTION
This produces six tests where the following [table](https://github.com/ccao-data/wiki/blob/master/Data/Class-Definitions.pdf) identifies a date range.
The results of the tests are as follows:
iasworld_dweldat_yrblt_205_more_than_62_years_old - 36 failures
iasworld_dweldat_yrblt_206_more_than_62_years_old - 31 failures
iasworld_dweldat_yrblt_207_less_than_62_years_old - pass
iasworld_dweldat_yrblt_208_less_than_62_years_old - 1 failure
iasworld_dweldat_yrblt_278_less_than_62_years_old - 1 failure
iasworld_dweldat_yrblt_295_less_than_62_years_old - pass