### PR TITLE
Use jinja templating to reduce duplicated operations in `reporting.res_report_summary`

### DIFF
--- a/aws-athena/ctas/reporting-res_report_summary.sql
+++ b/aws-athena/ctas/reporting-res_report_summary.sql
@@ -190,28 +190,28 @@ class_modes AS (
 -- By township, assessment_stage, and property group
 values_town_groups AS (
     {{ summarize_res_report_summary(
-        True, True, 'assessment_stage, triad, township_code, year, property_group'
+        'Town', True, 'assessment_stage, triad, township_code, year, property_group'
         ) }}
 ),
 
 -- By township and assessment stage
 values_town_no_groups AS (
     {{ summarize_res_report_summary(
-        True, False, 'assessment_stage, triad, township_code, year'
+        'Town', False, 'assessment_stage, triad, township_code, year'
         ) }}
 ),
 
 -- By neighborhood, assessment_stage, and property group
 values_nbhd_groups AS (
     {{ summarize_res_report_summary(
-        False, True, 'assessment_stage, triad, townnbhd, year, property_group'
+        'TownNBHD', True, 'assessment_stage, triad, townnbhd, year, property_group'
         ) }}
 ),
 
 -- By neighborhood and assessment stage
 values_nbhd_no_groups AS (
     {{ summarize_res_report_summary(
-        False, False, 'assessment_stage, triad, townnbhd, year'
+        'TownNBHD', False, 'assessment_stage, triad, townnbhd, year'
         ) }}
 ),
 

--- a/aws-athena/ctas/reporting-res_report_summary.sql
+++ b/aws-athena/ctas/reporting-res_report_summary.sql
@@ -188,32 +188,18 @@ class_modes AS (
 
 -- Here we aggregate stats on AV and characteristics for each reporting group
 -- By township, assessment_stage, and property group
-values_town_groups AS (
-    {{ summarize_res_report_summary(
-        'Town', True, 'assessment_stage, triad, township_code, year, property_group'
-        ) }}
-),
+values_town_groups AS ({{ res_report_summarize_values('Town', True) }}),
 
 -- By township and assessment stage
-values_town_no_groups AS (
-    {{ summarize_res_report_summary(
-        'Town', False, 'assessment_stage, triad, township_code, year'
-        ) }}
-),
+values_town_no_groups AS ({{ res_report_summarize_values('Town', False) }}),
 
 -- By neighborhood, assessment_stage, and property group
-values_nbhd_groups AS (
-    {{ summarize_res_report_summary(
-        'TownNBHD', True, 'assessment_stage, triad, townnbhd, year, property_group'
-        ) }}
-),
+values_nbhd_groups AS ({{ res_report_summarize_values('TownNBHD', True) }}),
 
 -- By neighborhood and assessment stage
 values_nbhd_no_groups AS (
-    {{ summarize_res_report_summary(
-        'TownNBHD', False, 'assessment_stage, triad, townnbhd, year'
-        ) }}
-),
+    {{ res_report_summarize_values('TownNBHD', False) }}
+    ),
 
 -- Here we aggregate stats on sales for each reporting group
 -- By township and property group
@@ -227,7 +213,10 @@ sales_town_groups AS (
         MAX(sale_price) AS sale_max,
         COUNT(*) AS sale_n
     FROM sales
-    GROUP BY township_code, sale_year, property_group
+    GROUP BY
+        township_code,
+        sale_year,
+        property_group
 ),
 
 -- By township

--- a/aws-athena/ctas/reporting-res_report_summary.sql
+++ b/aws-athena/ctas/reporting-res_report_summary.sql
@@ -189,92 +189,30 @@ class_modes AS (
 -- Here we aggregate stats on AV and characteristics for each reporting group
 -- By township, assessment_stage, and property group
 values_town_groups AS (
-    SELECT
-        triad,
-        'Town' AS geography_type,
-        property_group,
-        assessment_stage,
-        township_code AS geography_id,
-        year,
-        APPROX_PERCENTILE(total, 0.5) AS fmv_median,
-        COUNT(*) AS pin_n,
-        APPROX_PERCENTILE(total_land_sf, 0.5) AS land_sf_median,
-        APPROX_PERCENTILE(total_bldg_sf, 0.5) AS bldg_sf_median,
-        APPROX_PERCENTILE(yrblt, 0.5) AS yrblt_median
-    FROM all_values
-    GROUP BY
-        assessment_stage,
-        triad,
-        township_code,
-        year,
-        property_group
+    {{ summarize_res_report_summary(
+        True, True, 'assessment_stage, triad, township_code, year, property_group'
+        ) }}
 ),
 
 -- By township and assessment stage
 values_town_no_groups AS (
-    SELECT
-        triad,
-        'Town' AS geography_type,
-        'ALL REGRESSION' AS property_group,
-        assessment_stage,
-        township_code AS geography_id,
-        year,
-        APPROX_PERCENTILE(total, 0.5) AS fmv_median,
-        COUNT(*) AS pin_n,
-        APPROX_PERCENTILE(total_land_sf, 0.5) AS land_sf_median,
-        APPROX_PERCENTILE(total_bldg_sf, 0.5) AS bldg_sf_median,
-        APPROX_PERCENTILE(yrblt, 0.5) AS yrblt_median
-    FROM all_values
-    GROUP BY
-        assessment_stage,
-        triad,
-        township_code,
-        year
+    {{ summarize_res_report_summary(
+        True, False, 'assessment_stage, triad, township_code, year'
+        ) }}
 ),
 
 -- By neighborhood, assessment_stage, and property group
 values_nbhd_groups AS (
-    SELECT
-        triad,
-        'TownNBHD' AS geography_type,
-        property_group,
-        assessment_stage,
-        townnbhd AS geography_id,
-        year,
-        APPROX_PERCENTILE(total, 0.5) AS fmv_median,
-        COUNT(*) AS pin_n,
-        APPROX_PERCENTILE(total_land_sf, 0.5) AS land_sf_median,
-        APPROX_PERCENTILE(total_bldg_sf, 0.5) AS bldg_sf_median,
-        APPROX_PERCENTILE(yrblt, 0.5) AS yrblt_median
-    FROM all_values
-    GROUP BY
-        assessment_stage,
-        triad,
-        townnbhd,
-        year,
-        property_group
+    {{ summarize_res_report_summary(
+        False, True, 'assessment_stage, triad, townnbhd, year, property_group'
+        ) }}
 ),
 
 -- By neighborhood and assessment stage
 values_nbhd_no_groups AS (
-    SELECT
-        triad,
-        'TownNBHD' AS geography_type,
-        'ALL REGRESSION' AS property_group,
-        assessment_stage,
-        townnbhd AS geography_id,
-        year,
-        APPROX_PERCENTILE(total, 0.5) AS fmv_median,
-        COUNT(*) AS pin_n,
-        APPROX_PERCENTILE(total_land_sf, 0.5) AS land_sf_median,
-        APPROX_PERCENTILE(total_bldg_sf, 0.5) AS bldg_sf_median,
-        APPROX_PERCENTILE(yrblt, 0.5) AS yrblt_median
-    FROM all_values
-    GROUP BY
-        assessment_stage,
-        triad,
-        townnbhd,
-        year
+    {{ summarize_res_report_summary(
+        False, False, 'assessment_stage, triad, townnbhd, year'
+        ) }}
 ),
 
 -- Here we aggregate stats on sales for each reporting group

--- a/dbt/macros/res_report_summarize_values.sql
+++ b/dbt/macros/res_report_summarize_values.sql
@@ -5,7 +5,7 @@
 -- If the `print` argument is set to True (default is False), the macro will
 -- print the results of the query to stdout, which allows this macro to be used
 -- by scripts to return data.
-{% macro summarize_res_report_summary(geo_type, group_prop, group_by) %}
+{% macro res_report_summarize_values(geo_type, group_prop) %}
     select
         triad,
         '{{ geo_type }}' AS geography_type,
@@ -27,5 +27,18 @@
         APPROX_PERCENTILE(total_bldg_sf, 0.5) as bldg_sf_median,
         APPROX_PERCENTILE(yrblt, 0.5) as yrblt_median
     from all_values
-    group by {{ group_by }}
+    group by
+        assessment_stage,
+        triad,
+        {% if geo_type == "Town" %}
+        township_code,
+        {% elif geo_type == "TownNBHD" %}
+        townnbhd,
+        {% endif %}
+        {% if group_prop %}
+        year,
+        property_group
+        {% else %}
+        year
+        {% endif %}
 {% endmacro %}

--- a/dbt/macros/summarize_res_report_summary.sql
+++ b/dbt/macros/summarize_res_report_summary.sql
@@ -1,0 +1,35 @@
+-- Macro that takes a model and returns its row count grouped and
+-- sorted by a given column. The sort order for the results can be specified
+-- with the `ordering` argument, defaulting to "asc".
+--
+-- If the `print` argument is set to True (default is False), the macro will
+-- print the results of the query to stdout, which allows this macro to be used
+-- by scripts to return data.
+{% macro summarize_res_report_summary(town, prop, group_by) %}
+    select
+        triad,
+        {% if town %}
+        'Town' AS geography_type,
+        {% else %}
+        'TownNBHD' AS geography_type,
+        {% endif %}
+        {% if prop %}
+        property_group,
+        {% else %}
+        'ALL REGRESSION' as property_group,
+        {% endif %}
+        assessment_stage,
+        {% if town %}
+        township_code as geography_id,
+        {% else %}
+        townnbhd AS property_group,
+        {% endif %}
+        year,
+        APPROX_PERCENTILE(total, 0.5) as fmv_median,
+        COUNT(*) as pin_n,
+        APPROX_PERCENTILE(total_land_sf, 0.5) as land_sf_median,
+        APPROX_PERCENTILE(total_bldg_sf, 0.5) as bldg_sf_median,
+        APPROX_PERCENTILE(yrblt, 0.5) as yrblt_median
+    from all_values
+    group by {{ group_by }}
+{% endmacro %}

--- a/dbt/macros/summarize_res_report_summary.sql
+++ b/dbt/macros/summarize_res_report_summary.sql
@@ -5,24 +5,20 @@
 -- If the `print` argument is set to True (default is False), the macro will
 -- print the results of the query to stdout, which allows this macro to be used
 -- by scripts to return data.
-{% macro summarize_res_report_summary(town, prop, group_by) %}
+{% macro summarize_res_report_summary(geo_type, group_prop, group_by) %}
     select
         triad,
-        {% if town %}
-        'Town' AS geography_type,
-        {% else %}
-        'TownNBHD' AS geography_type,
-        {% endif %}
-        {% if prop %}
+        '{{ geo_type }}' AS geography_type,
+        {% if group_prop %}
         property_group,
         {% else %}
         'ALL REGRESSION' as property_group,
         {% endif %}
         assessment_stage,
-        {% if town %}
+        {% if geo_type == "Town" %}
         township_code as geography_id,
-        {% else %}
-        townnbhd AS property_group,
+        {% elif geo_type == "TownNBHD" %}
+        townnbhd as geography_id,
         {% endif %}
         year,
         APPROX_PERCENTILE(total, 0.5) as fmv_median,


### PR DESCRIPTION
`reporting.res_report_summary` performs a lot of repetitive operations across a number of CTEs. Creating a jinja template for these operations will save us code and better ensure accuracy.