### PR TITLE
Add `pin_test` dbt seed

### DIFF
--- a/dbt/models/ccao/docs.md
+++ b/dbt/models/ccao/docs.md
@@ -90,14 +90,3 @@ Collected yearly from Valuations via spreadsheets.
 
 **Primary Key**: `pin`, `year`
 {% enddocs %}
-
-# pin_weird
-
-{% docs table_pin_weird %}
-Table to collect strange, troublesome, or otherwise problematic PINs.
-
-Sourced from a manually updated CSV on S3. Download, edit, then reupload the
-CSV in order to add to the table.
-
-**Primary Key**: `pin`, `year`
-{% enddocs %}

--- a/dbt/models/ccao/schema.yml
+++ b/dbt/models/ccao/schema.yml
@@ -70,9 +70,6 @@ sources:
         tags:
           - type_condo
 
-      - name: pin_weird
-        description: '{{ doc("table_pin_weird") }}'
-
 exposures:
   - name: commercial_valuation_data
     label: Commercial Valuation Data

--- a/dbt/seeds/ccao/ccao.pin_test.csv
+++ b/dbt/seeds/ccao/ccao.pin_test.csv
@@ -1,0 +1,4 @@
+﻿year,pin,class,triad_code,township_code,is_test,test_type,description
+2022,17102060351010,299,1,74,FALSE,just_weird,The photo for this PIN used to be a picture of two guys eating lunch
+2022,16143120330000,211,1,77,TRUE,incorrect_char,This 5175 sqft 211 has 90 bedrooms
+2024,11312110190000,517,1,75,FALSE,split_class,Split 517 and 236 multi-family mixed use

--- a/dbt/seeds/ccao/docs.md
+++ b/dbt/seeds/ccao/docs.md
@@ -7,3 +7,22 @@ regressions and reporting classes.
 
 **Primary Key**: `class_code`
 {% enddocs %}
+
+# pin_test
+
+{% docs seed_pin_test %}
+Table containing a set of PINs used for various pipeline and valuation tests.
+Mainly includes unusual PINs such as PINs with multiple cards (dwellings) _and_
+an associated tieback (proration). The possible values for `test_type` include:
+
+- `class_change`
+- `incorrect_char`
+- `just_weird`
+- `multi_card`
+- `multi_card_prorated`
+- `omitted_assessment`
+- `prorated`
+- `split_class`
+
+**Primary Key**: `year`, `pin`
+{% enddocs %}

--- a/dbt/seeds/ccao/docs.md
+++ b/dbt/seeds/ccao/docs.md
@@ -12,8 +12,11 @@ regressions and reporting classes.
 
 {% docs seed_pin_test %}
 Table containing a set of PINs used for various pipeline and valuation tests.
-Mainly includes unusual PINs such as PINs with multiple cards (dwellings) _and_
-an associated tieback (proration). The possible values for `test_type` include:
+Mainly includes PINs with unusual situations, such as those with multiple cards
+(dwellings) _and_ an associated tieback (proration). The Data Department uses
+this as a repository of PINs for testing views, models, and applications.
+
+The possible values for `test_type` include:
 
 - `class_change`
 - `incorrect_char`

--- a/dbt/seeds/ccao/schema.yml
+++ b/dbt/seeds/ccao/schema.yml
@@ -33,3 +33,33 @@ seeds:
         description: Double of minimum age for 200-class property codes
       - name: max_age
         description: Double of maximum age for 200-class property codes
+
+  - name: ccao.pin_test
+    description: '{{ doc("seed_pin_test") }}'
+    config:
+      column_types:
+        year: string
+        pin: string
+        class: string
+        triad_code: string
+        township_code: string
+
+    columns:
+      - name: year
+        description: '{{ doc("shared_column_year") }}'
+      - name: pin
+        description: '{{ doc("shared_column_pin") }}'
+      - name: class
+        description: '{{ doc("shared_column_class") }}'
+      - name: triad_code
+        description: '{{ doc("shared_column_triad_code") }}'
+      - name: township_code
+        description: '{{ doc("shared_column_township_code") }}'
+      - name: is_test
+        description: |
+          Boolean for whether or not the PIN is useful for integration testing
+      - name: test_type
+        description: Type of integration test this PIN is useful for
+      - name: description
+        description: |
+          Short description of the issue, use, or situation with this PIN


### PR DESCRIPTION
This PR moves the `pin_weird` table from S3 to dbt. It renames the table to better align with its use (of holding test cases), and instantiates it using dbt's seed functionality.

Related to #380.