### PR TITLE
Reporting views for municipalities

### DIFF
--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -22,8 +22,9 @@ SELECT
     munis.major_class AS class,
     COUNT(*) AS n,
     pin_counts.total_n,
-    COUNT(*) / pin_counts.total_n AS stage_portion,
-    AVG(CAST(munis.reassessment_year AS INT)) AS reassessment_portion,
+    CAST(COUNT(*) AS DOUBLE)
+    / CAST(pin_counts.total_n AS DOUBLE) AS stage_portion,
+    AVG(CAST(munis.reassessment_year AS DOUBLE)) AS reassessment_portion,
     SUM(vpvl.bldg) AS bldg_sum,
     CAST(APPROX_PERCENTILE(vpvl.bldg, 0.5) AS INT) AS bldg_median,
     SUM(vpvl.land) AS land_sum,

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -34,7 +34,8 @@ Starting in 2020 a small number of PINs are present in iasworld.asmt_all for
 one or two but not all three stages of assessment when we would expect all three
 stages to be present for said PINs. This is also a data error, but is NOT
 addressed in this view and leads to a few instances where stage_portion ends up
-being less than 1 when it should equal 1. */
+being less than 1 when it should equal 1. 16-07-219-029-1032 missing a mailed
+value but having CCAO and BOR certified values in 2021 is an example. */
 trimmed_town_class AS (
     SELECT vptc.*
     FROM {{ ref('reporting.vw_pin_township_class') }} AS vptc

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -34,8 +34,7 @@ Starting in 2020 a small number of PINs are present in iasworld.asmt_all for
 one or two but not all three stages of assessment when we would expect all three
 stages to be present for said PINs. This is also a data error, but is NOT
 addressed in this view and leads to a few instances where stage_portion ends up
-being less than 1 when it should equal 1.
-*/
+being less than 1 when it should equal 1. */
 trimmed_town_class AS (
     SELECT vptc.*
     FROM {{ ref('reporting.vw_pin_township_class') }} AS vptc

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -20,7 +20,7 @@ LEFT JOIN {{ ref('reporting.vw_pin_township_class') }} AS townships
     ON values_by_year.pin = townships.pin
     AND values_by_year.year = townships.year
 LEFT JOIN {{ ref('location.tax') }} AS tax
-    ON SUSBTR(values_by_year.pin, 1, 10) = tax.pin10
+    ON SUBSTR(values_by_year.pin, 1, 10) = tax.pin10
     AND values_by_year.year = tax.year
 WHERE townships.township_name IS NOT NULL
 GROUP BY

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -1,7 +1,7 @@
 -- Gathers AVs by year, major class, assessment stage, and municipality for
 -- reporting
 
--- Ensure every municipality/class/year has an row for every stage through
+-- Ensure every municipality/class/year has a row for every stage through
 -- cross-joining
 WITH stages AS (
 

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -22,7 +22,13 @@ progressed through an assessment stage.
 It does NOT remove PINs from the most recent year of
 reporting.vw_pin_township_class since we expect these differences based on how
 iasworld.asmt_all is populated through the year as the assessment cycle
-progresses. */
+progresses.
+
+Starting in 2020 a small number of PINs are present in iasworld.asmt_all for
+one or two but not all three stages of assessment when we would expect all three
+stages to be present for said PINs. This is also a data error, but is NOT
+addressed in this view.
+*/
 trimmed_town_class AS (
     SELECT vptc.*
     FROM {{ ref('reporting.vw_pin_township_class') }} AS vptc

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -5,7 +5,7 @@
 SELECT
     values_by_year.year,
     LOWER(values_by_year.stage_name) AS stage,
-    tax.municpality_name,
+    tax.tax_municipality_name AS municipality_name,
     townships.major_class AS class,
     townships.reassessment_year,
     COUNT(*) AS n,
@@ -24,13 +24,13 @@ LEFT JOIN {{ ref('location.tax') }} AS tax
     AND values_by_year.year = tax.year
 WHERE townships.township_name IS NOT NULL
 GROUP BY
-    tax.municpality_name,
+    tax.tax_municipality_name,
     values_by_year.year,
     townships.major_class,
     values_by_year.stage_name,
     townships.reassessment_year
 ORDER BY
-    tax.municpality_name,
+    tax.tax_municipality_name,
     values_by_year.year,
     values_by_year.stage_name,
     townships.major_class

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -18,7 +18,7 @@ WITH pin_counts AS (
 SELECT
     vpvl.year,
     COALESCE(LOWER(vpvl.stage_name), 'mailed') AS stage,
-    COALESCE(munis.municipality_name = pin_counts.municipality_name)
+    COALESCE(munis.municipality_name, pin_counts.municipality_name)
         AS municipality_name,
     COALESCE(munis.major_class, pin_counts.major_class) AS class,
     CASE WHEN COUNT(*) IS NULL THEN 0 ELSE COUNT(*) END AS n,

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -26,9 +26,12 @@ emblematic of what portion of a municipality has actually progressed through an
 assessment stage.
 
 It does NOT remove PINs from the most recent year of
-reporting.vw_pin_township_class since we expect these differences based on how
+reporting.vw_pin_township_class since we expect differences based on how
 iasworld.asmt_all is populated through the year as the assessment cycle
-progresses.
+progresses. This means data errors caused by differences between iasworld.pardat
+and iasworld.asmt_all won't be addressed in the most recent year. Unfortunately,
+we can't know what those errors are (or if they even exist) until asmt_all has
+at least one fully complete stage for a given year.
 
 Starting in 2020 a small number of PINs are present in iasworld.asmt_all for
 one or two but not all three stages of assessment when we would expect all three

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -44,7 +44,6 @@ GROUP BY
     munis.municipality_name,
     vpvl.year,
     munis.major_class,
-    munis.triad_name,
     vpvl.stage_name,
     pin_counts.total_n
 ORDER BY

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -1,8 +1,8 @@
--- Gathers AVs by year, major class, assessment stage, and
--- municipality for reporting
+-- Gathers AVs by year, major class, assessment stage, and municipality for
+-- reporting
 
--- This CTE is just way to make sure every municipality/class/year has an row
--- for every stage through cross joining
+-- Ensure every municipality/class/year has an row for every stage through
+-- cross-joining
 WITH stages AS (
 
     SELECT 'mailed' AS stage
@@ -13,12 +13,12 @@ WITH stages AS (
 
 ),
 
-/* This CTE removes historical PINs in pardat that are not in asmt_all. These
-differences are data errors and not emblematic of what portion of a
-municipality has actually progressed through an assessment stage. It does NOT
-remove PINs from the most recent year of pardat since we expect these
-differences based on how asmt_all is populated through the year as the
-assessment cycle progresses. */
+/* This CTE removes historical PINs in iasworld.pardat that are not in
+iasworld.asmt_all. These differences are data errors and not emblematic of what
+portion of a municipality has actually progressed through an assessment stage.
+It does NOT remove PINs from the most recent year of iasworld.pardat since we
+expect these differences based on how iasworld.asmt_all is populated through the
+year as the assessment cycle progresses. */
 trimmed_town_class AS (
     SELECT vptc.*
     FROM {{ ref('reporting.vw_pin_township_class') }} AS vptc
@@ -38,8 +38,9 @@ trimmed_town_class AS (
 
 ),
 
--- Calculate the denominator for the stage_portion column. pardat serves as the
--- universe of yearly PINs we expect to see in asmt_all.
+/* Calculate the denominator for the stage_portion column. iasworld.pardat
+(through reporting.vw_pin_township_class) serves as the universe of yearly PINs
+we expect to see in iasworld.asmt_all. */
 pin_counts AS (
     SELECT
         vptc.municipality_name,

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -13,9 +13,12 @@ WITH stages AS (
 
 ),
 
-/* This CTE removes historical PINs in iasworld.pardat that are not in
-iasworld.asmt_all. These differences are data errors and not emblematic of what
-portion of a municipality has actually progressed through an assessment stage.
+/* This CTE removes historical PINs in reporting.vw_pin_township_class that are
+not in reporting.vw_pin_value_long. These differences are inherent in the tables
+that feed these views (iasworld.pardat and iasworld.asmt_all, respectively) and
+are data errors - not emblematic of what portion of a municipality has actually
+progressed through an assessment stage.
+
 It does NOT remove PINs from the most recent year of iasworld.pardat since we
 expect these differences based on how iasworld.asmt_all is populated through the
 year as the assessment cycle progresses. */
@@ -38,9 +41,9 @@ trimmed_town_class AS (
 
 ),
 
-/* Calculate the denominator for the stage_portion column. iasworld.pardat
-(through reporting.vw_pin_township_class) serves as the universe of yearly PINs
-we expect to see in iasworld.asmt_all. */
+/* Calculate the denominator for the stage_portion column.
+reporting.vw_pin_township_class serves as the universe of yearly PINs we expect
+to see in reporting.vw_pin_value_long. */
 pin_counts AS (
     SELECT
         vptc.municipality_name,

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -25,7 +25,7 @@ GROUP BY
     vpvl.year,
     munis.major_class,
     munis.triad_name,
-    vpvl.stage_name,
+    vpvl.stage_name
 ORDER BY
     munis.municipality_name,
     vpvl.year,

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -24,7 +24,6 @@ SELECT
     pin_counts.total_n,
     CAST(COUNT(*) AS DOUBLE)
     / CAST(pin_counts.total_n AS DOUBLE) AS stage_portion,
-    AVG(CAST(munis.reassessment_year AS DOUBLE)) AS reassessment_portion,
     SUM(vpvl.bldg) AS bldg_sum,
     CAST(APPROX_PERCENTILE(vpvl.bldg, 0.5) AS INT) AS bldg_median,
     SUM(vpvl.land) AS land_sum,

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -1,8 +1,12 @@
 -- Gathers AVs by year, major class, assessment stage, and municipality for
 -- reporting
 
--- Ensure every municipality/class/year has a row for every stage through
--- cross-joining
+/* Ensure every municipality/class/year has a row for every stage through
+cross-joining. This is to it clear that combinations that do not yet
+exist in iasworld.asmt_all for the current year WILL exist, but have not yet
+been populated. For example, even if no class 4s in the City of Chicago have
+been mailed yet for the current assessment year, we would still like an empty
+City of Chicago/class 4 row to exist for the mailed stage. */
 WITH stages AS (
 
     SELECT 'mailed' AS stage

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -19,9 +19,10 @@ that feed these views (iasworld.pardat and iasworld.asmt_all, respectively) and
 are data errors - not emblematic of what portion of a municipality has actually
 progressed through an assessment stage.
 
-It does NOT remove PINs from the most recent year of iasworld.pardat since we
-expect these differences based on how iasworld.asmt_all is populated through the
-year as the assessment cycle progresses. */
+It does NOT remove PINs from the most recent year of
+reporting.vw_pin_township_class since we expect these differences based on how
+iasworld.asmt_all is populated through the year as the assessment cycle
+progresses. */
 trimmed_town_class AS (
     SELECT vptc.*
     FROM {{ ref('reporting.vw_pin_township_class') }} AS vptc

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -1,0 +1,36 @@
+-- Gathers AVs by year, major class, assessment stage, and
+-- township for reporting
+
+-- Add total and median values by township
+SELECT
+    values_by_year.year,
+    LOWER(values_by_year.stage_name) AS stage,
+    tax.municpality_name,
+    townships.major_class AS class,
+    townships.reassessment_year,
+    COUNT(*) AS n,
+    SUM(values_by_year.bldg) AS bldg_sum,
+    CAST(APPROX_PERCENTILE(values_by_year.bldg, 0.5) AS INT) AS bldg_median,
+    SUM(values_by_year.land) AS land_sum,
+    CAST(APPROX_PERCENTILE(values_by_year.land, 0.5) AS INT) AS land_median,
+    SUM(values_by_year.tot) AS tot_sum,
+    CAST(APPROX_PERCENTILE(values_by_year.tot, 0.5) AS INT) AS tot_median
+FROM {{ ref('reporting.vw_pin_value_long') }} AS values_by_year
+LEFT JOIN {{ ref('reporting.vw_pin_township_class') }} AS townships
+    ON values_by_year.pin = townships.pin
+    AND values_by_year.year = townships.year
+LEFT JOIN {{ ref('location.tax') }} AS tax
+    ON SUSBTR(values_by_year.pin, 1, 10) = tax.pin10
+    AND values_by_year.year = tax.year
+WHERE townships.township_name IS NOT NULL
+GROUP BY
+    tax.municpality_name,
+    values_by_year.year,
+    townships.major_class,
+    values_by_year.stage_name,
+    townships.reassessment_year
+ORDER BY
+    tax.municpality_name,
+    values_by_year.year,
+    values_by_year.stage_name,
+    townships.major_class

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -31,7 +31,8 @@ progresses.
 Starting in 2020 a small number of PINs are present in iasworld.asmt_all for
 one or two but not all three stages of assessment when we would expect all three
 stages to be present for said PINs. This is also a data error, but is NOT
-addressed in this view.
+addressed in this view and leads to a few instances where stage_portion ends up
+being less than 1 when it should equal 1.
 */
 trimmed_town_class AS (
     SELECT vptc.*

--- a/aws-athena/views/reporting-vw_assessment_roll_muni.sql
+++ b/aws-athena/views/reporting-vw_assessment_roll_muni.sql
@@ -2,11 +2,11 @@
 -- reporting
 
 /* Ensure every municipality/class/year has a row for every stage through
-cross-joining. This is to it clear that combinations that do not yet
-exist in iasworld.asmt_all for the current year WILL exist, but have not yet
-been populated. For example, even if no class 4s in the City of Chicago have
-been mailed yet for the current assessment year, we would still like an empty
-City of Chicago/class 4 row to exist for the mailed stage. */
+cross-joining. This is to make sure that combinations that do not yet
+exist in iasworld.asmt_all for the current year will exist in the view, but have
+largely empty columns. For example: even if no class 4s in the City of Chicago
+have been mailed yet for the current assessment year, we would still like an
+empty City of Chicago/class 4 row to exist for the mailed stage. */
 WITH stages AS (
 
     SELECT 'mailed' AS stage
@@ -18,10 +18,12 @@ WITH stages AS (
 ),
 
 /* This CTE removes historical PINs in reporting.vw_pin_township_class that are
-not in reporting.vw_pin_value_long. These differences are inherent in the tables
-that feed these views (iasworld.pardat and iasworld.asmt_all, respectively) and
-are data errors - not emblematic of what portion of a municipality has actually
-progressed through an assessment stage.
+not in reporting.vw_pin_value_long. We do this to make sure the samples we
+derive the numerator and denominator from for stage_portion are the same. These
+differences are inherent in the tables that feed these views (iasworld.pardat
+and iasworld.asmt_all, respectively) and are data errors - not emblematic of
+what portion of a municipality has actually progressed through an assessment
+stage.
 
 It does NOT remove PINs from the most recent year of
 reporting.vw_pin_township_class since we expect these differences based on how

--- a/aws-athena/views/reporting-vw_pin_township_class.sql
+++ b/aws-athena/views/reporting-vw_pin_township_class.sql
@@ -47,6 +47,7 @@ SELECT
         WHEN UPPER(TRIM(leg.cityname)) = 'LA GRANGE PK' THEN 'LA GRANGE PARK'
         WHEN UPPER(TRIM(leg.cityname)) = 'PALTINE' THEN 'PALATINE'
         WHEN UPPER(TRIM(leg.cityname)) = 'TINLEY PK' THEN 'TINLEY PARK'
+        ELSE UPPER(TRIM(leg.cityname))
     END AS municipality_name,
     correct.class,
     groups.reporting_class_code AS major_class,

--- a/aws-athena/views/reporting-vw_pin_township_class.sql
+++ b/aws-athena/views/reporting-vw_pin_township_class.sql
@@ -19,7 +19,35 @@ SELECT
     town.township_name,
     leg.user1 AS township_code,
     SUBSTR(correct.nbhd, 3, 3) AS nbhd,
-    leg.cityname AS municipality_name,
+    CASE WHEN
+            UPPER(TRIM(leg.cityname)) IN (
+                'ARLNGTN HTS', 'ARLNGTN HGTS', 'ARLNGTON HGT', 'ARLINGTN HTS'
+            )
+            THEN 'ARLINGTON HEIGHTS'
+        WHEN UPPER(TRIM(leg.cityname)) = 'BERKLEY' THEN 'BERKELEY'
+        WHEN
+            UPPER(TRIM(leg.cityname)) IN (
+                'ELK GR VILL', 'ELK GROVE VL', 'ELK GROVE VILLAGE'
+            )
+            THEN 'ELK GROVE'
+        WHEN UPPER(TRIM(leg.cityname)) = 'HICKORY HLS' THEN 'HICKORY HILLS'
+        WHEN UPPER(TRIM(leg.cityname)) = 'CHICAGO HTS' THEN 'CHICAGO HEIGHTS'
+        WHEN UPPER(TRIM(leg.cityname)) = 'STONE PK' THEN 'STONE PARK'
+        WHEN UPPER(TRIM(leg.cityname)) = 'CHGO' THEN 'CHICAGO'
+        WHEN UPPER(TRIM(leg.cityname)) = 'HOFFMAN ESTS' THEN 'HOFFMAN ESTATES'
+        WHEN UPPER(TRIM(leg.cityname)) = 'OLYMPIA FLDS' THEN 'OLYMPIA FIELDS'
+        WHEN UPPER(TRIM(leg.cityname)) = 'ORLAND PK' THEN 'ORLAND PARK'
+        WHEN UPPER(TRIM(leg.cityname)) = 'S. BARRINGTON' THEN 'SOUTH BARRINGTON'
+        WHEN UPPER(TRIM(leg.cityname)) = 'SO HOLLAND' THEN 'SOUTH HOLLAND'
+        WHEN
+            UPPER(TRIM(leg.cityname)) IN ('WESTERN SPGS', 'WESTERN SPRG')
+            THEN 'WESTERN SPRINGS'
+        WHEN UPPER(TRIM(leg.cityname)) = 'BEDFORD PK' THEN 'BEDFORD PARK'
+        WHEN UPPER(TRIM(leg.cityname)) = 'EVERGREEN PK' THEN 'EVERGREEN PARK'
+        WHEN UPPER(TRIM(leg.cityname)) = 'LA GRANGE PK' THEN 'LA GRANGE PARK'
+        WHEN UPPER(TRIM(leg.cityname)) = 'PALTINE' THEN 'PALATINE'
+        WHEN UPPER(TRIM(leg.cityname)) = 'TINLEY PK' THEN 'TINLEY PARK'
+    END AS municipality_name,
     correct.class,
     groups.reporting_class_code AS major_class,
     groups.modeling_group AS property_group,

--- a/aws-athena/views/reporting-vw_pin_township_class.sql
+++ b/aws-athena/views/reporting-vw_pin_township_class.sql
@@ -50,19 +50,28 @@ SELECT
             THEN 'MOUNT PROSPECT'
         WHEN UPPER(TRIM(leg.cityname)) = 'NORTHFILED' THEN 'NORTHFIELD'
         WHEN UPPER(TRIM(leg.cityname)) = 'OAK PK' THEN 'OAK PARK'
-        WHEN UPPER(TRIM(leg.cityname)) = 'ORLAND PK' THEN 'ORLAND PARK'
+        WHEN
+            UPPER(TRIM(leg.cityname)) IN ('ORLAND', 'ORLAND PK')
+            THEN 'ORLAND PARK'
         WHEN UPPER(TRIM(leg.cityname)) = 'OLYMPIA FLDS' THEN 'OLYMPIA FIELDS'
         WHEN UPPER(TRIM(leg.cityname)) = 'PALTINE' THEN 'PALATINE'
         WHEN UPPER(TRIM(leg.cityname)) = 'ROLLING MEADOW' THEN 'ROLLING MEADOWS'
         WHEN UPPER(TRIM(leg.cityname)) = 'SCHILLET PARK' THEN 'SCHILLER PARK'
-        WHEN UPPER(TRIM(leg.cityname)) = 'S. BARRINGTON' THEN 'SOUTH BARRINGTON'
+        WHEN
+            UPPER(TRIM(leg.cityname)) IN ('S. BARRINGTON', 'S BARRINGTON')
+            THEN 'SOUTH BARRINGTON'
         WHEN UPPER(TRIM(leg.cityname)) = 'SO HOLLAND' THEN 'SOUTH HOLLAND'
         WHEN UPPER(TRIM(leg.cityname)) = 'STONE PK' THEN 'STONE PARK'
-        WHEN UPPER(TRIM(leg.cityname)) = 'SUMMIT ARGO' THEN 'SUMMIT'
+        WHEN UPPER(TRIM(leg.cityname)) IN ('ARGO', 'SUMMIT ARGO') THEN 'SUMMIT'
         WHEN
             UPPER(TRIM(leg.cityname)) IN ('TINLEY PK', 'TINELY PK')
             THEN 'TINLEY PARK'
         WHEN UPPER(TRIM(leg.cityname)) = 'UNIC' THEN 'UNINCORPORATED'
+        WHEN
+            UPPER(TRIM(leg.cityname)) IN (
+                'FORT WORTH', 'MINNEAPOLIS', 'PHILADELPHIA', 'PORTLAND'
+            )
+            THEN 'UNKNOWN'
         WHEN
             UPPER(TRIM(leg.cityname)) IN ('WESTERN SPGS', 'WESTERN SPRG')
             THEN 'WESTERN SPRINGS'

--- a/aws-athena/views/reporting-vw_pin_township_class.sql
+++ b/aws-athena/views/reporting-vw_pin_township_class.sql
@@ -19,7 +19,10 @@ SELECT
     town.township_name,
     leg.user1 AS township_code,
     SUBSTR(correct.nbhd, 3, 3) AS nbhd,
-    ARRAY_JOIN(tax.tax_municipality_name, ', ', NULL) AS municipality_name,
+    CASE
+        WHEN ARRAY_JOIN(tax.tax_municipality_name, ', ') = '' THEN NULL ELSE
+            ARRAY_JOIN(tax.tax_municipality_name, ', ')
+    END AS municipality_name,
     correct.class,
     groups.reporting_class_code AS major_class,
     groups.modeling_group AS property_group,

--- a/aws-athena/views/reporting-vw_pin_township_class.sql
+++ b/aws-athena/views/reporting-vw_pin_township_class.sql
@@ -19,6 +19,7 @@ SELECT
     town.township_name,
     leg.user1 AS township_code,
     SUBSTR(correct.nbhd, 3, 3) AS nbhd,
+    leg.cityname AS municipality_name,
     correct.class,
     groups.reporting_class_code AS major_class,
     groups.modeling_group AS property_group,

--- a/aws-athena/views/reporting-vw_pin_township_class.sql
+++ b/aws-athena/views/reporting-vw_pin_township_class.sql
@@ -21,32 +21,51 @@ SELECT
     SUBSTR(correct.nbhd, 3, 3) AS nbhd,
     CASE WHEN
             UPPER(TRIM(leg.cityname)) IN (
-                'ARLNGTN HTS', 'ARLNGTN HGTS', 'ARLNGTON HGT', 'ARLINGTN HTS'
+                'ARLNGTN HTS',
+                'ARLNGTN HGTS',
+                'ARLNGTON HGT',
+                'ARLINGTN HTS',
+                'ARLIGNTON HEIGHTS',
+                'ARLINGTON HT'
             )
             THEN 'ARLINGTON HEIGHTS'
+        WHEN UPPER(TRIM(leg.cityname)) = 'BEDFORD PK' THEN 'BEDFORD PARK'
         WHEN UPPER(TRIM(leg.cityname)) = 'BERKLEY' THEN 'BERKELEY'
+        WHEN UPPER(TRIM(leg.cityname)) = 'CHGO' THEN 'CHICAGO'
+        WHEN UPPER(TRIM(leg.cityname)) = 'CHICAGO HTS' THEN 'CHICAGO HEIGHTS'
+        WHEN UPPER(TRIM(leg.cityname)) = 'CRESWTOOD' THEN 'CRESTWOOD'
         WHEN
             UPPER(TRIM(leg.cityname)) IN (
                 'ELK GR VILL', 'ELK GROVE VL', 'ELK GROVE VILLAGE'
             )
             THEN 'ELK GROVE'
+        WHEN UPPER(TRIM(leg.cityname)) = 'EVERGREEN PK' THEN 'EVERGREEN PARK'
+        WHEN UPPER(TRIM(leg.cityname)) = 'FORESTVIEW' THEN 'FOREST VIEW'
         WHEN UPPER(TRIM(leg.cityname)) = 'HICKORY HLS' THEN 'HICKORY HILLS'
-        WHEN UPPER(TRIM(leg.cityname)) = 'CHICAGO HTS' THEN 'CHICAGO HEIGHTS'
-        WHEN UPPER(TRIM(leg.cityname)) = 'STONE PK' THEN 'STONE PARK'
-        WHEN UPPER(TRIM(leg.cityname)) = 'CHGO' THEN 'CHICAGO'
         WHEN UPPER(TRIM(leg.cityname)) = 'HOFFMAN ESTS' THEN 'HOFFMAN ESTATES'
-        WHEN UPPER(TRIM(leg.cityname)) = 'OLYMPIA FLDS' THEN 'OLYMPIA FIELDS'
+        WHEN UPPER(TRIM(leg.cityname)) = 'LAGRANGE' THEN 'LA GRANGE'
+        WHEN UPPER(TRIM(leg.cityname)) = 'LA GRANGE PK' THEN 'LA GRANGE PARK'
+        WHEN
+            UPPER(TRIM(leg.cityname)) IN ('MT PROSPECT', 'MT. PROSPECT')
+            THEN 'MOUNT PROSPECT'
+        WHEN UPPER(TRIM(leg.cityname)) = 'NORTHFILED' THEN 'NORTHFIELD'
+        WHEN UPPER(TRIM(leg.cityname)) = 'OAK PK' THEN 'OAK PARK'
         WHEN UPPER(TRIM(leg.cityname)) = 'ORLAND PK' THEN 'ORLAND PARK'
+        WHEN UPPER(TRIM(leg.cityname)) = 'OLYMPIA FLDS' THEN 'OLYMPIA FIELDS'
+        WHEN UPPER(TRIM(leg.cityname)) = 'PALTINE' THEN 'PALATINE'
+        WHEN UPPER(TRIM(leg.cityname)) = 'ROLLING MEADOW' THEN 'ROLLING MEADOWS'
+        WHEN UPPER(TRIM(leg.cityname)) = 'SCHILLET PARK' THEN 'SCHILLER PARK'
         WHEN UPPER(TRIM(leg.cityname)) = 'S. BARRINGTON' THEN 'SOUTH BARRINGTON'
         WHEN UPPER(TRIM(leg.cityname)) = 'SO HOLLAND' THEN 'SOUTH HOLLAND'
+        WHEN UPPER(TRIM(leg.cityname)) = 'STONE PK' THEN 'STONE PARK'
+        WHEN UPPER(TRIM(leg.cityname)) = 'SUMMIT ARGO' THEN 'SUMMIT'
+        WHEN
+            UPPER(TRIM(leg.cityname)) IN ('TINLEY PK', 'TINELY PK')
+            THEN 'TINLEY PARK'
+        WHEN UPPER(TRIM(leg.cityname)) = 'UNIC' THEN 'UNINCORPORATED'
         WHEN
             UPPER(TRIM(leg.cityname)) IN ('WESTERN SPGS', 'WESTERN SPRG')
             THEN 'WESTERN SPRINGS'
-        WHEN UPPER(TRIM(leg.cityname)) = 'BEDFORD PK' THEN 'BEDFORD PARK'
-        WHEN UPPER(TRIM(leg.cityname)) = 'EVERGREEN PK' THEN 'EVERGREEN PARK'
-        WHEN UPPER(TRIM(leg.cityname)) = 'LA GRANGE PK' THEN 'LA GRANGE PARK'
-        WHEN UPPER(TRIM(leg.cityname)) = 'PALTINE' THEN 'PALATINE'
-        WHEN UPPER(TRIM(leg.cityname)) = 'TINLEY PK' THEN 'TINLEY PARK'
         ELSE UPPER(TRIM(leg.cityname))
     END AS municipality_name,
     correct.class,

--- a/aws-athena/views/reporting-vw_pin_township_class.sql
+++ b/aws-athena/views/reporting-vw_pin_township_class.sql
@@ -19,7 +19,7 @@ SELECT
     town.township_name,
     leg.user1 AS township_code,
     SUBSTR(correct.nbhd, 3, 3) AS nbhd,
-    ARRAY_JOIN(tax.tax_municipality_name, ', ') AS municipality_name,
+    ARRAY_JOIN(tax.tax_municipality_name, ', ', NULL) AS municipality_name,
     correct.class,
     groups.reporting_class_code AS major_class,
     groups.modeling_group AS property_group,
@@ -49,6 +49,7 @@ LEFT JOIN {{ source('spatial', 'township') }} AS town
 -- Exclude classes without a reporting class
 INNER JOIN {{ ref('ccao.class_dict') }} AS groups
     ON correct.class = groups.class_code
+-- Tax municipality data lags iasWorld data by a year or two at any given time
 LEFT JOIN {{ ref('location.tax') }} AS tax
     ON SUBSTR(correct.parid, 1, 10) = tax.pin10
     AND CASE

--- a/dbt/models/reporting/docs.md
+++ b/dbt/models/reporting/docs.md
@@ -30,7 +30,7 @@ assessment stage, and year. Feeds public reporting assets.
 **Primary Key**: `year`, `township_name`, `class`, `stage`
 {% enddocs %}
 
-# vw_assessment_muni
+# vw_assessment_roll_muni
 
 {% docs view_vw_assessment_roll_muni %}
 View for reporting total AVs and PIN counts per major class group, municipality,

--- a/dbt/models/reporting/docs.md
+++ b/dbt/models/reporting/docs.md
@@ -30,6 +30,15 @@ assessment stage, and year. Feeds public reporting assets.
 **Primary Key**: `year`, `township_name`, `class`, `stage`
 {% enddocs %}
 
+# vw_assessment_muni
+
+{% docs view_vw_assessment_roll_muni %}
+View for reporting total AVs and PIN counts per major class group, municipality,
+assessment stage, and year. Feeds public reporting assets.
+
+**Primary Key**: `year`, `municipality_name`, `class`, `stage`
+{% enddocs %}
+
 # vw_pin_most_recent_boundary
 
 {% docs view_vw_pin_most_recent_boundary %}

--- a/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
+++ b/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
@@ -1,0 +1,1 @@
+../../../aws-athena/views/reporting-vw_assessment_roll_muni.sql

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -94,13 +94,16 @@ models:
             - stage
             - municipality_name
             - class
+          config:
+            error_if: ">1572" # as of 2024-04-25
       - expression_is_true:
           name: reporting_vw_assessment_roll_muni_no_nulls
           expression: |
             stage IS NOT NULL
-            AND township_name IS NOT NULL
-            AND triad IS NOT NULL
+            AND municipality_name IS NOT NULL
             AND class IS NOT NULL
+          config:
+            error_if: ">1370" # as of 2024-04-25
 
   - name: reporting.vw_pin_most_recent_boundary
     description: '{{ doc("view_vw_pin_most_recent_boundary") }}'

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -84,6 +84,24 @@ models:
             AND triad IS NOT NULL
             AND class IS NOT NULL
 
+  - name: reporting.vw_assessment_roll_muni
+    description: '{{ doc("view_vw_assessment_roll_muni") }}'
+    tests:
+      - unique_combination_of_columns:
+          name: reporting_vw_assessment_roll_muni_unique_by_keys
+          combination_of_columns:
+            - year
+            - stage
+            - municipality_name
+            - class
+      - expression_is_true:
+          name: reporting_vw_assessment_roll_muni_no_nulls
+          expression: |
+            stage IS NOT NULL
+            AND township_name IS NOT NULL
+            AND triad IS NOT NULL
+            AND class IS NOT NULL
+
   - name: reporting.vw_pin_most_recent_boundary
     description: '{{ doc("view_vw_pin_most_recent_boundary") }}'
     tests:

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -94,16 +94,12 @@ models:
             - stage
             - municipality_name
             - class
-          config:
-            error_if: ">1299" # as of 2024-04-29
       - expression_is_true:
           name: reporting_vw_assessment_roll_muni_no_nulls
           expression: |
             stage IS NOT NULL
             AND municipality_name IS NOT NULL
             AND class IS NOT NULL
-          config:
-            error_if: ">1370" # as of 2024-04-25
 
   - name: reporting.vw_pin_most_recent_boundary
     description: '{{ doc("view_vw_pin_most_recent_boundary") }}'

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -95,7 +95,7 @@ models:
             - municipality_name
             - class
           config:
-            error_if: ">1572" # as of 2024-04-25
+            error_if: ">2229" # as of 2024-04-25
       - expression_is_true:
           name: reporting_vw_assessment_roll_muni_no_nulls
           expression: |

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -94,7 +94,8 @@ models:
             - stage
             - municipality_name
             - class
-            - reassessment_year
+          config:
+            error_if: ">2747" # as of 2024-04-29
       - expression_is_true:
           name: reporting_vw_assessment_roll_muni_no_nulls
           expression: |

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -94,8 +94,7 @@ models:
             - stage
             - municipality_name
             - class
-          config:
-            error_if: ">2229" # as of 2024-04-25
+            - reassessment_year
       - expression_is_true:
           name: reporting_vw_assessment_roll_muni_no_nulls
           expression: |

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -95,7 +95,7 @@ models:
             - municipality_name
             - class
           config:
-            error_if: ">2747" # as of 2024-04-29
+            error_if: ">1299" # as of 2024-04-29
       - expression_is_true:
           name: reporting_vw_assessment_roll_muni_no_nulls
           expression: |


### PR DESCRIPTION
> In reporting, we currently have vw_assessment_roll and vw_top_5 for townships. I'd like to create two similar separate views for municipalities.
> ### Use case
> 
> - This is frequently requested data for Assessor Leadership; let's institutionalize it.
> 
> - I also want to have an auto-updating version of a [municipal dashboard](https://www.cookcountyassessor.com/node/1887075).
> 
> 
> ### Complication: Assessment cycles
> 
> the assessment system works on a township cycle, not a municipal cycle, so some municipalities might have some PINs in one assessment stage and other PINs in a different stage.
> ### Possible solution
> 
> I _think_ the best way around this is to add an additional column on the assessment_roll version indicating, for each municipality, for the year & stage, the percentage of its PINs that have passed through that year & stage.
> 
> The ideal behavior of this "percent complete" column would be if the percent indicator had "memory." For example:
> 
> - if a multi-township muni like Chicago had fully passed through the 2023 certified stage but only 50% of its PINs had reached the 2023 bor stage, then the percentage indicator would say 100% when year = 2023 and stage = assessor certified, and 50% when year = 2023 and stage = bor.
> 
> - and, because in this scenario 2022 is complete, then for all 3 stages, the percent complete would be 100%.