### PR TITLE
Test conditionally forward filling `default.vw_pin_universe`

### DIFF
--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -14,7 +14,7 @@ WITH pardat_adjusted_years AS (
         nbhd,
         cur,
         deactivat
-    FROM iasworld.pardat
+    FROM {{ source('iasworld', 'pardat') }}
 
 )
 

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -12,7 +12,7 @@ WITH pardat_adjusted_years AS (
         CASE
             WHEN
                 taxyr > (SELECT MAX(year) FROM {{ source('spatial', 'parcel') }})
-                THEN (SELECT MAX(year) FROM {{ source('spatial', 'parcel') }}l)
+                THEN (SELECT MAX(year) FROM {{ source('spatial', 'parcel') }})
             ELSE taxyr
         END AS join_year,
         class,

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -1,9 +1,14 @@
 -- Source of truth view for PIN location
 
--- This CTE ensures the most recent year of pardat data is joined to spatial
--- data regardless of timing. This is necessary since spatial data releases late
--- in a calendar year while the CCAO's universe of PINs is rolled over much
--- sooner.
+/* This CTE ensures the most recent year of pardat data is joined to spatial
+data regardless of timing. This is necessary since spatial data releases late in
+a calendar year while the CCAO's universe of PINs is rolled over much sooner.
+
+Specifically, the CCAO usually rolls over iasworld in January of each year while
+spatial data (parcel, tiger/line shapefiles, etc.) do not typically become
+available until November or Decemeber of that same year. This leave almost an
+entire calendar year duing which the most recent (and relevant) year of iasworld
+data is unmatched with spatial data. */
 WITH pardat_adjusted_years AS (
 
     SELECT

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -11,7 +11,8 @@ WITH pardat_adjusted_years AS (
         taxyr,
         CASE
             WHEN
-                taxyr > (SELECT MAX(year) FROM {{ source('spatial', 'parcel') }})
+                taxyr
+                > (SELECT MAX(year) FROM {{ source('spatial', 'parcel') }})
                 THEN (SELECT MAX(year) FROM {{ source('spatial', 'parcel') }})
             ELSE taxyr
         END AS join_year,

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -169,7 +169,6 @@ LEFT JOIN {{ source('spatial', 'township') }} AS twn
     ON leg.user1 = CAST(twn.township_code AS VARCHAR)
 LEFT JOIN {{ source('ccao', 'corner_lot') }} AS lot
     ON SUBSTR(par.parid, 1, 10) = lot.pin10
-
 WHERE par.cur = 'Y'
     AND par.deactivat IS NULL
     -- Remove any parcels with non-numeric characters

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -11,8 +11,8 @@ WITH pardat_adjusted_years AS (
         taxyr,
         CASE
             WHEN
-                taxyr > (SELECT MAX(year) FROM spatial.parcel)
-                THEN (SELECT MAX(year) FROM spatial.parcel)
+                taxyr > (SELECT MAX(year) FROM {{ source('spatial', 'parcel') }})
+                THEN (SELECT MAX(year) FROM {{ source('spatial', 'parcel') }}l)
             ELSE taxyr
         END AS join_year,
         class,

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -1,4 +1,9 @@
 -- Source of truth view for PIN location
+
+-- This CTE ensures the most recent year of pardat data is joined to spatial
+-- data regardless of timing. This is necessary since spatial data releases late
+-- in a calendar year while the CCAO's universe of PINs is rolled-over much
+-- sooner.
 WITH pardat_adjusted_years AS (
 
     SELECT

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -4,10 +4,10 @@
 data regardless of timing. This is necessary since spatial data releases late in
 a calendar year while the CCAO's universe of PINs is rolled over much sooner.
 
-Specifically, the CCAO usually rolls over iasworld in January of each year while
+Specifically, the CCAO usually rolls over iasWorld in January of each year while
 spatial data (parcel, tiger/line shapefiles, etc.) do not typically become
-available until November or Decemeber of that same year. This leave almost an
-entire calendar year duing which the most recent (and relevant) year of iasworld
+available until November or Decemeber of that same year. This leaves almost an
+entire calendar year duing which the most recent (and relevant) year of iasWorld
 data is unmatched with spatial data. */
 WITH pardat_adjusted_years AS (
 

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -37,6 +37,7 @@ SELECT
     REGEXP_REPLACE(par.nbhd, '([^0-9])', '') AS nbhd_code,
     leg.taxdist AS tax_code,
     NULLIF(leg.zip1, '00000') AS zip_code,
+    par.join_year AS spatial_data_year,
 
     -- Centroid of each PIN from county parcel files
     sp.lon,
@@ -151,7 +152,7 @@ SELECT
 FROM pardat_adjusted_years AS par
 LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg
     ON par.parid = leg.parid
-    AND par.join_year = leg.taxyr
+    AND par.taxyr = leg.taxyr
     AND leg.cur = 'Y'
     AND leg.deactivat IS NULL
 LEFT JOIN {{ source('spatial', 'parcel') }} AS sp

--- a/aws-athena/views/default-vw_pin_universe.sql
+++ b/aws-athena/views/default-vw_pin_universe.sql
@@ -42,7 +42,6 @@ SELECT
     REGEXP_REPLACE(par.nbhd, '([^0-9])', '') AS nbhd_code,
     leg.taxdist AS tax_code,
     NULLIF(leg.zip1, '00000') AS zip_code,
-    par.join_year AS spatial_data_year,
 
     -- Centroid of each PIN from county parcel files
     sp.lon,


### PR DESCRIPTION
Reporting on 2024 is pretty difficult with no 2024 spatial data. Let's try forward filling it in `vw_pin_universe` and see what that gets us.