### PR TITLE
Fix `reassessment_year` in `vw_pin_township_class`

### DIFF
--- a/aws-athena/views/reporting-vw_pin_township_class.sql
+++ b/aws-athena/views/reporting-vw_pin_township_class.sql
@@ -43,7 +43,7 @@ LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg
     AND correct.taxyr = leg.taxyr
     AND leg.cur = 'Y'
     AND leg.deactivat IS NULL
-LEFT JOIN {{ source('spatial', 'township') }} AS town
+INNER JOIN {{ source('spatial', 'township') }} AS town
     ON leg.user1 = town.township_code
 -- Exclude classes without a reporting class
 INNER JOIN {{ ref('ccao.class_dict') }} AS groups


### PR DESCRIPTION
`reassessment_year` is coming up as false/true within years and tris because of missing values for `legdat.user1`. An `INNER JOIN` should fix this.