### PR TITLE
Bump role duration for daily builds

### DIFF
--- a/.github/workflows/build_daily_dbt_models.yaml
+++ b/.github/workflows/build_daily_dbt_models.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
-          role-duration-seconds: 900
+          role-duration-seconds: 14400  # Worst-case time for full build
 
       - name: Restore dbt state cache
         id: cache


### PR DESCRIPTION
Our [daily dbt build](https://github.com/ccao-data/data-architecture/actions/runs/9017116315/job/24780765574) failed this morning with a role timeout. I'm fairly certain we just need to bump the role duration passed during the setup stage of the workflow.