### PR TITLE
Update `vw_pin_appeal` with new post-2020 logic cutoff

### DIFF
--- a/aws-athena/views/default-vw_pin_appeal.sql
+++ b/aws-athena/views/default-vw_pin_appeal.sql
@@ -33,30 +33,30 @@ SELECT
     -- Status, reason codes, and agent name come from different columns
     -- before and after 2020
     CASE
-        WHEN htpar.taxyr < '2020' AND htpar.resact = 'C' THEN 'change'
-        WHEN htpar.taxyr < '2020' AND htpar.resact = 'NC' THEN 'no change'
+        WHEN htpar.taxyr <= '2020' AND htpar.resact = 'C' THEN 'change'
+        WHEN htpar.taxyr <= '2020' AND htpar.resact = 'NC' THEN 'no change'
         WHEN
-            htpar.taxyr >= '2020' AND TRIM(LOWER(htpar.user104)) = 'decrease'
+            htpar.taxyr > '2020' AND TRIM(LOWER(htpar.user104)) = 'decrease'
             THEN 'change'
-        WHEN htpar.taxyr >= '2020' THEN TRIM(LOWER(htpar.user104))
+        WHEN htpar.taxyr > '2020' THEN TRIM(LOWER(htpar.user104))
     END AS change,
     CASE
-        WHEN htpar.taxyr < '2020'
+        WHEN htpar.taxyr <= '2020'
             AND TRIM(SUBSTR(htpar.user42, 1, 2)) NOT IN ('0', ':')
             THEN TRIM(SUBSTR(htpar.user42, 1, 2))
-        WHEN htpar.taxyr >= '2020' THEN htpar.user89
+        WHEN htpar.taxyr > '2020' THEN htpar.user89
     END AS reason_code1,
     CASE
-        WHEN htpar.taxyr < '2020'
+        WHEN htpar.taxyr <= '2020'
             AND TRIM(SUBSTR(htpar.user43, 1, 2)) NOT IN ('0', ':')
             THEN TRIM(SUBSTR(htpar.user42, 1, 2))
-        WHEN htpar.taxyr >= '2020' THEN htpar.user100
+        WHEN htpar.taxyr > '2020' THEN htpar.user100
     END AS reason_code2,
     CASE
-        WHEN htpar.taxyr < '2020'
+        WHEN htpar.taxyr <= '2020'
             AND TRIM(SUBSTR(htpar.user44, 1, 2)) NOT IN ('0', ':')
             THEN TRIM(SUBSTR(htpar.user42, 1, 2))
-        WHEN htpar.taxyr >= '2020' THEN htpar.user101
+        WHEN htpar.taxyr > '2020' THEN htpar.user101
     END AS reason_code3,
     htpar.cpatty AS agent_code,
     htagnt.name1 AS agent_name,


### PR DESCRIPTION
It looks like our logic in `vw_pin_appeal` for including ~2020 appeals is potentially wrong (or the underlying data has changed). This PR updates the logic to take the correct set of columns for 2020.

## Current output

You can see from the table below that the change and reason code columns are entirely null for 2020. Each cell is the null proportion for that year and column.

<details>
  <summary>See query</summary>

```sql
SELECT
    year,
    ROUND(SUM(CAST(change IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS change_np,
    ROUND(SUM(CAST(reason_code1 IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS reason1_np,
    ROUND(SUM(CAST(reason_code2 IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS reason2_np,
    ROUND(SUM(CAST(reason_code3 IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS reason3_np,
    ROUND(SUM(CAST(agent_code IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS agent_code_np,
    ROUND(SUM(CAST(agent_name IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS agent_name_np
FROM default.vw_pin_appeal
WHERE year >= '2017'
GROUP BY year
ORDER BY year DESC
```

</details>

| year | change_np | reason1_np | reason2_np | reason3_np | agent_code_np | agent_name_np |
|------|-----------|------------|------------|------------|---------------|---------------|
| 2024 | 0.093     | 0.093      | 0.962      | 0.998      | 0.22          | 0.22          |
| 2023 | 0.071     | 0.071      | 0.948      | 0.991      | 0.299         | 0.299         |
| 2022 | 0.001     | 0.001      | 0.963      | 0.994      | 0.167         | 0.167         |
| 2021 | 0.0       | 0.0        | 0.987      | 1.0        | 0.131         | 0.131         |
| 2020 | 1.0       | 1.0        | 1.0        | 1.0        | 1.0           | 1.0           |
| 2019 | 0.1       | 0.1        | 0.929      | 1.0        | 1.0           | 1.0           |
| 2018 | 0.158     | 0.158      | 0.846      | 1.0        | 1.0           | 1.0           |
| 2017 | 0.282     | 0.281      | 0.901      | 1.0        | 1.0           | 1.0           |


## After PR

The updated view populates the change column for 2020 and thus reduces the null proportion. However, the other columns (reason codes, agent names) don't seem to be populated in any of the potential columns, so the null proportion is still 1.

<details>
  <summary>See query</summary>

```sql
SELECT
    year,
    ROUND(SUM(CAST(change IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS change_np,
    ROUND(SUM(CAST(reason_code1 IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS reason1_np,
    ROUND(SUM(CAST(reason_code2 IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS reason2_np,
    ROUND(SUM(CAST(reason_code3 IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS reason3_np,
    ROUND(SUM(CAST(agent_code IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS agent_code_np,
    ROUND(SUM(CAST(agent_name IS NULL AS int)) / CAST(COUNT(*) AS double), 3) AS agent_name_np
FROM z_ci_dfsnow_fix_appeal_view_default.vw_pin_appeal
WHERE year >= '2017'
GROUP BY year
ORDER BY year DESC
```

</details>

| year | change_np | reason1_np | reason2_np | reason3_np | agent_code_np | agent_name_np |
|------|-----------|------------|------------|------------|---------------|---------------|
| 2024 | 0.093     | 0.093      | 0.962      | 0.998      | 0.22          | 0.22          |
| 2023 | 0.071     | 0.071      | 0.948      | 0.991      | 0.299         | 0.299         |
| 2022 | 0.001     | 0.001      | 0.963      | 0.994      | 0.167         | 0.167         |
| 2021 | 0.0       | 0.0        | 0.987      | 1.0        | 0.131         | 0.131         |
| 2020 | **0.007** | 1.0        | 1.0        | 1.0        | 1.0           | 1.0           |
| 2019 | 0.1       | 0.1        | 0.929      | 1.0        | 1.0           | 1.0           |
| 2018 | 0.158     | 0.158      | 0.846      | 1.0        | 1.0           | 1.0           |
| 2017 | 0.282     | 0.281      | 0.901      | 1.0        | 1.0           | 1.0           |

@ccao-jardine FYI