### PR TITLE
[Do not merge] Configure high availability on all dbt tables

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -52,6 +52,7 @@ models:
     +materialized: view
     +write_compression: zstd
     +format: parquet
+    +ha: true
     census:
       +schema: census
     default:

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -5,7 +5,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-dev-us-east-1/results/
       s3_data_dir: s3://ccao-dbt-athena-dev-us-east-1/data/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       # "schema" here corresponds to a Glue database
       schema: z_static_unused_dbt_stub_database
@@ -18,7 +18,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-ci-us-east-1/results/
       s3_data_dir: s3://ccao-dbt-athena-ci-us-east-1/data/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
@@ -29,7 +29,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-athena-results-us-east-1/
       s3_data_dir: s3://ccao-athena-ctas-us-east-1/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       schema: default
       database: awsdatacatalog


### PR DESCRIPTION
⚠️ **Note: Do not merge until West reporting is complete**. ⚠️ 

This PR updates all of our dbt tables to be [high availability](https://github.com/dbt-athena/dbt-athena?tab=readme-ov-file#highly-available-table-ha) by default. This change should prevent downtime when building a new version of a table.

Closes #460.