### PR TITLE
Deploy dbt model dependencies before building daily models

### DIFF
--- a/.github/workflows/build_daily_dbt_models.yaml
+++ b/.github/workflows/build_daily_dbt_models.yaml
@@ -31,6 +31,11 @@ jobs:
           path: ${{ env.PROJECT_DIR }}/${{ env.STATE_DIR }}
           key: ${{ env.CACHE_KEY }}
 
+      - name: Deploy model dependencies
+        run: ../.github/scripts/deploy_dbt_model_dependencies.sh
+        working-directory: ${{ env.PROJECT_DIR }}
+        shell: bash
+
       - name: Build daily models
         run: dbt run -t "$TARGET" -s tag:daily --defer --state "$STATE_DIR"
         working-directory: ${{ env.PROJECT_DIR }}


### PR DESCRIPTION
As discussed in https://github.com/ccao-data/aws-infrastructure/pull/26#discussion_r1609011282, there's currently an edge case in our dbt model dependency deployment pipeline that could bite us in the future. The problem is the combination of these three aspects of the pipeline:

* Model dependencies are only deployed as part of the `build-and-test-dbt` workflow, which runs on PRs being merged to the main branch
* Model dependencies are configured to expire every 90 days
* Model dependencies are required by the `build-daily-dbt-models` workflow, which is scheduled to run once a day

As such, it's possible for `build-daily-dbt-models` to run without model dependencies existing, if they happen to have expired before it runs.

This PR fixes this edge case by updating `build-daily-dbt-models` to deploy model dependencies in the same way that `build-and-test-dbt` does.

I tested this PR by manually dispatching `build-daily-dbt-models` from this branch. (I ran the action just long enough to confirm that the deployment step succeeds, but cancelled it at that point, so the workflow appears to have failed.) Here's evidence that the deployment step succeeds: https://github.com/ccao-data/data-architecture/actions/runs/9193740823/job/25286017600#step:5:28