### PR TITLE
Upgrade dbt-core to 1.8.1

### DIFF
--- a/dbt/requirements.txt
+++ b/dbt/requirements.txt
@@ -1,2 +1,2 @@
 dbt-athena-community==1.8.1
-dbt-core==1.8.0
+dbt-core==1.8.1


### PR DESCRIPTION
This housekeeping PR updates dbt-core to [1.8.1](https://github.com/dbt-labs/dbt-core/releases/tag/v1.8.1), released today.