### PR TITLE
Fix broken categorization in `transform_dbt_test_results.py` and remove `dbt_utils` dependency

### DIFF
--- a/.github/scripts/transform_dbt_test_results.py
+++ b/.github/scripts/transform_dbt_test_results.py
@@ -108,16 +108,13 @@ WEN_FIELD = "wen"
 # Mapping that defines category names that should be reported for tests
 # based on their generics
 TEST_CATEGORIES = {
-    "macro.athena.test_accepted_range": "incorrect_values",
-    "macro.dbt_utils.test_accepted_range": "incorrect_values",
-    "macro.athena.test_accepted_values": "incorrect_values",
-    "macro.athena.test_not_accepted_values": "incorrect_values",
-    "macro.dbt_utils.test_not_accepted_values": "incorrect_values",
-    "macro.athena.test_unique_combination_of_columns": "duplicate_records",
-    "macro.dbt_utils.test_unique_combination_of_columns": "duplicate_records",
-    "macro.athena.test_not_null": "missing_values",
-    "macro.athena.test_is_null": "missing_values",
-    "macro.athena.test_res_class_matches_pardat": "class_mismatch_or_issue",
+    "test_accepted_range": "incorrect_values",
+    "test_accepted_values": "incorrect_values",
+    "test_not_accepted_values": "incorrect_values",
+    "test_unique_combination_of_columns": "duplicate_records",
+    "test_not_null": "missing_values",
+    "test_is_null": "missing_values",
+    "test_res_class_matches_pardat": "class_mismatch_or_issue",
 }
 # Fallback for tests whose category we can't determine from either the
 # test name, the `meta.category` attribute, or the TEST_CATEGORIES mapping
@@ -1184,16 +1181,15 @@ def get_category_from_node(node: typing.Dict) -> str:
         return meta_category
 
     for dependency_macro in node["depends_on"]["macros"]:
-        if custom_test_name := TEST_CATEGORIES.get(dependency_macro):
+        # Macro names in the DAG are fully qualified following the pattern
+        # `macro.<project_name>.<macro_name>`, so remove the prefix to extract
+        # just the name of the macro
+        cleaned_macro_name = dependency_macro.split(".")[-1]
+        if custom_test_name := TEST_CATEGORIES.get(cleaned_macro_name):
             return custom_test_name
-        # Custom generic tests are always formatted like
-        # macro.dbt.test_<generic_name>
-        if dependency_macro.startswith("macro.athena.test_"):
-            return dependency_macro.split("macro.athena.test_")[-1]
-        # dbt_utils generic tests are always formatted like
-        # macro.dbt_utils.test_<generic_name>
-        if dependency_macro.startswith("macro.dbt_utils.test_"):
-            return dependency_macro.split("macro.dbt_utils.test_")[-1]
+        # Custom generic tests are always formatted like test_<generic_name>
+        if cleaned_macro_name.startswith("test_"):
+            return cleaned_macro_name.split("test_")[-1]
 
     return DEFAULT_TEST_CATEGORY
 

--- a/dbt/package-lock.yml
+++ b/dbt/package-lock.yml
@@ -1,4 +1,0 @@
-packages:
-- package: dbt-labs/dbt_utils
-  version: 1.1.1
-sha1_hash: a158c48c59c2bb7d729d2a4e215aabe5bb4f3353

--- a/dbt/packages.yml
+++ b/dbt/packages.yml
@@ -1,3 +1,0 @@
-packages:
-  - package: dbt-labs/dbt_utils
-    version: 1.1.1

--- a/dbt/tests/generic/test_sequential_values.sql
+++ b/dbt/tests/generic/test_sequential_values.sql
@@ -8,7 +8,7 @@
     additional_select_columns=[]
 ) %}
 
-    {%- set previous_column_name = "previous_" ~ dbt_utils.slugify(column_name) -%}
+    {%- set previous_column_name = "previous_" ~ slugify(column_name) -%}
 
     {%- if group_by_columns | length() > 0 -%}
         {%- set select_gb_cols = group_by_columns | join(",") -%}


### PR DESCRIPTION
I noticed today that the categorization of tests performed by `transform_dbt_test_results.py` broke after we changed the name of our dbt project from `athena` to `ccao_data_athena` in https://github.com/ccao-data/data-architecture/pull/422, causing most of our tests to get incorrectly categorized as `miscellaneous`. This PR fixes that bug and removes the coupling of `transform_dbt_test_results.py` to the dbt project name so that we can change the name of the project without breaking the script in the future.

I also searched the repo to double-check that there aren't any more hidden references to the old project name hanging around, and as far as I can tell this is the last one.

Note that this PR also removes the dependency on `dbt_utils`, since I noticed that the last remaining use of a `dbt_utils` macro could be refactored to use one of our macros. We've been following a de facto pattern of vendoring `dbt_utils` macros since we need them to support our `additional_select_columns` interface, and this change makes that pattern official.

I tested this by rerunning `transform_dbt_test_results.py` and confirming that the test categorization works as expected again. I'm happy to share the output if you would like to double-check.