### PR TITLE
Revert "Configure high availability on all dbt tables"

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -52,7 +52,6 @@ models:
     +materialized: view
     +write_compression: zstd
     +format: parquet
-    +ha: true
     census:
       +schema: census
     default:

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -5,7 +5,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-dev-us-east-1/results/
       s3_data_dir: s3://ccao-dbt-athena-dev-us-east-1/data/
-      s3_data_naming: schema_table_unique
+      s3_data_naming: schema_table
       region_name: us-east-1
       # "schema" here corresponds to a Glue database
       schema: z_static_unused_dbt_stub_database
@@ -18,7 +18,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-ci-us-east-1/results/
       s3_data_dir: s3://ccao-dbt-athena-ci-us-east-1/data/
-      s3_data_naming: schema_table_unique
+      s3_data_naming: schema_table
       region_name: us-east-1
       schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
@@ -29,7 +29,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-athena-results-us-east-1/
       s3_data_dir: s3://ccao-athena-ctas-us-east-1/
-      s3_data_naming: schema_table_unique
+      s3_data_naming: schema_table
       region_name: us-east-1
       schema: default
       database: awsdatacatalog


### PR DESCRIPTION
Reverts ccao-data/data-architecture#462. We're getting the following failure on Spark tables:

```
File "<stdin>", line 387, in <module>
  File "<stdin>", line 239, in model
  File "<stdin>", line 384, in <lambda>
  File "<stdin>", line 292, in ref
  File "<stdin>", line 378, in get_spark_df
  File "/opt/amazon/spark/python/lib/pyspark.zip/pyspark/sql/session.py", line 700, in table
    return DataFrame(self._jsparkSession.table(tableName), self._sc, self._jconf)
  File "/opt/amazon/spark/python/lib/py4j-0.10.9.3-src.zip/py4j/java_gateway.py", line 1321, in __call__
    return_value = get_return_value(
  File "/opt/amazon/spark/python/lib/pyspark.zip/pyspark/sql/utils.py", line 117, in deco
    raise converted from None
pyspark.sql.utils.AnalysisException: Path does not exist: s3://ccao-athena-ctas-us-east-1/reporting/ratio_stats_input/abb06ce1-9e51-40e6-bdc5-aaceb2c5e2cc
```