### PR TITLE
Upgrade sqlfluff to 3.0.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # All available hooks: https://pre-commit.com/hooks.html
 repos:
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 2.1.1
+    rev: 3.0.7
     hooks:
     -   id: sqlfluff-lint
     -   id: sqlfluff-fix

--- a/dbt/models/proximity/proximity.dist_pin_to_cta_route.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_cta_route.sql
@@ -8,7 +8,7 @@
     )
 }}
 
-WITH cta_route AS (
+WITH cta_route AS (  -- noqa: ST03
     SELECT *
     FROM {{ source('spatial', 'transit_route') }}
     WHERE agency = 'cta'

--- a/dbt/models/proximity/proximity.dist_pin_to_cta_stop.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_cta_stop.sql
@@ -8,7 +8,7 @@
     )
 }}
 
-WITH cta_stop AS (
+WITH cta_stop AS (  -- noqa: ST03
     SELECT *
     FROM {{ source('spatial', 'transit_stop') }}
     WHERE agency = 'cta'

--- a/dbt/models/proximity/proximity.dist_pin_to_metra_route.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_metra_route.sql
@@ -8,7 +8,7 @@
     )
 }}
 
-WITH metra_route AS (
+WITH metra_route AS (  -- noqa: ST03
     SELECT *
     FROM {{ source('spatial', 'transit_route') }}
     WHERE agency = 'metra'

--- a/dbt/models/proximity/proximity.dist_pin_to_metra_stop.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_metra_stop.sql
@@ -8,7 +8,7 @@
     )
 }}
 
-WITH metra_stop AS (
+WITH metra_stop AS (  -- noqa: ST03
     SELECT *
     FROM {{ source('spatial', 'transit_stop') }}
     WHERE agency = 'metra'

--- a/dbt/models/proximity/proximity.dist_pin_to_park.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_park.sql
@@ -8,7 +8,7 @@
     )
 }}
 
-WITH parks AS (
+WITH parks AS (  -- noqa: ST03
     SELECT *
     FROM {{ source('spatial', 'park') }}
     WHERE ST_AREA(ST_GEOMFROMBINARY(geometry_3435)) > 87120

--- a/dbt/models/proximity/proximity.dist_pin_to_university.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_university.sql
@@ -8,7 +8,7 @@
     )
 }}
 
-WITH major_universities AS (
+WITH major_universities AS (  -- noqa: ST03
     SELECT *
     FROM {{ source('spatial', 'school_location') }}
     WHERE type = 'HigherEd'

--- a/dbt/models/proximity/proximity.dist_pin_to_vacant_land.sql
+++ b/dbt/models/proximity/proximity.dist_pin_to_vacant_land.sql
@@ -7,7 +7,7 @@
     )
 }}
 
-WITH vacant_land AS (
+WITH vacant_land AS (  -- noqa: ST03
     SELECT
         parcel.pin10,
         ST_ASBINARY(ST_POINT(parcel.x_3435, parcel.y_3435)) AS geometry_3435,


### PR DESCRIPTION
This PR brings us up to date with the latest sqlfluff release, and ignores a few lines for a new rule ([ST03](https://docs.sqlfluff.com/en/stable/rules.html#rule-ST03)) that is incorrectly failing in cases where we define a CTE so that we can pass its name into a dbt macro.

Closes https://github.com/ccao-data/data-architecture/issues/456.