### PR TITLE
Upgrade to dbt-athena v1.8.2 to fix cloning of Python models

### DIFF
--- a/dbt/requirements.txt
+++ b/dbt/requirements.txt
@@ -1,2 +1,2 @@
-dbt-athena-community==1.8.1
+dbt-athena-community==1.8.2
 dbt-core==1.8.1


### PR DESCRIPTION
The `dbt clone` workflow we recommend in our README to our team members who are setting up dev environmens has been broken since https://github.com/ccao-data/data-architecture/pull/422 due to a bug in the way that the dbt-athena adapter handles cloning Python models (https://github.com/dbt-athena/dbt-athena/issues/645). That bug was fixed in https://github.com/dbt-athena/dbt-athena/pull/651 and has now been officially released in (v1.8.2)[https://github.com/dbt-athena/dbt-athena/releases/tag/v1.8.2], so this PR updates the dependency to fix the bug on our end as well.

I tested this by running `dbt clone --select reporting.ratio_stats --state master-cache` locally to confirm that it completed successfully.