### PR TITLE
Switch dev and staging dbt targets to dedicated staging Spark workgroup

### DIFF
--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -66,8 +66,12 @@ jobs:
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
             if [[ $MANUALLY_DISPATCHED == 'true' ]]; then
-              echo "Running build on manually selected resources"
-              dbt build -t "$TARGET" -s ${{ inputs.models }} --defer --state "$STATE_DIR" --resource-types model seed
+              echo "Running build on manually selected resources: $SELECTED_RESOURCES"
+              if [ "$SELECTED_RESOURCES" == "*" ]; then
+                dbt build -t "$TARGET" --resource-types model seed
+              else
+                dbt build -t "$TARGET" -s $SELECTED_RESOURCES --defer --state "$STATE_DIR" --resource-types model seed
+              fi
             else
               echo "Running build on modified/new resources only"
               dbt build -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR" --resource-types model seed
@@ -78,6 +82,8 @@ jobs:
           fi
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
+        env:
+          SELECTED_RESOURCES: ${{ inputs.models }}
 
       - name: Test models
         run: |

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -66,12 +66,8 @@ jobs:
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
             if [[ $MANUALLY_DISPATCHED == 'true' ]]; then
-              echo "Running build on manually selected resources: $SELECTED_RESOURCES"
-              if [ "$SELECTED_RESOURCES" == "*" ]; then
-                dbt build -t "$TARGET" --resource-types model seed
-              else
-                dbt build -t "$TARGET" -s $SELECTED_RESOURCES --defer --state "$STATE_DIR" --resource-types model seed
-              fi
+              echo "Running build on manually selected resources"
+              dbt build -t "$TARGET" -s ${{ inputs.models }} --defer --state "$STATE_DIR" --resource-types model seed
             else
               echo "Running build on modified/new resources only"
               dbt build -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR" --resource-types model seed
@@ -82,8 +78,6 @@ jobs:
           fi
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
-        env:
-          SELECTED_RESOURCES: ${{ inputs.models }}
 
       - name: Test models
         run: |

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -70,7 +70,7 @@ jobs:
               if [ "$SELECTED_RESOURCES" == "*" ]; then
                 dbt build -t "$TARGET" --resource-types model seed
               else
-                dbt build -t "$TARGET" -s $SELECTED_RESOURCES --defer --state "$STATE_DIR" --resource-types model seed
+                dbt build -t "$TARGET" -s "$SELECTED_RESOURCES" --defer --state "$STATE_DIR" --resource-types model seed
               fi
             else
               echo "Running build on modified/new resources only"

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -66,12 +66,8 @@ jobs:
         run: |
           if [[ $MODIFIED_RESOURCES_ONLY == 'true' ]]; then
             if [[ $MANUALLY_DISPATCHED == 'true' ]]; then
-              echo "Running build on manually selected resources: $SELECTED_RESOURCES"
-              if [ "$SELECTED_RESOURCES" == "*" ]; then
-                dbt build -t "$TARGET" --resource-types model seed
-              else
-                dbt build -t "$TARGET" -s "$SELECTED_RESOURCES" --defer --state "$STATE_DIR" --resource-types model seed
-              fi
+              echo "Running build on manually selected resources"
+              dbt build -t "$TARGET" -s ${{ inputs.models }} --defer --state "$STATE_DIR" --resource-types model seed
             else
               echo "Running build on modified/new resources only"
               dbt build -t "$TARGET" -s state:modified state:new --defer --state "$STATE_DIR" --resource-types model seed
@@ -82,8 +78,6 @@ jobs:
           fi
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
-        env:
-          SELECTED_RESOURCES: ${{ inputs.models }}
 
       - name: Test models
         run: |

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -11,7 +11,7 @@ athena:
       schema: z_static_unused_dbt_stub_database
       # "database" here corresponds to a Glue data catalog
       database: awsdatacatalog
-      spark_work_group: primary-spark
+      spark_work_group: primary-spark-staging
       threads: 5
       num_retries: 1
     ci:
@@ -22,7 +22,7 @@ athena:
       region_name: us-east-1
       schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
-      spark_work_group: primary-spark
+      spark_work_group: primary-spark-staging
       threads: 5
       num_retries: 1
     prod:


### PR DESCRIPTION
I noticed during the process of investigating problems with https://github.com/ccao-data/data-architecture/issues/460 that our dbt targets all share the same workgroup for Athena PySpark. This isn't ideal from a permissions perspective, since it means that  dev and staging targets can access a role that has CRUD permissions over prod tables and views. This PR changes our profiles so that our dev and staging targets point to a dedicated staging Spark workgroup, `primary-spark-staging`, that only has CRUD permissions over dev/staging tables and views.

The PR also sneaks in one minor unrelated change: Recently as I've been debugging our builds more extensively, I've been finding myself wishing there was a way that we could manually dispatch a run that rebuilds the entire DAG. As far as I can tell, there is no built-in [selector](https://docs.getdbt.com/reference/node-selection/syntax) pattern to do this, but I could be wrong. In any case, this PR also adds a feature whereby a single asterisk (`*`) in the `models` input will indicate to the `build-and-test-dbt` workflow that it should rebuild the entire DAG.