### PR TITLE
Remove deleted `print_s3_dependency_dir` macro call from `cleanup-dbt-resources` workflow

### DIFF
--- a/.github/scripts/cleanup_dbt_resources.sh
+++ b/.github/scripts/cleanup_dbt_resources.sh
@@ -51,12 +51,5 @@ echo "$schemas"
 
 echo "$schemas" | xargs -i bash -c 'delete_database {}'
 
-s3_dependency_dir=$(dbt run-operation print_s3_dependency_dir --quiet \
-    --target "$1"
-)
-
-echo "Deleting Python model requirements at $s3_dependency_dir"
-aws s3 rm "$s3_dependency_dir" --recursive
-
 echo
 echo "Done!"


### PR DESCRIPTION
The `cleanup-dbt-resources` workflow started raising errors after we merged #475 since it was still referencing the `print_s3_dependency_dir` macro that we deleted as part of that PR. See [here](https://github.com/ccao-data/data-architecture/actions/runs/9354399654/job/25747188925) for a sample broken workflow run (note that the 404 warning in the logs is irrelevant, since the script is configured to expect those kinds of 404s and continue execution after encountering them). Note that no resources remain in need of being cleaned up from these failed workflow runs, since they all failed on the very last step that has been functionally a no-op since https://github.com/ccao-data/data-architecture/pull/461.

See [this workflow run](https://github.com/ccao-data/data-architecture/actions/runs/9356664715/job/25754655060) for evidence that this new version of the script executes successfully.

Sidebar: It would be nice if we could figure out a way to unit test this cleanup script, since it has a tendency to break unexpectedly like this, but I can't think of an obvious way to do so. Perhaps we somehow mock the awscli calls and then confirm that the correct list of databases gets expanded into arguments? Curious what you think!