### PR TITLE
Configure high availability for `location` schema

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -48,6 +48,7 @@ models:
     default:
       +schema: default
     location:
+      +ha: true
       +schema: location
     model:
       +schema: model

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -49,6 +49,7 @@ models:
       +schema: default
     location:
       +ha: true
+      +s3_data_naming: schema_table_unique
       +schema: location
     model:
       +schema: model

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -12,7 +12,7 @@ athena:
       # "database" here corresponds to a Glue data catalog
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 5
+      threads: 10
       num_retries: 1
     ci:
       type: athena
@@ -23,7 +23,7 @@ athena:
       schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 5
+      threads: 10
       num_retries: 1
     prod:
       type: athena
@@ -34,5 +34,5 @@ athena:
       schema: default
       database: awsdatacatalog
       spark_work_group: primary-spark
-      threads: 5
+      threads: 10
       num_retries: 1


### PR DESCRIPTION
Testing out more high availability tables following a successful experiment in https://github.com/ccao-data/data-architecture/pull/486.

We also bump the number of threads used by dbt for issuing queries to 10.