### PR TITLE
Switch the whole DAG back to high availability

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -43,13 +43,12 @@ models:
     +materialized: view
     +write_compression: zstd
     +format: parquet
+    +ha: true
     census:
       +schema: census
     default:
       +schema: default
     location:
-      +ha: true
-      +s3_data_naming: schema_table_unique
       +schema: location
     model:
       +schema: model

--- a/dbt/models/model/model.final_model.sql
+++ b/dbt/models/model/model.final_model.sql
@@ -1,9 +1,5 @@
 {{
-    config(
-        materialized='table',
-        ha=true,
-        s3_data_naming='schema_table_unique'
-    )
+    config(materialized='table')
 }}
 
 SELECT

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -5,7 +5,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-dev-us-east-1/results/
       s3_data_dir: s3://ccao-dbt-athena-dev-us-east-1/data/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       # "schema" here corresponds to a Glue database
       schema: z_static_unused_dbt_stub_database
@@ -18,7 +18,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-ci-us-east-1/results/
       s3_data_dir: s3://ccao-dbt-athena-ci-us-east-1/data/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
@@ -29,7 +29,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-athena-results-us-east-1/
       s3_data_dir: s3://ccao-athena-ctas-us-east-1/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       schema: default
       database: awsdatacatalog

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -12,7 +12,7 @@ athena:
       # "database" here corresponds to a Glue data catalog
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 10
+      threads: 16
       num_retries: 1
     ci:
       type: athena
@@ -23,7 +23,7 @@ athena:
       schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 10
+      threads: 16
       num_retries: 1
     prod:
       type: athena
@@ -34,5 +34,5 @@ athena:
       schema: default
       database: awsdatacatalog
       spark_work_group: primary-spark
-      threads: 10
+      threads: 16
       num_retries: 1


### PR DESCRIPTION
This PR reverts the changes in https://github.com/ccao-data/data-architecture/pull/476, effectively reimplementing https://github.com/ccao-data/data-architecture/pull/462 now that we've built confidence in the HA approach in https://github.com/ccao-data/data-architecture/pull/487 and https://github.com/ccao-data/data-architecture/pull/486.

We also bump our dbt thread count to 16 now that our Athena service quota has been increased to 50 concurrent DDL queries.