### PR TITLE
[Do not merge] Re-enable high availability tables

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -43,6 +43,7 @@ models:
     +materialized: view
     +write_compression: zstd
     +format: parquet
+    +ha: true
     census:
       +schema: census
     default:

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -17,7 +17,7 @@ athena:
     ci:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-ci-us-east-1/results/
-      s3_data_dir: s3://ccao-dbt-athena-ci-us-east-1/data/
+      s3_data_dir: s3://z-ci-ccao-athena-ctas-us-east-1/
       s3_data_naming: schema_table
       region_name: us-east-1
       schema: z_static_unused_dbt_stub_database

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -5,34 +5,34 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-dev-us-east-1/results/
       s3_data_dir: s3://ccao-dbt-athena-dev-us-east-1/data/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       # "schema" here corresponds to a Glue database
       schema: z_static_unused_dbt_stub_database
       # "database" here corresponds to a Glue data catalog
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 5
+      threads: 10
       num_retries: 1
     ci:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-ci-us-east-1/results/
       s3_data_dir: s3://z-ci-ccao-athena-ctas-us-east-1/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 5
+      threads: 10
       num_retries: 1
     prod:
       type: athena
       s3_staging_dir: s3://ccao-athena-results-us-east-1/
       s3_data_dir: s3://ccao-athena-ctas-us-east-1/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       schema: default
       database: awsdatacatalog
       spark_work_group: primary-spark
-      threads: 5
+      threads: 10
       num_retries: 1

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -20,9 +20,9 @@ athena:
       s3_data_dir: s3://z-ci-ccao-athena-ctas-us-east-1/
       s3_data_naming: schema_table_unique
       region_name: us-east-1
-      schema: z_static_unused_dbt_stub_database
+      schema: default
       database: awsdatacatalog
-      spark_work_group: primary-spark-staging
+      spark_work_group: primary-spark
       threads: 10
       num_retries: 1
     prod:

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -17,12 +17,12 @@ athena:
     ci:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-ci-us-east-1/results/
-      s3_data_dir: s3://z-ci-ccao-athena-ctas-us-east-1/
+      s3_data_dir: s3://ccao-dbt-athena-ci-us-east-1/data/
       s3_data_naming: schema_table_unique
       region_name: us-east-1
-      schema: default
+      schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
-      spark_work_group: primary-spark
+      spark_work_group: primary-spark-staging
       threads: 10
       num_retries: 1
     prod:


### PR DESCRIPTION
This PR acts as a reversion of https://github.com/ccao-data/data-architecture/pull/490, mostly for the debugging purposes. If we can get to a place where we're very confident in a fix, I'll plan to merge this into the main branch; otherwise, I'll close this once we have a root cause analysis of the failures we're seeing on prod when deploying high availability tables.