### PR TITLE
Add empty `packages.yml` as cache key

### DIFF
--- a/dbt/packages.yml
+++ b/dbt/packages.yml
@@ -1,0 +1,3 @@
+# This file is hashed by our GitHub workflows for use as a key in the dbt deps
+# cache. The file is empty since we currently have no deps, but we need it
+# here so that we don't break the caching step.


### PR DESCRIPTION
Quick PR to close #489. GitHub Actions isn't properly caching dbt packages because it expects the `packages.yml` file to exist as a key. Since we aren't currently using any packages, this file does not exist, and the hash function used for the key returns an empty string. Just replacing this with an empty file should fix the problem.