### PR TITLE
Bump number of threads used by all dbt targets

### DIFF
--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -12,7 +12,7 @@ athena:
       # "database" here corresponds to a Glue data catalog
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 5
+      threads: 16
       num_retries: 1
     ci:
       type: athena
@@ -23,7 +23,7 @@ athena:
       schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 5
+      threads: 16
       num_retries: 1
     prod:
       type: athena
@@ -34,5 +34,5 @@ athena:
       schema: default
       database: awsdatacatalog
       spark_work_group: primary-spark
-      threads: 5
+      threads: 16
       num_retries: 1


### PR DESCRIPTION
The dbt [threads](https://docs.getdbt.com/docs/running-a-dbt-project/using-threads) argument specifies the maximum number of models that can be simultaneously built without breaking the dependency graph. We had it set to 5 for reasons I can't quite remember, but Athena can handle many more simultaneous queries (DDL statements, in this case). This PR bumps the maximum number of threads to 16. This should result in slightly faster full DAG builds.