### PR TITLE
Sales val migration q2 2024 ias world spec

### DIFF
--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -248,7 +248,7 @@ sales_val AS (
         sf.sv_outlier_reason3,
         sf.run_id AS sv_run_id,
         sf.version AS sv_version
-    FROM 
+    FROM
         {{ source('sale', 'flag') }}
             AS sf
     INNER JOIN max_version_flag AS mv

--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -243,7 +243,9 @@ sales_val AS (
         sf.sv_is_outlier,
         sf.sv_is_ptax_outlier,
         sf.sv_is_heuristic_outlier,
-        sf.sv_outlier_type,
+        sf.sv_outlier_reason1,
+        sf.sv_outlier_reason2,
+        sf.sv_outlier_reason3,
         sf.run_id AS sv_run_id,
         sf.version AS sv_version
     FROM {{ source('sale', 'flag') }} AS sf
@@ -325,7 +327,9 @@ SELECT
     sales_val.sv_is_outlier,
     sales_val.sv_is_ptax_outlier,
     sales_val.sv_is_heuristic_outlier,
-    sales_val.sv_outlier_type,
+    sales_val.sv_outlier_reason1,
+    sales_val.sv_outlier_reason2,
+    sales_val.sv_outlier_reason3,
     sales_val.sv_run_id,
     sales_val.sv_version
 FROM unique_sales

--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -233,8 +233,7 @@ max_version_flag AS (
     SELECT
         meta_sale_document_num,
         MAX(version) AS max_version
-    FROM
-        "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
+    FROM {{ source('sale', 'flag') }}
     GROUP BY meta_sale_document_num
 ),
 
@@ -249,8 +248,7 @@ sales_val AS (
         sf.sv_outlier_reason3,
         sf.run_id AS sv_run_id,
         sf.version AS sv_version
-    FROM
-    "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
+    FROM {{ source('sale', 'flag') }}
         AS sf
     INNER JOIN max_version_flag AS mv
         ON sf.meta_sale_document_num = mv.meta_sale_document_num

--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -248,7 +248,8 @@ sales_val AS (
         sf.sv_outlier_reason3,
         sf.run_id AS sv_run_id,
         sf.version AS sv_version
-    FROM {{ source('sale', 'flag') }}
+    FROM 
+        {{ source('sale', 'flag') }}
             AS sf
     INNER JOIN max_version_flag AS mv
         ON sf.meta_sale_document_num = mv.meta_sale_document_num

--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -249,7 +249,7 @@ sales_val AS (
         sf.run_id AS sv_run_id,
         sf.version AS sv_version
     FROM {{ source('sale', 'flag') }}
-        AS sf
+            AS sf
     INNER JOIN max_version_flag AS mv
         ON sf.meta_sale_document_num = mv.meta_sale_document_num
         AND sf.version = mv.max_version

--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -233,7 +233,7 @@ max_version_flag AS (
     SELECT
         meta_sale_document_num,
         MAX(version) AS max_version
-    FROM {{ source('sale', 'flag') }}
+    FROM {{ source('z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale', 'new_prod_data') }}
     GROUP BY meta_sale_document_num
 ),
 
@@ -248,7 +248,7 @@ sales_val AS (
         sf.sv_outlier_reason3,
         sf.run_id AS sv_run_id,
         sf.version AS sv_version
-    FROM {{ source('sale', 'flag') }} AS sf
+    FROM {{ source('z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale', 'new_prod_data') }} AS sf
     INNER JOIN max_version_flag AS mv
         ON sf.meta_sale_document_num = mv.meta_sale_document_num
         AND sf.version = mv.max_version

--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -233,7 +233,8 @@ max_version_flag AS (
     SELECT
         meta_sale_document_num,
         MAX(version) AS max_version
-    FROM "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
+    FROM
+        "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
     GROUP BY meta_sale_document_num
 ),
 
@@ -248,7 +249,9 @@ sales_val AS (
         sf.sv_outlier_reason3,
         sf.run_id AS sv_run_id,
         sf.version AS sv_version
-    FROM "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data" AS sf
+    FROM
+    "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
+        AS sf
     INNER JOIN max_version_flag AS mv
         ON sf.meta_sale_document_num = mv.meta_sale_document_num
         AND sf.version = mv.max_version

--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -233,7 +233,7 @@ max_version_flag AS (
     SELECT
         meta_sale_document_num,
         MAX(version) AS max_version
-    FROM {{ source('z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale', 'new_prod_data') }}
+    FROM "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
     GROUP BY meta_sale_document_num
 ),
 
@@ -248,7 +248,7 @@ sales_val AS (
         sf.sv_outlier_reason3,
         sf.run_id AS sv_run_id,
         sf.version AS sv_version
-    FROM {{ source('z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale', 'new_prod_data') }} AS sf
+    FROM "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data" AS sf
     INNER JOIN max_version_flag AS mv
         ON sf.meta_sale_document_num = mv.meta_sale_document_num
         AND sf.version = mv.max_version

--- a/dbt/models/sale/sale.vw_ias_salesval_upload.sql
+++ b/dbt/models/sale/sale.vw_ias_salesval_upload.sql
@@ -18,7 +18,9 @@ max_version AS (
 SELECT
     ias_sales.salekey,
     sf.sv_is_outlier,
-    sf.sv_outlier_type,
+    sf.sv_outlier_reason1,
+    sf.sv_outlier_reason2,
+    sf.sv_outlier_reason3,
     sf.run_id
 FROM ias_sales
 INNER JOIN {{ source('sale', 'flag') }} AS sf

--- a/dbt/models/sale/sale.vw_ias_salesval_upload.sql
+++ b/dbt/models/sale/sale.vw_ias_salesval_upload.sql
@@ -11,7 +11,7 @@ max_version AS (
     SELECT
         meta_sale_document_num,
         MAX(version) AS max_version
-    FROM "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale'.'new_prod_data"
+    FROM "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
     GROUP BY meta_sale_document_num
 )
 
@@ -23,7 +23,7 @@ SELECT
     sf.sv_outlier_reason3,
     sf.run_id
 FROM ias_sales
-INNER JOIN source("z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data") AS sf
+INNER JOIN "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data" AS sf
     ON ias_sales.instruno_clean = sf.meta_sale_document_num
 INNER JOIN max_version AS mv
     ON sf.meta_sale_document_num = mv.meta_sale_document_num

--- a/dbt/models/sale/sale.vw_ias_salesval_upload.sql
+++ b/dbt/models/sale/sale.vw_ias_salesval_upload.sql
@@ -11,7 +11,7 @@ max_version AS (
     SELECT
         meta_sale_document_num,
         MAX(version) AS max_version
-    FROM {{ source('sale', 'flag') }}
+    FROM {{ source('z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale', 'new_prod_data') }}
     GROUP BY meta_sale_document_num
 )
 
@@ -23,7 +23,7 @@ SELECT
     sf.sv_outlier_reason3,
     sf.run_id
 FROM ias_sales
-INNER JOIN {{ source('sale', 'flag') }} AS sf
+INNER JOIN {{ source('z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale', 'new_prod_data') }} AS sf
     ON ias_sales.instruno_clean = sf.meta_sale_document_num
 INNER JOIN max_version AS mv
     ON sf.meta_sale_document_num = mv.meta_sale_document_num

--- a/dbt/models/sale/sale.vw_ias_salesval_upload.sql
+++ b/dbt/models/sale/sale.vw_ias_salesval_upload.sql
@@ -11,7 +11,7 @@ max_version AS (
     SELECT
         meta_sale_document_num,
         MAX(version) AS max_version
-    FROM {{ source('z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale', 'new_prod_data') }}
+    FROM "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale'.'new_prod_data"
     GROUP BY meta_sale_document_num
 )
 
@@ -23,7 +23,7 @@ SELECT
     sf.sv_outlier_reason3,
     sf.run_id
 FROM ias_sales
-INNER JOIN {{ source('z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale', 'new_prod_data') }} AS sf
+INNER JOIN source("z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data") AS sf
     ON ias_sales.instruno_clean = sf.meta_sale_document_num
 INNER JOIN max_version AS mv
     ON sf.meta_sale_document_num = mv.meta_sale_document_num

--- a/dbt/models/sale/sale.vw_ias_salesval_upload.sql
+++ b/dbt/models/sale/sale.vw_ias_salesval_upload.sql
@@ -11,7 +11,8 @@ max_version AS (
     SELECT
         meta_sale_document_num,
         MAX(version) AS max_version
-    FROM "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
+    FROM 
+        "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
     GROUP BY meta_sale_document_num
 )
 
@@ -23,7 +24,9 @@ SELECT
     sf.sv_outlier_reason3,
     sf.run_id
 FROM ias_sales
-INNER JOIN "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data" AS sf
+INNER JOIN
+    "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
+        AS sf
     ON ias_sales.instruno_clean = sf.meta_sale_document_num
 INNER JOIN max_version AS mv
     ON sf.meta_sale_document_num = mv.meta_sale_document_num

--- a/dbt/models/sale/sale.vw_ias_salesval_upload.sql
+++ b/dbt/models/sale/sale.vw_ias_salesval_upload.sql
@@ -11,8 +11,7 @@ max_version AS (
     SELECT
         meta_sale_document_num,
         MAX(version) AS max_version
-    FROM 
-        "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
+    FROM {{ source('sale', 'flag') }}
     GROUP BY meta_sale_document_num
 )
 
@@ -24,9 +23,7 @@ SELECT
     sf.sv_outlier_reason3,
     sf.run_id
 FROM ias_sales
-INNER JOIN
-    "z_ci_0002-update-outlier-column-structure-w-iasworld-2024-update_sale"."new_prod_data"
-        AS sf
+INNER JOIN {{ source('sale', 'flag') }} AS sf
     ON ias_sales.instruno_clean = sf.meta_sale_document_num
 INNER JOIN max_version AS mv
     ON sf.meta_sale_document_num = mv.meta_sale_document_num

--- a/dbt/models/sale/schema.yml
+++ b/dbt/models/sale/schema.yml
@@ -25,8 +25,12 @@ sources:
             description: '{{ doc("shared_column_sv_is_ptax_outlier") }}'
           - name: sv_is_outlier
             description: '{{ doc("shared_column_sv_is_outlier") }}'
-          - name: sv_outlier_type
-            description: '{{ doc("shared_column_sv_outlier_type") }}'
+          - name: sv_outlier_reason1
+            description: '{{ doc("shared_column_sv_outlier_reason1") }}'
+          - name: sv_outlier_reason1
+            description: '{{ doc("shared_column_sv_outlier_reason2") }}'
+          - name: sv_outlier_reason1
+            description: '{{ doc("shared_column_sv_outlier_reason3") }}'
           - name: version
             description: '{{ doc("shared_column_sv_version") }}'
 
@@ -169,5 +173,9 @@ models:
         description: '{{ doc("shared_column_sale_key") }}'
       - name: sv_is_outlier
         description: '{{ doc("shared_column_sv_is_outlier") }}'
-      - name: sv_outlier_type
-        description: '{{ doc("shared_column_sv_outlier_type") }}'
+      - name: sv_outlier_reason1
+        description: '{{ doc("shared_column_sv_outlier_reason1") }}'
+      - name: sv_outlier_reason2
+        description: '{{ doc("shared_column_sv_outlier_reason2") }}'
+      - name: sv_outlier_reason3
+        description: '{{ doc("shared_column_sv_outlier_reason3") }}'

--- a/dbt/models/sale/schema.yml
+++ b/dbt/models/sale/schema.yml
@@ -26,11 +26,11 @@ sources:
           - name: sv_is_outlier
             description: '{{ doc("shared_column_sv_is_outlier") }}'
           - name: sv_outlier_reason1
-            description: '{{ doc("shared_column_sv_outlier_reason1") }}'
+            description: '{{ doc("shared_column_sv_outlier_reason") }}'
           - name: sv_outlier_reason1
-            description: '{{ doc("shared_column_sv_outlier_reason2") }}'
+            description: '{{ doc("shared_column_sv_outlier_reason") }}'
           - name: sv_outlier_reason1
-            description: '{{ doc("shared_column_sv_outlier_reason3") }}'
+            description: '{{ doc("shared_column_sv_outlier_reason") }}'
           - name: version
             description: '{{ doc("shared_column_sv_version") }}'
 

--- a/dbt/models/sale/schema.yml
+++ b/dbt/models/sale/schema.yml
@@ -174,8 +174,8 @@ models:
       - name: sv_is_outlier
         description: '{{ doc("shared_column_sv_is_outlier") }}'
       - name: sv_outlier_reason1
-        description: '{{ doc("shared_column_sv_outlier_reason1") }}'
+        description: '{{ doc("shared_column_sv_outlier_reason") }}'
       - name: sv_outlier_reason2
-        description: '{{ doc("shared_column_sv_outlier_reason2") }}'
+        description: '{{ doc("shared_column_sv_outlier_reason") }}'
       - name: sv_outlier_reason3
-        description: '{{ doc("shared_column_sv_outlier_reason3") }}'
+        description: '{{ doc("shared_column_sv_outlier_reason") }}'

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -840,7 +840,7 @@ Year the property was constructed
 {% docs shared_column_card %}
 Sub-unit of a PIN.
 
-For residential properties, cards usually identify each *building*, For
+For residential properties, cards usually identify each _building_, For
 commercial properties, they can identify spaces within the same building.
 Cards also serve as the unit of observation for the residential model.
 
@@ -870,6 +870,7 @@ purposes. See `ccao.class_dict` for more information
 {% enddocs %}
 
 ## is_active_exe_homeowner
+
 {% docs shared_column_is_active_exe_homeowner %}
 Parcel has an active homeowner exemption
 {% enddocs %}
@@ -1300,9 +1301,27 @@ with `sv_is_ptax_outlier` (using OR logic).
 NOTE: Outlier flags only exist for sales _after_ 2014.
 {% enddocs %}
 
-## sv_outlier_type
+## sv_outlier_reason1
 
-{% docs shared_column_sv_outlier_type %}
+{% docs shared_column_sv_outlier_reason1 %}
+Heuristic or model used to flag an outlier.
+
+See the [model-sales-val](https://github.com/ccao-data/model-sales-val) repo
+for a list of possible flags.
+{% enddocs %}
+
+## sv_outlier_reason2
+
+{% docs shared_column_sv_outlier_reason2 %}
+Heuristic or model used to flag an outlier.
+
+See the [model-sales-val](https://github.com/ccao-data/model-sales-val) repo
+for a list of possible flags.
+{% enddocs %}
+
+## sv_outlier_reason3
+
+{% docs shared_column_sv_outlier_reason3 %}
 Heuristic or model used to flag an outlier.
 
 See the [model-sales-val](https://github.com/ccao-data/model-sales-val) repo

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1301,27 +1301,9 @@ with `sv_is_ptax_outlier` (using OR logic).
 NOTE: Outlier flags only exist for sales _after_ 2014.
 {% enddocs %}
 
-## sv_outlier_reason1
+## sv_outlier_reason
 
-{% docs shared_column_sv_outlier_reason1 %}
-Heuristic or model used to flag an outlier.
-
-See the [model-sales-val](https://github.com/ccao-data/model-sales-val) repo
-for a list of possible flags.
-{% enddocs %}
-
-## sv_outlier_reason2
-
-{% docs shared_column_sv_outlier_reason2 %}
-Heuristic or model used to flag an outlier.
-
-See the [model-sales-val](https://github.com/ccao-data/model-sales-val) repo
-for a list of possible flags.
-{% enddocs %}
-
-## sv_outlier_reason3
-
-{% docs shared_column_sv_outlier_reason3 %}
+{% docs shared_column_sv_outlier_reason %}
 Heuristic or model used to flag an outlier.
 
 See the [model-sales-val](https://github.com/ccao-data/model-sales-val) repo


### PR DESCRIPTION
This PR updates `vw_pin_sale` and `vw_ias_salesval_upload` with the new column structure from the [sales val migration](https://github.com/ccao-data/model-sales-val/pull/130/files). We also edit schema and shared_columns files accordingly.

Note: I will need to change the refs back to the prod table at some point after we do the migration.

I am getting a sql fluff error on the pre-commit check that I'm not entirely sure is working correctly, curious about your thoughts @jeancochrane. 

Eyeballing these queries confirm that things are not totally out-of-whack:

```sql
SELECT sv_is_outlier, COUNT(*)
FROM "z_ci_sales_val_migration_q2_2024_ias_design_doc_default"."vw_pin_sale"
WHERE sv_run_id is not null
GROUP BY sv_is_outlier
ORDER BY COUNT(*) DESC;
```

```sql
SELECT sv_outlier_reason1, COUNT(*)
FROM "z_ci_sales_val_migration_q2_2024_ias_design_doc_default"."vw_pin_sale"
WHERE sv_run_id is not null
GROUP BY sv_outlier_reason1
ORDER BY COUNT(*) DESC;
```

```sql
SELECT sv_outlier_reason2, COUNT(*)
FROM "z_ci_sales_val_migration_q2_2024_ias_design_doc_default"."vw_pin_sale"
WHERE sv_run_id is not null
GROUP BY sv_outlier_reason2
ORDER BY COUNT(*) DESC;
```

