### PR TITLE
Expand lines in `new-dbt-model` issue template for friendlier formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-dbt-model.md
+++ b/.github/ISSUE_TEMPLATE/new-dbt-model.md
@@ -14,54 +14,32 @@ _(Brief description of the task here.)_
 
 ## Model attributes
 
-* **Name**: _(What should the model be called? See [Model
- naming](/ccao-data/data-architecture/tree/master/dbt#model-naming) for guidance.)_
-* **Model type**: _(SQL or Python? See [Model type (SQL or
-  Python)](/ccao-data/data-architecture/tree/master/dbt#model-type-sql-or-python)
-  for guidance.)_
-* **Materialization**: _(Should the model be a table or a view? See [Model
-  materialization](/ccao-data/data-architecture/tree/master/dbt#model-materialization) for
-  guidance.)_
+* **Name**: _(What should the model be called? See [Model naming](/ccao-data/data-architecture/tree/master/dbt#model-naming) for guidance.)_
+* **Model type**: _(SQL or Python? See [Model type (SQL or Python)](/ccao-data/data-architecture/tree/master/dbt#model-type-sql-or-python) for guidance.)_
+* **Materialization**: _(Should the model be a table or a view? See [Model materialization](/ccao-data/data-architecture/tree/master/dbt#model-materialization) for guidance.)_
 * **Tests**:
-  * _(Add a bulleted list of tests here. See [Model
-  tests](/ccao-data/data-architecture/tree/master/dbt#model-tests) for guidance.)_
-* **Description**: _(Provide a rich description for this model that will be
-  displayed in documentation. Markdown is supported, and encouraged for more
-  complex models. See [Model
-  description](/ccao-data/data-architecture/tree/master/dbt#model-description) for guidance.)_
+  * _(Add a bulleted list of tests here. See [Model tests](/ccao-data/data-architecture/tree/master/dbt#model-tests) for guidance.)_
+* **Description**: _(Provide a rich description for this model that will be displayed in documentation. Markdown is supported, and encouraged for more complex models. See [Model description](/ccao-data/data-architecture/tree/master/dbt#model-description) for guidance.)_
 
 ## Short checklist
 
-_(Use this checklist if the assignee already knows how to add a dbt model.
-Otherwise, delete it in favor of the long checklist in the following section.)_
+_(Use this checklist if the assignee already knows how to add a dbt model. Otherwise, delete it in favor of the long checklist in the following section.)_
 
-- [ ] Confirm that a subdirectory for this model's database exists in
-  the `dbt/models/` directory, and if not, create one, add a new `schema.yml`
-  file, and update `dbt_project.yml` to document the `+schema`
-- [ ] Define the SQL query or Python script that creates the model in the model
-  subdirectory, following any existing file naming schema
+- [ ] Confirm that a subdirectory for this model's database exists in the `dbt/models/` directory, and if not, create one, add a new `schema.yml` file, and update `dbt_project.yml` to document the `+schema`
+- [ ] Define the SQL query or Python script that creates the model in the model subdirectory, following any existing file naming schema
 - [ ] Use `source()` and `ref()` to reference other models where possible
-- [ ] _[SQL models only]_ Optionally configure model materialization in the
-  query file
-- [ ] Update the `schema.yml` file in the subfolder of `dbt/models/` to point
-  to the new model definition
+- [ ] _[SQL models only]_ Optionally configure model materialization in the query file
+- [ ] Update the `schema.yml` file in the subfolder of `dbt/models/` to point to the new model definition
 - [ ] _[Python models only]_ Configure any third-party pure Python packages
 - [ ] Add tests to the model schema definition in `schema.yml`
-- [ ] _[SQL models only]_ If your model definition requires any new macros, make
-  sure those macros are tested in `dbt/macros/tests/test_all.sql`
+- [ ] _[SQL models only]_ If your model definition requires any new macros, make sure those macros are tested in `dbt/macros/tests/test_all.sql`
 - [ ] Commit your changes to a branch and open a pull request
 
 ## Checklist
 
 Complete the following checklist to add the model:
 
-- [ ] Confirm that a subdirectory for this model's database exists in
-  the `dbt/models/` directory (e.g. `dbt/models/default/` for
-  the `default.new_model` model). If a subdirectory does not yet exist, create
-  one, add a `schema.yml` file to the directory to store [model
-  properties](https://docs.getdbt.com/reference/model-properties), and update
-  `dbt_project.yml` to document the new directory under the `models.athena`
-  key with a `+schema` attribute.
+- [ ] Confirm that a subdirectory for this model's database exists in the `dbt/models/` directory (e.g. `dbt/models/default/` for the `default.new_model` model). If a subdirectory does not yet exist, create one, add a `schema.yml` file to the directory to store [model properties](https://docs.getdbt.com/reference/model-properties), and update `dbt_project.yml` to document the new directory under the `models.athena` key with a `+schema` attribute.
 
 ```yaml
 # Table example (only the model name would change for a view)
@@ -84,13 +62,7 @@ models:
        +schema: census
 ```
 
-- [ ] Define the SQL query or Python script that creates the model in the
-  appropriate subfolder of the `dbt/models/` directory. For example, if you're
-  adding a view to the `default` schema, then the model definition file should
-  live in `dbt/models/default`. The file should have the same name as the model
-  that appears in Athena. A period in the model name should separate the
-  entity name from the database namespace (e.g. `default.vw_pin_universe.sql`).
-  All views should have a name prefixed with `vw_`.
+- [ ] Define the SQL query or Python script that creates the model in the appropriate subfolder of the `dbt/models/` directory. For example, if you're adding a view to the `default` schema, then the model definition file should live in `dbt/models/default`. The file should have the same name as the model that appears in Athena. A period in the model name should separate the entity name from the database namespace (e.g. `default.vw_pin_universe.sql`). All views should have a name prefixed with `vw_`.
 
 ```bash
 # SQL view example
@@ -103,10 +75,7 @@ touch dbt/models/proximity/proximity.new_model.sql
 touch dbt/models/proximity/proximity.new_model.py
 ```
 
-- [ ] Use
-  [`source()`](https://docs.getdbt.com/reference/dbt-jinja-functions/source)
-  and [`ref()`](https://docs.getdbt.com/reference/dbt-jinja-functions/ref) to
-  reference other models where possible in your query or script.
+- [ ] Use [`source()`](https://docs.getdbt.com/reference/dbt-jinja-functions/source) and [`ref()`](https://docs.getdbt.com/reference/dbt-jinja-functions/ref) to reference other models where possible in your query or script.
 
 ```sql
 -- SQL view or table example
@@ -130,11 +99,7 @@ def model(dbt, spark_session):
     dbt.write(result[["pin10", "year"]])
 ```
 
-- [ ] _[SQL models only]_ Optionally configure model materialization. If the
-  output of the query should be a view, no action is necessary, since the
-  default for all models in this repository is to materialize as views; but if
-  the output should be a table, with table data stored in S3, then you'll need
-  to add a config block to the top of the view to configure materialization.
+- [ ] _[SQL models only]_ Optionally configure model materialization. If the output of the query should be a view, no action is necessary, since the default for all models in this repository is to materialize as views; but if the output should be a table, with table data stored in S3, then you'll need to add a config block to the top of the view to configure materialization.
 
 ```diff
 # Table example
@@ -154,12 +119,7 @@ join {{ ref('default.vw_pin_universe') }}
 using (pin10, year)
 ```
 
-- [ ] Update the `schema.yml` file in the subfolder of `dbt/models/` where you
-  created your model definition. Make sure to add descriptions for new entities
-  (models, sources, columns, etc). See
-  [Model description](/ccao-data/data-architecture/tree/master/dbt#model-description)
-  and [Column descriptions](/ccao-data/data-architecture/tree/master/dbt#column-descriptions)
-  for specific guidance on doc locations and using docs blocks.
+- [ ] Update the `schema.yml` file in the subfolder of `dbt/models/` where you created your model definition. Make sure to add descriptions for new entities (models, sources, columns, etc). See [Model description](/ccao-data/data-architecture/tree/master/dbt#model-description) and [Column descriptions](/ccao-data/data-architecture/tree/master/dbt#column-descriptions) for specific guidance on doc locations and using docs blocks.
 
 ```diff
 # Table example (only the model name would change for a view)
@@ -179,11 +139,7 @@ using (pin10, year)
      data_tests:
 ```
 
-- [ ] _[Python models only]_ If you need any third-party pure Python packages
-  that are not [preinstalled in the Athena PySpark
-  environment](https://docs.aws.amazon.com/athena/latest/ug/notebooks-spark-preinstalled-python-libraries.html),
-  follow [the docs for configuring Python model
-  dependencies](/ccao-data/data-architecture/tree/master/dbt#a-note-on-third-party-pure-python-dependencies-for-python-models).
+- [ ] _[Python models only]_ If you need any third-party pure Python packages that are not [preinstalled in the Athena PySpark environment](https://docs.aws.amazon.com/athena/latest/ug/notebooks-spark-preinstalled-python-libraries.html), follow [the docs for configuring Python model dependencies](/ccao-data/data-architecture/tree/master/dbt#a-note-on-third-party-pure-python-dependencies-for-python-models).
 
 - [ ] Add tests to your new model definition in `schema.yml`.
 
@@ -211,9 +167,6 @@ using (pin10, year)
      data_tests:
 ```
 
-- [ ] _[SQL models only]_ If your model definition requires any new macros, make
-  sure those macros are tested in `dbt/macros/tests/test_all.sql`. If any tests
-  need implementing, follow the pattern set by existing tests to implement them.
+- [ ] _[SQL models only]_ If your model definition requires any new macros, make sure those macros are tested in `dbt/macros/tests/test_all.sql`. If any tests need implementing, follow the pattern set by existing tests to implement them.
 
-- [ ] Commit your changes to a branch and open a pull request to build your
-  model and run tests in a CI environment.
+- [ ] Commit your changes to a branch and open a pull request to build your model and run tests in a CI environment.


### PR DESCRIPTION
I noticed while showing off updates to the `new-dbt-model` issue template that the line breaks that we use in the Markdown file to make editing easier get reproduced in the final issue, where they are not automatically expanded out into full lines. This makes the final issue look a bit weird and hard to read. See [a draft issue](https://github.com/ccao-data/data-architecture/issues/new?template=new-dbt-model.md&title=Add+a+new+dbt+model) for an example (select the Preview tab to see how the issue gets rendered).

This PR expands out the lines in that issue template, which makes editing slightly more annoying but significantly improves the reading experience of the final issue. It also aligns the formatting of `new-dbt-model` with our other issue template, [`data-onboarding`](https://github.com/ccao-data/data-architecture/issues/new?template=data-onboarding.md).