### PR TITLE
Switch back to high availability tables

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -43,6 +43,7 @@ models:
     +materialized: view
     +write_compression: zstd
     +format: parquet
+    +ha: true
     census:
       +schema: census
     default:

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -5,7 +5,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-dev-us-east-1/results/
       s3_data_dir: s3://ccao-dbt-athena-dev-us-east-1/data/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       # "schema" here corresponds to a Glue database
       schema: z_static_unused_dbt_stub_database
@@ -18,7 +18,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-dbt-athena-ci-us-east-1/results/
       s3_data_dir: s3://ccao-dbt-athena-ci-us-east-1/data/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
@@ -29,7 +29,7 @@ athena:
       type: athena
       s3_staging_dir: s3://ccao-athena-results-us-east-1/
       s3_data_dir: s3://ccao-athena-ctas-us-east-1/
-      s3_data_naming: schema_table
+      s3_data_naming: schema_table_unique
       region_name: us-east-1
       schema: default
       database: awsdatacatalog

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -12,7 +12,7 @@ athena:
       # "database" here corresponds to a Glue data catalog
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 3
+      threads: 16
       num_retries: 1
     ci:
       type: athena
@@ -23,7 +23,7 @@ athena:
       schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 3
+      threads: 16
       num_retries: 1
     prod:
       type: athena
@@ -34,5 +34,5 @@ athena:
       schema: default
       database: awsdatacatalog
       spark_work_group: primary-spark
-      threads: 3
+      threads: 16
       num_retries: 1

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -12,7 +12,7 @@ athena:
       # "database" here corresponds to a Glue data catalog
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 16
+      threads: 3
       num_retries: 1
     ci:
       type: athena
@@ -23,7 +23,7 @@ athena:
       schema: z_static_unused_dbt_stub_database
       database: awsdatacatalog
       spark_work_group: primary-spark-staging
-      threads: 16
+      threads: 3
       num_retries: 1
     prod:
       type: athena
@@ -34,5 +34,5 @@ athena:
       schema: default
       database: awsdatacatalog
       spark_work_group: primary-spark
-      threads: 16
+      threads: 3
       num_retries: 1


### PR DESCRIPTION
This PR is the latest in a long effort to get [high availability tables](https://github.com/dbt-athena/dbt-athena?tab=readme-ov-file#highly-available-table-ha) working with our dbt configuration (search ["high availability"](https://github.com/ccao-data/data-architecture/pulls?q=high+availability) in our PRs for the full history).

While deploying previous versions of this PR, we had seen strange behavior whereby dbt was deleting the underlying S3 immediately after creating them. We were able to debug this and determine that it happens only for pre-existing tables when switching from non-high-availability to high availability and from the `schema_table` naming scheme to `schema_table_unique`: In these cases, the Glue database retains a reference to an old version of the table with the `schema_table` naming scheme (e.g. `/location/access`), and then when a high-availability version is created to supercede that old version with a unique naming scheme (e.g. `/location/access/<uuid>`), dbt can end up deleting the old version and with it the whole prefix that contains the new data (e.g. `/location/access`).

In order to properly handle this behavior, we need to make sure to delete all of our Glue databases that referenced materialized tables before deploying this PR. If that proves to be too much trouble, we could also consider just rerunning the new DAG build a couple of times, at which point the reference to the old `schema_table` version of the database will get deleted and subsequent runs will correctly clean up old versions without wiping away the entire S3 prefix that contains the table data.