### PR TITLE
Add new model features to capture parcel shape

### DIFF
--- a/etl/etl.Rproj
+++ b/etl/etl.Rproj
@@ -12,6 +12,6 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
-StripTrailingWhitespace: Yes
 AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
 LineEndingConversion: Posix

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
@@ -280,8 +280,11 @@ process_parcel_file <- function(s3_bucket_uri,
         dist_to_centroid = sqrt(
           (X - mean(X)) ^ 2 +
             (Y - mean(Y)) ^ 2
-        )
+        ),
+        # Recalculate the angle after removing straight angles
+        angle = calculate_angles(as.matrix(.SD))
       ),
+      .SDcols = c("X", "Y"),
       by = c("L1", "L2", "L3")
     ]
 

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
@@ -212,6 +212,8 @@ process_parcel_file <- function(s3_bucket_uri,
     # Using data.table here because it's much faster than dplyr
     spatial_mat_coords <- spatial_df_merged %>%
       st_set_geometry("geometry_3435") %>%
+      st_simplify(dTolerance = 1, preserveTopology = TRUE) %>%
+      st_cast("MULTIPOLYGON") %>%
       st_coordinates() %>%
       as.data.table()
 

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
@@ -251,7 +251,7 @@ process_parcel_file <- function(s3_bucket_uri,
     spatial_mat_calc_edge <- spatial_mat_calc[
       ,
       .(
-        shp_parcel_edge_len_ft_sd = sd(tail(edge_len, -1), na.rm = TRUE),
+        shp_parcel_edge_len_ft_sd = sd(tail(edge_len, -1), na.rm = TRUE)
       ),
       by = "L3"
     ]

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
@@ -315,16 +315,16 @@ process_parcel_file <- function(s3_bucket_uri,
   }
 
   # Write final dataframe to dataset on S3, partitioned by town and year
-  # spatial_df_final %>%
-  #   mutate(year = file_year) %>%
-  #   group_by(year, town_code) %>%
-  #   write_partitions_to_s3(s3_bucket_uri, is_spatial = TRUE, overwrite = FALSE)
+  spatial_df_final %>%
+    mutate(year = file_year) %>%
+    group_by(year, town_code) %>%
+    write_partitions_to_s3(s3_bucket_uri, is_spatial = TRUE, overwrite = FALSE)
   tictoc::toc()
 }
 
 
 # Apply function to all parcel files
-pwalk(parcel_files_df[24,], function(...) {
+pwalk(parcel_files_df, function(...) {
   df <- tibble::tibble(...)
   process_parcel_file(
     s3_bucket_uri = output_bucket,

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
@@ -50,7 +50,7 @@ save_local_parcel_files <- function(year, spatial_uri, attr_uri) {
 
 # Function to calculate the interior angles of a polygon given its X and Y
 # coordinates using the directions of the vectors between each pair of points
-# See: https://stackoverflow.com/questions/12083480/finding-internal-angles-of-polygon
+# See: https://stackoverflow.com/a/12090743
 # Good example parcel for angle calc: 1418307019
 calculate_angles <- function(points) {
   vectors <- diff(rbind(points, points[2, ])) * -1
@@ -79,9 +79,15 @@ process_parcel_file <- function(s3_bucket_uri,
   save_local_parcel_files(file_year, spatial_uri, attr_uri)
 
   # Local file paths for parcel files
-  local_spatial_file <- file.path(parcel_tmp_dir, paste0(file_year, ".geojson"))
-  local_attr_file <- file.path(parcel_tmp_dir, paste0(file_year, "-attr.parquet"))
-  local_backup_file <- file.path(parcel_tmp_dir, paste0(file_year, "-proc.parquet"))
+  local_spatial_file <- file.path(
+    parcel_tmp_dir, paste0(file_year, ".geojson")
+  )
+  local_attr_file <- file.path(
+    parcel_tmp_dir, paste0(file_year, "-attr.parquet")
+  )
+  local_backup_file <- file.path(
+    parcel_tmp_dir, paste0(file_year, "-proc.parquet")
+  )
 
   # Only run processing if local backup doesn't exist
   if (!file.exists(local_backup_file)) {
@@ -175,7 +181,10 @@ process_parcel_file <- function(s3_bucket_uri,
 
     # If centroids are missing from join (invalid geom, empty, etc.)
     # fill them in with centroid of the full multipolygon
-    if (any(is.na(spatial_df_merged$lon) | any(is.na(spatial_df_merged$x_3435)))) {
+    if (any(
+      is.na(spatial_df_merged$lon) |
+        any(is.na(spatial_df_merged$x_3435))
+    )) {
       # Calculate centroids for missing
       spatial_df_missing <- spatial_df_merged %>%
         filter(is.na(lon) | is.na(x_3435)) %>%
@@ -205,7 +214,7 @@ process_parcel_file <- function(s3_bucket_uri,
     # the polygon
     spatial_mat_calc <- spatial_mat_coords[
       ,
-      `:=` (
+      `:=`(
         # Get edge length using Pythagorean theorem and a rolling lag to get
         # the distance between each pair of points
         edge_len = sqrt(

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
@@ -15,7 +15,7 @@ source("utils.R")
 # This script cleans historical Cook County parcel data and uploads it to S3
 AWS_S3_RAW_BUCKET <- Sys.getenv("AWS_S3_RAW_BUCKET")
 AWS_S3_WAREHOUSE_BUCKET <- Sys.getenv("AWS_S3_WAREHOUSE_BUCKET")
-output_bucket <- file.path(AWS_S3_WAREHOUSE_BUCKET, "spatial", "parcel_new")
+output_bucket <- file.path(AWS_S3_WAREHOUSE_BUCKET, "spatial", "parcel")
 parcel_tmp_dir <- here("parcel-tmp")
 
 # Get list of all parcel files (geojson AND attribute files) in the raw bucket

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
@@ -316,7 +316,9 @@ process_parcel_file <- function(s3_bucket_uri,
           st_area(geometry_3435) / parcel_area
         ),
         # Sometimes the ratio here is very slightly less than 1, even though
-        # that should be impossible. Seems to an artifact of some malformed
+        # that should be impossible. This seems to happen mostly for extremely
+        # long, skinny triangle parcels. The error is small enough that it's
+        # probably fine to ignore for now
         shp_parcel_mrr_area_ratio = ifelse(
           shp_parcel_mrr_area_ratio < 1,
           1,

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
@@ -177,6 +177,12 @@ process_parcel_file <- function(s3_bucket_uri,
         lon, lat, x_3435, y_3435, geometry, geometry_3435,
         town_code, year
       ) %>%
+      summarize(
+        across(tax_code:year, dplyr::first),
+        geometry = st_union(geometry),
+        geometry_3435 = st_union(geometry_3435),
+        .by = "pin10"
+      ) %>%
       distinct(pin10, .keep_all = TRUE)
     tictoc::toc()
 
@@ -212,7 +218,7 @@ process_parcel_file <- function(s3_bucket_uri,
     # Using data.table here because it's much faster than dplyr
     spatial_mat_coords <- spatial_df_merged %>%
       st_set_geometry("geometry_3435") %>%
-      st_simplify(dTolerance = 1, preserveTopology = TRUE) %>%
+      st_simplify(dTolerance = 2, preserveTopology = FALSE) %>%
       st_cast("MULTIPOLYGON") %>%
       st_coordinates() %>%
       as.data.table()

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-parcel.R
@@ -60,8 +60,8 @@ calculate_angles <- function(points) {
   dot_product <- vectors[-nrow(vectors), 1] * vectors[-1, 1] +
     vectors[-nrow(vectors), 2] * vectors[-1, 2]
 
-  angle <- pi + atan2(cross_product, dot_product)
-  angles <- c(NA_real_, angle * 180 / pi)
+  angles <- pi + atan2(cross_product, dot_product)
+  angles <- c(NA_real_, angles * 180 / pi)
 
   return(angles)
 }
@@ -206,10 +206,8 @@ process_parcel_file <- function(s3_bucket_uri,
     spatial_mat_calc <- spatial_mat_coords[
       ,
       `:=` (
-        # Distance between points using Pythagorean theorem. The first point in
-        # each group (polygon) is the same as the last point, so calculating the
-        # length between all points in a group does capture the length of all
-        # edges
+        # Get edge length using Pythagorean theorem and a rolling lag to get
+        # the distance between each pair of points
         edge_len = sqrt(
           (X - shift(X, type = "lag")) ^ 2 +
             (Y - shift(Y, type = "lag")) ^ 2
@@ -219,7 +217,7 @@ process_parcel_file <- function(s3_bucket_uri,
           (X - mean(X)) ^ 2 +
             (Y - mean(Y)) ^ 2
         ),
-        # Calculate the angle between each pair of points
+        # Calculate the interior angle between each pair of points
         angle = calculate_angles(as.matrix(.SD))
       ),
       .SDcols = c("X", "Y"),


### PR DESCRIPTION
This PR updates the parcel file ETL to add 6 new features for modeling. These features attempt to capture the complexity of the parcel shape, based on the idea that more "regular" shaped parcels are more desirable and are thus worth more, they were mostly taken from [this paper](https://eres.architexturez.net/system/files/P_20230206101430_7873.pdf). The 6 features are:

1. The standard deviation of the interior angles of the parcel polygon
2. The standard deviation of the parcel polygon edge length
3. The standard deviation of the parcel vertices' distance to the parcel centroid
4. The total number of vertices in the parcel polygon
5. The ratio of the length of the sides of the minimum spanning rotated rectangle
6. The ratio of the areas of the minimum spanning rotated rectangle and the parcel polygon itself

I haven't actually run this script yet to replace any cleaned up prod parcel files, but I'll do so once this is merged.

I'll make a follow-up PR to add the output features to dbt and all the necessary views/docs.