### PR TITLE
Update `test_dbt_models` workflow to reflect recent changes to `transform_dbt_test_results` script

### DIFF
--- a/.github/workflows/test_dbt_models.yaml
+++ b/.github/workflows/test_dbt_models.yaml
@@ -53,9 +53,7 @@ jobs:
       - name: Extract test results
         run: |
           python3 ../.github/scripts/transform_dbt_test_results.py \
-            ./target/run_results.json \
-            ./target/manifest.json \
-            ./qc_test_results/
+            --output-dir ./qc_test_results/
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
         env:


### PR DESCRIPTION
I updated `transform_dbt_test_results.py` in https://github.com/ccao-data/data-architecture/pull/527 to clean up the CLI interface and add support for filtering results by township, but I neglected to update the usage in the `test_dbt_models` workflow, so now [it's failing](https://github.com/ccao-data/data-architecture/actions/runs/9906586814/job/27368438662). This PR tweaks the script call in `test_dbt_models` to get it passing again; see [here](https://github.com/ccao-data/data-architecture/actions/runs/9911093016/job/27383393115) for a successful run on this branch.