### PR TITLE
Persist row-level test results in `transform_dbt_test_results` script

### DIFF
--- a/.github/scripts/transform_dbt_test_results.py
+++ b/.github/scripts/transform_dbt_test_results.py
@@ -24,7 +24,7 @@ import openpyxl.cell
 import openpyxl.styles
 import openpyxl.styles.colors
 import openpyxl.utils
-import pyarrow
+import pyarrow as pa
 import pyarrow.parquet
 import pyathena
 import pyathena.cursor
@@ -86,6 +86,7 @@ class TestResult:
         self,
         name: str,
         table_name: str,
+        column_name: typing.Optional[str],
         status: Status,
         description: str,
         elapsed_time: decimal.Decimal,
@@ -94,10 +95,11 @@ class TestResult:
         """
         The failing_rows list should be formatted like the rows
         returned by a csv.DictReader or a DictCursor, i.e. a list of
-        dicts mapping `{column_name: row_value}`.
+        dicts mapping `{field_name: row_value}`.
         """
         self.name = name
         self.table_name = table_name
+        self.column_name = column_name
         self.status = status
         self.description = description
         self.elapsed_time = elapsed_time
@@ -120,6 +122,7 @@ class TestResult:
         return {
             "name": self.name,
             "table_name": self.table_name,
+            "column_name": self.column_name,
             "status": self.status.value,
             "description": self.description,
             "elapsed_time": self.elapsed_time,
@@ -132,6 +135,7 @@ class TestResult:
         return TestResult(
             name=result_dict["name"],
             table_name=result_dict["table_name"],
+            column_name=result_dict["column_name"],
             status=Status(result_dict["status"]),
             description=result_dict["description"],
             elapsed_time=result_dict["elapsed_time"],
@@ -163,6 +167,7 @@ class TestResult:
         base_kwargs = {
             "name": self.name,
             "table_name": self.table_name,
+            "column_name": self.column_name,
             "status": self.status,
             "description": self.description,
             "elapsed_time": self.elapsed_time,
@@ -207,14 +212,14 @@ class TestCategory:
     results for output to a workbook and saving them to a cache."""
 
     # Names of fields that are used for debugging
-    _debugging_fieldnames = [TEST_NAME_FIELD, DOCS_URL_FIELD]
+    possible_debugging_fieldnames = [TEST_NAME_FIELD, DOCS_URL_FIELD]
     # Names of fields that identify the test
-    _test_metadata_fieldnames = [
+    possible_test_metadata_fieldnames = [
         *[SOURCE_TABLE_FIELD, DESCRIPTION_FIELD],
-        *_debugging_fieldnames,
+        *possible_debugging_fieldnames,
     ]
     # Names of fields that are used for diagnostics
-    _diagnostic_fieldnames = [
+    possible_diagnostic_fieldnames = [
         TAXYR_FIELD,
         PARID_FIELD,
         CARD_FIELD,
@@ -225,9 +230,9 @@ class TestCategory:
         WEN_FIELD,
     ]
     # The complete set of fixed fields
-    _fixed_fieldnames = [
-        *_test_metadata_fieldnames,
-        *_diagnostic_fieldnames,
+    possible_fixed_fieldnames = [
+        *possible_test_metadata_fieldnames,
+        *possible_diagnostic_fieldnames,
     ]
 
     def __init__(
@@ -280,7 +285,7 @@ class TestCategory:
         # Remove any fixed fieldnames from the ordered list that are not
         # present in this group
         fixed_field_order = [
-            field for field in self._fixed_fieldnames if field in fieldnames
+            field for field in self.possible_fixed_fieldnames if field in fieldnames
         ]
 
         # Reorder the fieldnames so that diagnostic fields are presented in the
@@ -516,14 +521,14 @@ class TestCategory:
     def debugging_fieldnames(self) -> typing.List[str]:
         """Get a list of fieldnames (e.g. ["foo", "bar"]) for fields that
         are used for debugging."""
-        return self._filter_for_existing_fieldnames(self._debugging_fieldnames)
+        return self._filter_for_existing_fieldnames(self.possible_debugging_fieldnames)
 
     @property
     def debugging_field_indexes(self) -> tuple:
         """Get a tuple of field indexes (e.g. ["A", "B"]) for fields that
         are used for debugging."""
         return self._filter_for_existing_field_indexes(
-            self._debugging_fieldnames
+            self.possible_debugging_fieldnames
         )
 
     @property
@@ -531,7 +536,7 @@ class TestCategory:
         """Get a list of fieldnames (e.g. ["foo", "bar"]) for fields that
         are used for identifying tests."""
         return self._filter_for_existing_fieldnames(
-            self._test_metadata_fieldnames
+            self.possible_test_metadata_fieldnames
         )
 
     @property
@@ -539,7 +544,7 @@ class TestCategory:
         """Get a tuple of field indexes (e.g. ["A", "B"]) for fields that
         are used for identifying tests."""
         return self._filter_for_existing_field_indexes(
-            self._test_metadata_fieldnames
+            self.possible_test_metadata_fieldnames
         )
 
     @property
@@ -547,7 +552,7 @@ class TestCategory:
         """Get a list of fieldnames (e.g. ["foo", "bar"]) for fields that
         are used for diagnostics."""
         return self._filter_for_existing_fieldnames(
-            self._diagnostic_fieldnames
+            self.possible_diagnostic_fieldnames
         )
 
     @property
@@ -555,7 +560,7 @@ class TestCategory:
         """Get a tuple of field indexes (e.g. ["A", "B"]) for fields that
         are used for diagnostics."""
         return self._filter_for_existing_field_indexes(
-            self._diagnostic_fieldnames
+            self.possible_diagnostic_fieldnames
         )
 
     @property
@@ -563,14 +568,14 @@ class TestCategory:
         """Get a list of fieldnames (e.g. ["foo", "bar"]) for fields that
         are fixed (i.e. whose position is always at the start of the sheet,
         for diagnostic purposes)."""
-        return self._filter_for_existing_fieldnames(self._fixed_fieldnames)
+        return self._filter_for_existing_fieldnames(self.possible_fixed_fieldnames)
 
     @property
     def fixed_field_indexes(self) -> tuple:
         """Get a list of field indexes (e.g. ["A", "B"]) for fields that
         are fixed (i.e. whose position is always at the start of the sheet,
         for diagnostic purposes)."""
-        return self._filter_for_existing_field_indexes(self._fixed_fieldnames)
+        return self._filter_for_existing_field_indexes(self.possible_fixed_fieldnames)
 
     @property
     def nonfixed_fieldnames(self) -> typing.List[str]:
@@ -578,7 +583,7 @@ class TestCategory:
         are nonfixed (i.e. whose position comes after the fixed fields in the
         sheet and are thus variable)."""
         fieldnames = self.fieldnames
-        fixed_fieldnames = self._fixed_fieldnames
+        fixed_fieldnames = self.possible_fixed_fieldnames
         return [field for field in fieldnames if field not in fixed_fieldnames]
 
     @property
@@ -795,18 +800,22 @@ def main() -> None:
     test_run_result_metadata_list = TestRunResultMetadata.create_list(
         test_categories, run_results_filepath
     )
+    test_run_failing_row_metadata_list = TestRunFailingRowMetadata.create_list(
+        test_categories, run_results_filepath
+    )
     run_date = get_run_date_from_run_results(run_results_filepath)
     run_id = get_run_id_from_run_results(run_results_filepath)
 
     for metadata_list, tablename, partition_cols in [
         ([test_run_metadata], "test_run", ["run_year"]),
         (test_run_result_metadata_list, "test_run_result", ["run_year"]),
+        (test_run_failing_row_metadata_list, "test_run_failing_row", ["run_year"]),
     ]:
-        table = pyarrow.Table.from_pylist(
+        table = pa.Table.from_pylist(
             [
-                dataclasses.asdict(meta_obj)
+                meta_obj.to_dict()
                 for meta_obj in metadata_list  # type: ignore
-            ]
+            ],
         )
         metadata_root_path = os.path.join(output_dir, "metadata", tablename)
         pyarrow.parquet.write_to_dataset(
@@ -882,15 +891,20 @@ class TestRunMetadata:
             git_author=git_author,
         )
 
+    def to_dict(self) -> typing.Dict:
+        return dataclasses.asdict(self)
+
 
 @dataclasses.dataclass
 class TestRunResultMetadata:
-    """Metadata object storing information about test results in a run."""
+    """Metadata object storing aggregated information about township-level
+    test results in a run."""
 
     run_id: str
     run_year: str  # Duplicated with TestRunMetadata for partitioning
     test_name: str
     table_name: str
+    column_name: typing.Optional[str]
     category: str
     description: str
     township_code: typing.Optional[str]
@@ -917,6 +931,7 @@ class TestRunResultMetadata:
                 run_year=run_year,
                 test_name=township_result.name,
                 table_name=township_result.table_name,
+                column_name=township_result.column_name,
                 category=test_category.category,
                 description=township_result.description,
                 township_code=township_result.township_code,
@@ -928,6 +943,100 @@ class TestRunResultMetadata:
             for test_result in test_category.test_results
             for township_result in test_result.split_by_township()
         ]
+
+    def to_dict(self) -> typing.Dict:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass
+class TestRunFailingRowMetadata:
+    """Metadata object storing information about row-level individual test
+    failures in a run."""
+
+    # Fields that identify the run
+    run_id: str
+    run_year: str  # Duplicated with TestRunMetadata for partitioning
+    # Fields that identify the test
+    test_name: str
+    table_name: str
+    column_name: typing.Optional[str]
+    category: str
+    description: str
+    # Fields that identify the failing row. Some of these can occasionally
+    # be arrays for tests that query multiple rows (e.g. uniqueness tests)
+    # so for consistency we set them to always be arrays, even when there
+    # is only one value
+    parid: typing.Optional[str]
+    taxyr: typing.Optional[str]
+    card: typing.Optional[typing.List[int]]
+    lline: typing.Optional[typing.List[int]]
+    class_: typing.Optional[typing.List[str]]
+    township_code: typing.Optional[str]
+    who: typing.Optional[typing.List[str]]
+    wen: typing.Optional[typing.List[str]]
+    # Since the problematic fields can vary so widely, we store them as a
+    # JSON blob
+    problematic_fields: typing.Dict
+
+    @classmethod
+    def create_list(
+        cls,
+        test_categories: typing.List[TestCategory],
+        run_results_filepath: str,
+    ) -> typing.List["TestRunFailingRowMetadata"]:
+        """Generate a list of TestRunFailingRowMetadata object from a list of
+        TestCategory objects representing the categories in the run and a
+        filepath to a run_results.json file."""
+        run_id = get_run_id_from_run_results(run_results_filepath)
+        run_date = get_run_date_from_run_results(run_results_filepath)
+        run_year = run_date[:4]
+
+        def value_to_list(value):
+            """Tiny helper function to convert column values to lists."""
+            if value is None or type(value) == list:
+                return value
+            return [value]
+
+        return [
+            TestRunFailingRowMetadata(
+                run_id=run_id,
+                run_year=run_year,
+                test_name=township_result.name,
+                table_name=township_result.table_name,
+                column_name=township_result.column_name,
+                category=test_category.category,
+                description=township_result.description,
+                township_code=township_result.township_code,
+                parid=failing_row.get(PARID_FIELD),
+                taxyr=failing_row.get(TAXYR_FIELD),
+                card=value_to_list(failing_row.get(CARD_FIELD)),
+                lline=value_to_list(failing_row.get(LAND_LINE_FIELD)),
+                class_=value_to_list(failing_row.get(CLASS_FIELD)),
+                who=value_to_list(failing_row.get(WHO_FIELD)),
+                wen=value_to_list(failing_row.get(WEN_FIELD)),
+                problematic_fields={
+                    key: val
+                    for key, val
+                    in failing_row.items()
+                    # Use possible_fixed_fieldnames to avoid having to
+                    # recompute the exact fixed fieldnames on every iteration
+                    # (we could also solve this by expanding out the list
+                    # comprehension, but for now this is easier)
+                    if key not in test_category.possible_fixed_fieldnames
+                }
+            )
+            for test_category in test_categories
+            for test_result in test_category.test_results
+            for township_result in test_result.split_by_township()
+            for failing_row in township_result.failing_rows
+            if township_result.status == Status.FAIL
+        ]
+
+    def to_dict(self) -> typing.Dict:
+        output_data = dataclasses.asdict(self)
+        # Serialize the "class" attribute to a more human-friendly name
+        output_data["class"] = output_data.pop("class_")
+        return output_data
 
 
 def get_key_from_run_results(
@@ -1056,6 +1165,7 @@ def get_test_categories(
         meta = node.get("meta", {})
         category = get_category_from_node(node)
         tablename = get_tablename_from_node(node)
+        column_name = get_column_name_from_node(node)
         test_description = meta.get("description")
 
         # Basic attrs for the test result that apply whether or not the test
@@ -1063,6 +1173,7 @@ def get_test_categories(
         base_result_kwargs = {
             "name": test_name,
             "table_name": tablename,
+            "column_name": column_name,
             "description": test_description,
             "elapsed_time": execution_time,
         }
@@ -1310,6 +1421,18 @@ def get_tablename_from_node(node: typing.Dict) -> str:
         f" for test \"{node['name']}\". Inspect the dbt manifest file "
         "for more information"
     )
+
+
+def get_column_name_from_node(node: typing.Dict) -> typing.Optional[str]:
+    """Given a Node for a test extracted from a dbt manifest, return the name
+    of the column that the test is testing. Note that the column name is not
+    always set, e.g. for tests that are defined on a table instead of on
+    a column, so the return value can be None."""
+    if meta_column_name := node.get("meta", {}).get("column_name"):
+        # If meta.column_name is set, treat it as an override
+        return meta_column_name
+
+    return node.get("column_name")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/transform_dbt_test_results.py
+++ b/.github/scripts/transform_dbt_test_results.py
@@ -1002,7 +1002,10 @@ class TestRunFailingRowMetadata:
         run_year = run_date[:4]
 
         def value_to_list(value):
-            """Tiny helper function to convert column values to lists."""
+            """Tiny helper function to convert not-null column values to lists.
+            Useful in cases where a column can be either a scalar, a list,
+            or a null value, in which cases we want the output to always be
+            either a null value or a list."""
             if value is None or type(value) is list:
                 return value
             return [value]

--- a/.github/workflows/test_dbt_models.yaml
+++ b/.github/workflows/test_dbt_models.yaml
@@ -3,14 +3,7 @@ name: test-dbt-models
 # This workflow is not scheduled or run on PRs because it is manually triggered
 # by the Data Department's sqoop data extraction process upon completion. See
 # https://github.com/ccao-data/service-sqoop-iasworld
-on:
-  workflow_dispatch:
-    inputs:
-      upload:
-        description: Whether to upload results to S3
-        type: boolean
-        required: false
-        default: false
+on: workflow_dispatch
 
 jobs:
   test-dbt-models:
@@ -58,7 +51,6 @@ jobs:
         shell: bash
 
       - name: Extract test results
-        if: ${{ inputs.upload == 'true' }}
         run: |
           python3 ../.github/scripts/transform_dbt_test_results.py \
             --output-dir ./qc_test_results/
@@ -71,25 +63,13 @@ jobs:
           GIT_AUTHOR: ${{ github.event.commits[0].author.name }}
 
       - name: Save test results to S3
-        if: ${{ inputs.upload == 'true' }}
         run: |
-          s3_raw_prefix="s3://ccao-data-raw-us-east-1/qc"
-          s3_warehouse_prefix="s3://ccao-data-warehouse-us-east-1/qc"
-          local_prefix="qc_test_results"
-          echo "Copying test_run metadata to S3"
-          aws s3 sync \
-            "${local_prefix}/metadata/test_run" \
-            "${s3_warehouse_prefix}/test_run"
-
-          echo "Copying test_run_result metadata to S3"
-          aws s3 sync \
-            "${local_prefix}/metadata/test_run_result" \
-            "${s3_warehouse_prefix}/test_run_result"
-
-          echo "Copying test result workbook to S3"
-          aws s3 cp \
-            "${local_prefix}/qc_test_failures_*.xlsx" \
-            "${s3_raw_prefix}/workbooks/"
+          s3_prefix="s3://ccao-data-warehouse-us-east-1/qc"
+          local_prefix="qc_test_results/metadata"
+          for dir in "test_run" "test_run_result" "test_run_failing_row"; do
+            echo "Copying ${dir} metadata to S3"
+            aws s3 sync "${local_prefix}/${dir}" "${s3_prefix}/${dir}"
+          done
 
           crawler_name="ccao-data-warehouse-qc-crawler"
           aws glue start-crawler --name "$crawler_name"

--- a/.github/workflows/test_dbt_models.yaml
+++ b/.github/workflows/test_dbt_models.yaml
@@ -53,9 +53,7 @@ jobs:
       - name: Extract test results
         run: |
           python3 ../.github/scripts/transform_dbt_test_results.py \
-            ./target/run_results.json \
-            ./target/manifest.json \
-            ./qc_test_results/
+            --output-dir ./qc_test_results/
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash
         env:
@@ -66,17 +64,23 @@ jobs:
 
       - name: Save test results to S3
         run: |
-          s3_prefix="s3://ccao-data-warehouse-us-east-1/qc"
-          local_prefix="qc_test_results/metadata"
+          s3_raw_prefix="s3://ccao-data-raw-us-east-1/qc"
+          s3_warehouse_prefix="s3://ccao-data-warehouse-us-east-1/qc"
+          local_prefix="qc_test_results"
           echo "Copying test_run metadata to S3"
           aws s3 sync \
-            "${local_prefix}/test_run" \
-            "${s3_prefix}/test_run"
+            "${local_prefix}/metadata/test_run" \
+            "${s3_warehouse_prefix}/test_run"
 
           echo "Copying test_run_result metadata to S3"
           aws s3 sync \
-            "${local_prefix}/test_run_result" \
-            "${s3_prefix}/test_run_result"
+            "${local_prefix}/metadata/test_run_result" \
+            "${s3_warehouse_prefix}/test_run_result"
+
+          echo "Copying test result workbook to S3"
+          aws s3 cp \
+            "${local_prefix}/qc_test_failures_*.xlsx" \
+            "${s3_raw_prefix}/workbooks/"
 
           crawler_name="ccao-data-warehouse-qc-crawler"
           aws glue start-crawler --name "$crawler_name"

--- a/.github/workflows/test_dbt_models.yaml
+++ b/.github/workflows/test_dbt_models.yaml
@@ -3,7 +3,14 @@ name: test-dbt-models
 # This workflow is not scheduled or run on PRs because it is manually triggered
 # by the Data Department's sqoop data extraction process upon completion. See
 # https://github.com/ccao-data/service-sqoop-iasworld
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      upload:
+        description: Whether to upload results to S3
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   test-dbt-models:
@@ -51,6 +58,7 @@ jobs:
         shell: bash
 
       - name: Extract test results
+        if: ${{ inputs.upload == 'true' }}
         run: |
           python3 ../.github/scripts/transform_dbt_test_results.py \
             --output-dir ./qc_test_results/
@@ -63,6 +71,7 @@ jobs:
           GIT_AUTHOR: ${{ github.event.commits[0].author.name }}
 
       - name: Save test results to S3
+        if: ${{ inputs.upload == 'true' }}
         run: |
           s3_raw_prefix="s3://ccao-data-raw-us-east-1/qc"
           s3_warehouse_prefix="s3://ccao-data-warehouse-us-east-1/qc"


### PR DESCRIPTION
This PR updates the `.github/scripts/transform_dbt_test_results.py` script to output row-level test failure data to a parquet dataset with the name `test_run_failing_row`. This is intended to supplement the `test_run` dataset (which saves metadata about a specific run) and the `test_run_result` dataset (which saves aggregate statistics for tests at the township level).

In so doing, we also update `test_run_result` to include an nullable `column_name` attribute that matches the new `test_run_failing_row` dataset. This attribute has proven useful for the purposes of analysis, and saving it explicitly should be more robust than the current workflow where we extract the column name from the test name (which follows the pattern `iasworld_<tablename>_<column_name>_description` in cases where a column name exists for the test).

Sample output is available for review in Athena under the table name `qc.test_run_failing_row`.