### PR TITLE
Fix hard-coded asset names in qc.vw_change_in_ahsap_values.sql

### DIFF
--- a/dbt/models/qc/qc.vw_change_in_ahsap_values.sql
+++ b/dbt/models/qc/qc.vw_change_in_ahsap_values.sql
@@ -13,8 +13,8 @@ SELECT
     hist.board_class,
     hist.board_tot,
     hist.board_tot > hist.certified_tot * 1.2 AS large_board_increase
-FROM default.vw_pin_history AS hist
-INNER JOIN reporting.vw_pin_township_class AS ahsap
+FROM {{ ref('default.vw_pin_history') }} AS hist
+INNER JOIN {{ ref('reporting.vw_pin_township_class') }} AS ahsap
     ON hist.pin = ahsap.pin AND hist.year = ahsap.year
 WHERE ahsap.ahsap
     AND (


### PR DESCRIPTION
Let some standard sql view/table names slip through into this view.