### PR TITLE
Ingest BOR appeal data into lake

### DIFF
--- a/dbt/models/ccao/docs.md
+++ b/dbt/models/ccao/docs.md
@@ -1,6 +1,3 @@
-**Primary Key**: `reascd`
-{% enddocs %}
-
 # class_dict
 
 {% docs table_class_dict %}

--- a/dbt/models/ccbor/docs.md
+++ b/dbt/models/ccbor/docs.md
@@ -1,0 +1,9 @@
+# appeals
+
+{% docs table_appeals %}
+Historical Cook County Board of Review appeal decisions data from the county's
+[open dataportal](https://datacatalog.cookcountyil.gov/Property-Taxation/Board-of-Review-Appeal-Decision-History/7pny-nedm/about_data).
+
+
+**Primary Key**: `taxyr`, `pin`, `appealtrk`, `appealseq`
+{% enddocs %}

--- a/dbt/models/ccbor/docs.md
+++ b/dbt/models/ccbor/docs.md
@@ -5,5 +5,5 @@ Historical Cook County Board of Review appeal decisions data from the county's
 [open data portal](https://datacatalog.cookcountyil.gov/Property-Taxation/Board-of-Review-Appeal-Decision-History/7pny-nedm/about_data).
 
 
-**Primary Key**: `taxyr`, `pin`, `appealtrk`, `appealseq`
+**Primary Key**: `appeal_id`, `pin`, `taxyr`
 {% enddocs %}

--- a/dbt/models/ccbor/docs.md
+++ b/dbt/models/ccbor/docs.md
@@ -1,8 +1,8 @@
 # appeals
 
 {% docs table_appeals %}
-Historical Cook County Board of Review appeal decisions data from the county's
-[open data portal](https://datacatalog.cookcountyil.gov/Property-Taxation/Board-of-Review-Appeal-Decision-History/7pny-nedm/about_data).
+Historical Cook County Board of Review appeal decisions data from the County's
+[Open Data Portal](https://datacatalog.cookcountyil.gov/Property-Taxation/Board-of-Review-Appeal-Decision-History/7pny-nedm/about_data).
 
 
 **Primary Key**: `appeal_id`, `pin`, `taxyr`

--- a/dbt/models/ccbor/docs.md
+++ b/dbt/models/ccbor/docs.md
@@ -2,7 +2,7 @@
 
 {% docs table_appeals %}
 Historical Cook County Board of Review appeal decisions data from the county's
-[open dataportal](https://datacatalog.cookcountyil.gov/Property-Taxation/Board-of-Review-Appeal-Decision-History/7pny-nedm/about_data).
+[open data portal](https://datacatalog.cookcountyil.gov/Property-Taxation/Board-of-Review-Appeal-Decision-History/7pny-nedm/about_data).
 
 
 **Primary Key**: `taxyr`, `pin`, `appealtrk`, `appealseq`

--- a/dbt/models/ccbor/schema.yml
+++ b/dbt/models/ccbor/schema.yml
@@ -13,9 +13,9 @@ sources:
           - name: class
             description: '{{ doc("shared_column_class") }}'
           - name: township_code
-            description: '{{ docs shared_column_township_code }}'
+            description: '{{ doc("shared_column_township_code") }}'
           - name: tax_code
-            description: '{{ docs shared_column_tax_code }}'
+            description: '{{ doc("shared_column_tax_code") }}'
           - name: appeal_trk
             description: First part of the Complaint number
           - name: appeal_seq
@@ -25,17 +25,17 @@ sources:
           - name: appeal_type_desc
             description: Appeal type description
           - name: assessor_land_value
-            description: '{{ docs shared_column_certified_land }}'
+            description: '{{ doc("shared_column_certified_land") }}'
           - name: assessor_improvement_value
-            description: '{{ docs shared_column_certified_bldg }}'
+            description: '{{ doc("shared_column_certified_bldg") }}'
           - name: assessor_total_value
-            description: '{{ docs shared_column_certified_tot }}'
+            description: '{{ doc("shared_column_certified_tot") }}'
           - name: bor_land_value
-            description: '{{ docs shared_column_board_land }}'
+            description: '{{ doc("shared_column_board_land") }}'
           - name: bor_improvement_value
-            description: '{{ docs shared_column_board_bldg }}'
+            description: '{{ doc("shared_column_board_bldg") }}'
           - name: bor_total_value
-            description: '{{ docs shared_column_board_tot }}'
+            description: '{{ doc("shared_column_board_tot") }}'
           - name: result
             description: Board of Review appeal result
           - name: change_reason
@@ -67,4 +67,4 @@ sources:
           - name: attorney_firm_name
             description: Attorney firm name
           - name: taxyr
-            description: '{{ docs shared_column_year }}'
+            description: '{{ doc("shared_column_year") }}'

--- a/dbt/models/ccbor/schema.yml
+++ b/dbt/models/ccbor/schema.yml
@@ -13,9 +13,9 @@ sources:
           - name: class
             description: '{{ doc("shared_column_class") }}'
           - name: township_code
-            description: '{{% docs shared_column_township_code %}}'
+            description: '{{ docs shared_column_township_code }}'
           - name: tax_code
-            description: '{{% docs shared_column_tax_code %}}'
+            description: '{{ docs shared_column_tax_code }}'
           - name: appeal_trk
             description: First part of the Complaint number
           - name: appeal_seq
@@ -25,17 +25,17 @@ sources:
           - name: appeal_type_desc
             description: Appeal type description
           - name: assessor_land_value
-            description: '{{% docs shared_column_certified_land %}}'
+            description: '{{ docs shared_column_certified_land }}'
           - name: assessor_improvement_value
-            description: '{{% docs shared_column_certified_bldg %}}'
+            description: '{{ docs shared_column_certified_bldg }}'
           - name: assessor_total_value
-            description: '{{% docs shared_column_certified_tot %}}'
+            description: '{{ docs shared_column_certified_tot }}'
           - name: bor_land_value
-            description: '{{% docs shared_column_board_land %}}'
+            description: '{{ docs shared_column_board_land }}'
           - name: bor_improvement_value
-            description: '{{% docs shared_column_board_bldg %}}'
+            description: '{{ docs shared_column_board_bldg }}'
           - name: bor_total_value
-            description: '{{% docs shared_column_board_tot %}}'
+            description: '{{ docs shared_column_board_tot }}'
           - name: result
             description: Board of Review appeal result
           - name: change_reason
@@ -67,4 +67,4 @@ sources:
           - name: attorney_firm_name
             description: Attorney firm name
           - name: taxyr
-            description: '{{% docs shared_column_year %}}'
+            description: '{{ docs shared_column_year }}'

--- a/dbt/models/ccbor/schema.yml
+++ b/dbt/models/ccbor/schema.yml
@@ -5,3 +5,66 @@ sources:
     tables:
       - name: appeals
         description: '{{ doc("table_appeals") }}'
+        columns:
+          - name: appeal_id
+            description: Appeal ID. Matches the "Complaint" value on the Board of Review Decision Search.
+          - name: pin
+            description: '{{ doc("shared_column_pin") }}'
+          - name: class
+            description: '{{ doc("shared_column_class") }}'
+          - name: township_code
+            description: '{{% docs shared_column_township_code %}}'
+          - name: tax_code
+            description: '{{% docs shared_column_tax_code %}}'
+          - name: appeal_trk
+            description: First part of the Complaint number
+          - name: appeal_seq
+            description: Second part of the Complaint number
+          - name: appeal_type
+            description: Appeal type code
+          - name: appeal_type_desc
+            description: Appeal type description
+          - name: assessor_land_value
+            description: '{{% docs shared_column_certified_land %}}'
+          - name: assessor_improvement_value
+            description: '{{% docs shared_column_certified_bldg %}}'
+          - name: assessor_total_value
+            description: '{{% docs shared_column_certified_tot %}}'
+          - name: bor_land_value
+            description: '{{% docs shared_column_board_land %}}'
+          - name: bor_improvement_value
+            description: '{{% docs shared_column_board_bldg %}}'
+          - name: bor_total_value
+            description: '{{% docs shared_column_board_tot %}}'
+          - name: result
+            description: Board of Review appeal result
+          - name: change_reason
+            description: Reason code for change. This is only populated starting with 2015.
+          - name: change_reason_desc
+            description: Reason description for change. This is only populated starting with 2015.
+          - name: no_change_reason
+            description: Reason code for no change. This is only populated starting with 2015.
+          - name: no_change_reason_desc
+            description: Reason description for no change. This is only populated starting with 2015.
+          - name: appellant
+            description: Appellant name
+          - name: appellant_address
+            description: Appellant street address
+          - name: appellant_city
+            description: Appellant city
+          - name: appellant_state
+            description: Appellant state
+          - name: appellant_zip
+            description: Appellant zip code
+          - name: attorney_code
+            description: Attorney code; whether an attorney was used. Values are Individual/Pro Se, Exempt, or Attorney.
+          - name: attorney_id
+            description: Attorney ID. This can be used to join to the Attorney list dataset.
+          - name: attorney_first_name
+            description: Attorney first name
+          - name: attorney_last_name
+            description: Attorney last name
+          - name: attorney_firm_name
+            description: Attorney firm name
+          - name: taxyr
+            description: '{{% docs shared_column_year %}}'

--- a/dbt/models/ccbor/schema.yml
+++ b/dbt/models/ccbor/schema.yml
@@ -1,0 +1,7 @@
+sources:
+  - name: ccbor
+    tags:
+      - load_manual
+    tables:
+      - name: appeals
+        description: '{{ doc("table_appeals") }}'

--- a/dbt/models/ccbor/schema.yml
+++ b/dbt/models/ccbor/schema.yml
@@ -7,7 +7,7 @@ sources:
         description: '{{ doc("table_appeals") }}'
         columns:
           - name: appeal_id
-            description: Appeal ID. Matches the "Complaint" value on the Board of Review Decision Search.
+            description: Appeal ID. Matches the "Complaint" value on the Board of Review Decision Search
           - name: pin
             description: '{{ doc("shared_column_pin") }}'
           - name: class

--- a/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
@@ -10,6 +10,7 @@ library(RSocrata)
 AWS_S3_RAW_BUCKET <- Sys.getenv("AWS_S3_RAW_BUCKET")
 output_bucket <- file.path(AWS_S3_RAW_BUCKET, "ccbor", "appeals")
 
+# Determine years for which data is available
 years <- read_json(
   glue(
     "https://datacatalog.cookcountyil.gov/resource/7pny-nedm.json?",
@@ -26,6 +27,7 @@ walk(years, \(x) {
   remote_path <- file.path(output_bucket, paste0(x, '.parquet'))
 
   # Only gathers data if it doesn't already exist or is from the last two years
+  # of data
   if (!aws.s3::object_exists(remote_path) | x >= (max(years) - 1)) {
     print(paste0("Fetching BOR Appeals Data for ", x))
     read.socrata(

--- a/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
@@ -23,8 +23,7 @@ years <- read_json(
 
 # Gather BOR appeals data by year
 walk(years, \(x) {
-
-  remote_path <- file.path(output_bucket, paste0(x, '.parquet'))
+  remote_path <- file.path(output_bucket, paste0(x, ".parquet"))
 
   # Only gathers data if it doesn't already exist or is from the last two years
   # of data
@@ -36,8 +35,8 @@ walk(years, \(x) {
         "$select=tax_year={x}"
       ),
       app_token = Sys.getenv("SOCRATA_APP_TOKEN"),
-      email     = Sys.getenv("SOCRATA_EMAIL"),
-      password  = Sys.getenv("SOCRATA_PASSWORD")
+      email = Sys.getenv("SOCRATA_EMAIL"),
+      password = Sys.getenv("SOCRATA_PASSWORD")
     ) %>%
       write_parquet(remote_path)
   }

--- a/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
@@ -1,0 +1,42 @@
+library(arrow)
+library(glue)
+library(dplyr)
+library(jsonlite)
+library(purrr)
+library(RSocrata)
+
+# This script retrieves Board of Review appeals data from the county's open
+# data portal
+AWS_S3_RAW_BUCKET <- Sys.getenv("AWS_S3_RAW_BUCKET")
+output_bucket <- file.path(AWS_S3_RAW_BUCKET, "ccbor", "appeals")
+
+years <- read_json(
+  glue(
+    "https://datacatalog.cookcountyil.gov/resource/7pny-nedm.json?",
+    "$select=distinct(tax_year)"
+  ),
+  simplifyVector = TRUE
+) %>%
+  pull() %>%
+  as.numeric()
+
+# Gather BOR appeals data by year
+walk(years, \(x) {
+
+  remote_path <- file.path(output_bucket, paste0(x, '.parquet'))
+
+  # Only gathers data if it doesn't already exist or is from the last two years
+  if (!aws.s3::object_exists(remote_path) | x >= (max(years) - 1)) {
+    print(paste0("Fetching BOR Appeals Data for ", x))
+    read.socrata(
+      glue(
+        "https://datacatalog.cookcountyil.gov/resource/7pny-nedm.json?",
+        "$select=tax_year={x}"
+      ),
+      app_token = Sys.getenv("SOCRATA_APP_TOKEN"),
+      email     = Sys.getenv("SOCRATA_EMAIL"),
+      password  = Sys.getenv("SOCRATA_PASSWORD")
+    ) %>%
+      write_parquet(remote_path)
+  }
+}, .progress = TRUE)

--- a/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
@@ -25,8 +25,8 @@ years <- read_json(
 walk(years, \(x) {
   remote_path <- file.path(output_bucket, paste0(x, ".parquet"))
 
-  # Only gathers data if it doesn't already exist or is from the last two years
-  # of data
+  # Only gathers data if it doesn't already exist or is one of the two most
+  # recent years of available data
   if (!aws.s3::object_exists(remote_path) | x >= (max(years) - 1)) {
     print(paste0("Fetching BOR Appeals Data for ", x))
     read.socrata(

--- a/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
@@ -27,12 +27,12 @@ walk(years, \(x) {
 
   # Only gathers data if it doesn't already exist or is one of the two most
   # recent years of available data
-  if (!aws.s3::object_exists(remote_path) | x >= (max(years) - 1)) {
+  if (!aws.s3::object_exists(remote_path)) {
     print(paste0("Fetching BOR Appeals Data for ", x))
     read.socrata(
       glue(
         "https://datacatalog.cookcountyil.gov/resource/7pny-nedm.json?",
-        "$select=tax_year={x}"
+        "$where=tax_year={x}"
       ),
       app_token = Sys.getenv("SOCRATA_APP_TOKEN"),
       email = Sys.getenv("SOCRATA_EMAIL"),

--- a/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
@@ -5,8 +5,8 @@ library(jsonlite)
 library(purrr)
 library(RSocrata)
 
-# This script retrieves Board of Review appeals data from the county's open
-# data portal
+# This script retrieves Board of Review appeals data from the County's Open
+# Data Portal
 AWS_S3_RAW_BUCKET <- Sys.getenv("AWS_S3_RAW_BUCKET")
 output_bucket <- file.path(AWS_S3_RAW_BUCKET, "ccbor", "appeals")
 

--- a/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/ccbor/ccbor-appeals.R
@@ -27,7 +27,7 @@ walk(years, \(x) {
 
   # Only gathers data if it doesn't already exist or is one of the two most
   # recent years of available data
-  if (!aws.s3::object_exists(remote_path)) {
+  if (!aws.s3::object_exists(remote_path) | x >= (max(years) - 1)) {
     print(paste0("Fetching BOR Appeals Data for ", x))
     read.socrata(
       glue(

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
@@ -25,8 +25,39 @@ map(raw_paths, \(x) {
   read_parquet(file.path(AWS_S3_RAW_BUCKET, x))
 }) %>%
   bind_rows() %>%
-  select(-c(pin10:centroid_geom.coordinates)) %>%
-  rename(taxyr = tax_year) %>%
+  select(
+    appeal_id = appealid,
+    pin,
+    taxyr = tax_year,
+    class,
+    township_code,
+    tax_code = taxcode,
+    appeal_trk = appealtrk,
+    appeal_seq = appealseq,
+    appeal_type = appealtype,
+    appeal_type_desc = appealtypedescription,
+    assessor_land_value = assessor_landvalue,
+    assessor_improvement_value = assessor_improvementvalue,
+    assessor_total_value = assessor_totalvalue,
+    bor_land_value = bor_landvalue,
+    bor_improvement_value = bor_improvementvalue,
+    bor_total_value = bor_totalvalue,
+    result,
+    change_reason = changereason,
+    change_reason_desc = changereasondescription,
+    no_change_reason = nochangereason,
+    no_change_reason_desc = nochangereasondescription,
+    appellant,
+    appellant_address,
+    appellant_city,
+    appellant_state,
+    appellant_zip,
+    attorney_code = attorneycode,
+    attorney_id = attny,
+    attorney_first_name = attorney_firstname,
+    attorney_last_name = attorney_lastname,
+    attorney_firm_name = attorney_firmname
+  ) %>%
   group_by(taxyr) %>%
   write_partitions_to_s3(
     output_bucket,

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
@@ -28,7 +28,6 @@ map(raw_paths, \(x) {
   select(
     appeal_id = appealid,
     pin,
-    taxyr = tax_year,
     class,
     township_code,
     tax_code = taxcode,
@@ -56,7 +55,8 @@ map(raw_paths, \(x) {
     attorney_id = attny,
     attorney_first_name = attorney_firstname,
     attorney_last_name = attorney_lastname,
-    attorney_firm_name = attorney_firmname
+    attorney_firm_name = attorney_firmname,
+    taxyr = tax_year
   ) %>%
   mutate(
     across(.cols = everything(), ~ na_if(.x, "N/A")),

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
@@ -12,15 +12,18 @@ input_bucket <- file.path(AWS_S3_RAW_BUCKET, "ccabor", "appeals")
 output_bucket <- file.path(AWS_S3_WAREHOUSE_BUCKET, "ccbor", "appeals")
 
 # Grab the file paths for the raw data on S3
-raw_paths <- aws.s3::get_bucket_df(AWS_S3_RAW_BUCKET, prefix = "ccbor/appeals/") %>%
+raw_paths <- aws.s3::get_bucket_df(
+  AWS_S3_RAW_BUCKET,
+  prefix = "ccbor/appeals/"
+) %>%
   filter(str_detect(Key, "parquet")) %>%
   pull(Key)
 
 # Load the raw appeals data, rename and clean up columns, then write to S3
 # partitioned by year
-map(raw_paths, \(x){
+map(raw_paths, \(x) {
   read_parquet(file.path(AWS_S3_RAW_BUCKET, x))
-}) %>%
+} ) %>%
   bind_rows() %>%
   select(-c(pin10:centroid_geom.coordinates)) %>%
   rename(taxyr = tax_year) %>%

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
@@ -58,6 +58,11 @@ map(raw_paths, \(x) {
     attorney_last_name = attorney_lastname,
     attorney_firm_name = attorney_firmname
   ) %>%
+  mutate(
+    across(.cols = everything(), ~ na_if(.x, "N/A")),
+    across(.cols = everything(), ~ na_if(.x, "")),
+    across(contains("value"), as.integer)
+  ) %>%
   group_by(taxyr) %>%
   write_partitions_to_s3(
     output_bucket,

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
@@ -1,0 +1,32 @@
+library(arrow)
+library(dplyr)
+library(purrr)
+library(stringr)
+library(tidyr)
+source("utils.R")
+
+# This script retrieves and BOR appeals data and formats it for use in Athena
+AWS_S3_RAW_BUCKET <- Sys.getenv("AWS_S3_RAW_BUCKET")
+AWS_S3_WAREHOUSE_BUCKET <- Sys.getenv("AWS_S3_WAREHOUSE_BUCKET")
+input_bucket <- file.path(AWS_S3_RAW_BUCKET, "ccabor", "appeals")
+output_bucket <- file.path(AWS_S3_WAREHOUSE_BUCKET, "ccbor", "appeals")
+
+# Grab the file paths for the raw data on S3
+raw_paths <- aws.s3::get_bucket_df(AWS_S3_RAW_BUCKET, prefix = "ccbor/appeals/") %>%
+  filter(str_detect(Key, "parquet")) %>%
+  pull(Key)
+
+# Load the raw appeals data, rename and clean up columns, then write to S3
+# partitioned by year
+map(raw_paths, \(x){
+  read_parquet(file.path(AWS_S3_RAW_BUCKET, x))
+}) %>%
+  bind_rows() %>%
+  select(-c(pin10:centroid_geom.coordinates)) %>%
+  rename(taxyr = tax_year) %>%
+  group_by(taxyr) %>%
+  write_partitions_to_s3(
+    output_bucket,
+    is_spatial = FALSE,
+    overwrite = TRUE
+  )

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccbor/ccbor-appeals.R
@@ -23,7 +23,7 @@ raw_paths <- aws.s3::get_bucket_df(
 # partitioned by year
 map(raw_paths, \(x) {
   read_parquet(file.path(AWS_S3_RAW_BUCKET, x))
-} ) %>%
+}) %>%
   bind_rows() %>%
   select(-c(pin10:centroid_geom.coordinates)) %>%
   rename(taxyr = tax_year) %>%


### PR DESCRIPTION
ETL pipeline to take data from [BOR appeals open data asset](https://datacatalog.cookcountyil.gov/Property-Taxation/Board-of-Review-Appeal-Decision-History/7pny-nedm/about_data) and load it into athena. Data is more-or-less unaltered. Glue crawler for the `ccbor` database was also added.

See https://github.com/ccao-data/data-architecture/issues/548 for more details.

As of right now using the `RSocrata` package (since `jsonlite` can't handle the amount of data being gathered from the open data portal) which needs credentials. I've added them to `.Renviron`, but that's a file we track with git in this repo. So we'll need to figure out a solution for this.