### PR TITLE
Bump assesspy to 1.2.0

### DIFF
--- a/.github/scripts/deploy_dbt_model_dependencies.sh
+++ b/.github/scripts/deploy_dbt_model_dependencies.sh
@@ -16,7 +16,7 @@
 # into a Python model script with a set of import calls like so:
 #
 #   sc.addPyFile(f"{s3_dependency_dir}/attrs==23.2.0.zip")  # noqa: F821
-#   sc.addPyFile(f"{s3_dependency_dir}/assesspy==1.1.0.zip")  # noqa: F821
+#   sc.addPyFile(f"{s3_dependency_dir}/assesspy==1.2.0.zip")  # noqa: F821
 #   import attrs  # noqa: E402
 #   import assesspy  # noqa: E402
 #

--- a/dbt/models/reporting/reporting.ratio_stats.py
+++ b/dbt/models/reporting/reporting.ratio_stats.py
@@ -1,7 +1,7 @@
 # pylint: skip-file
 # type: ignore
 sc.addPyFile(  # noqa: F821
-    "s3://ccao-athena-dependencies-us-east-1/assesspy==1.1.0.zip"
+    "s3://ccao-athena-dependencies-us-east-1/assesspy==1.2.0.zip"
 )
 
 import numpy as np  # noqa: E402

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -5,7 +5,7 @@ models:
       tags:
         - daily
       packages:
-        - "assesspy==1.1.0"
+        - "assesspy==1.2.0"
     data_tests:
       - expression_is_true:
           name: reporting_ratio_stats_no_nulls


### PR DESCRIPTION
Fast follow on the changes from https://github.com/ccao-data/assesspy/pull/20. Need to bump the version number since I transferred the project to a `ccao-data` PyPI account and the old releases now no longer exist.