### PR TITLE
Investigate duplicates in `model.vw_card_res_input`

### DIFF
--- a/dbt/models/model/model.vw_card_res_input.sql
+++ b/dbt/models/model/model.vw_card_res_input.sql
@@ -654,6 +654,7 @@ LEFT JOIN (
     SELECT *
     FROM forward_fill
     WHERE NOT ind_pin_is_multicard
+        AND SUBSTR(meta_pin, 11, 4) = '0000'
         AND nearest_neighbor_1_dist_ft <= 500
 ) AS nn1
     ON f1.nearest_neighbor_1_pin10 = nn1.meta_pin10
@@ -662,6 +663,7 @@ LEFT JOIN (
     SELECT *
     FROM forward_fill
     WHERE NOT ind_pin_is_multicard
+        AND SUBSTR(meta_pin, 11, 4) = '0000'
         AND nearest_neighbor_2_dist_ft <= 500
 ) AS nn2
     ON f1.nearest_neighbor_1_pin10 = nn2.meta_pin10

--- a/dbt/models/model/model.vw_card_res_input.sql
+++ b/dbt/models/model/model.vw_card_res_input.sql
@@ -654,7 +654,11 @@ LEFT JOIN (
     SELECT *
     FROM forward_fill
     WHERE NOT ind_pin_is_multicard
-        -- Some res parcels are not unique by pin10
+        /* Unfortunately, some res parcels are not unique by pin10, card, and
+        year. This complicates one of our core assumptions about the res parcel
+        universe.
+        See https://github.com/ccao-data/data-architecture/issues/558 for more
+        information. */
         AND SUBSTR(meta_pin, 11, 4) = '0000'
         AND nearest_neighbor_1_dist_ft <= 500
 ) AS nn1
@@ -664,7 +668,6 @@ LEFT JOIN (
     SELECT *
     FROM forward_fill
     WHERE NOT ind_pin_is_multicard
-        -- Some res parcels are not unique by pin10
         AND SUBSTR(meta_pin, 11, 4) = '0000'
         AND nearest_neighbor_2_dist_ft <= 500
 ) AS nn2

--- a/dbt/models/model/model.vw_card_res_input.sql
+++ b/dbt/models/model/model.vw_card_res_input.sql
@@ -654,6 +654,7 @@ LEFT JOIN (
     SELECT *
     FROM forward_fill
     WHERE NOT ind_pin_is_multicard
+        -- Some res parcels are not unique by pin10
         AND SUBSTR(meta_pin, 11, 4) = '0000'
         AND nearest_neighbor_1_dist_ft <= 500
 ) AS nn1
@@ -663,6 +664,7 @@ LEFT JOIN (
     SELECT *
     FROM forward_fill
     WHERE NOT ind_pin_is_multicard
+        -- Some res parcels are not unique by pin10
         AND SUBSTR(meta_pin, 11, 4) = '0000'
         AND nearest_neighbor_2_dist_ft <= 500
 ) AS nn2

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -740,8 +740,6 @@ models:
             - meta_pin
             - meta_year
             - meta_card_num
-          config:
-            error_if: ">19"
 
   - name: model.vw_pin_condo_input
     description: '{{ doc("view_vw_pin_condo_input") }}'


### PR DESCRIPTION
See https://github.com/ccao-data/data-architecture/issues/558

Long story short, `model.vw_card_res_input` is not currently unique by pin10, card, and year due to nearest neighbor joins. These joins introduce duplicates because some non-condo res parcels have 14-digit pins rather than the 10 we assume.