### PR TITLE
Update docs.md

### DIFF
--- a/dbt/models/default/docs.md
+++ b/dbt/models/default/docs.md
@@ -156,7 +156,7 @@ process. The full data lineage looks something like:
 
 ![Data Flow Diagram](./assets/sales-lineage.svg)
 
-**Primary Key**: `year`, `pin`
+**Primary Key**: `doc_no`, `pin`
 {% enddocs %}
 
 # vw_pin_universe


### PR DESCRIPTION
pin and year are not primary keys for `default.vw_pin_sale`. `doc_no` has to be combined with `pin` since multisales make `doc_no` non-unique.