### PR TITLE
Configure ruff to sort Python imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,5 +22,10 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.5
     hooks:
+      # Python linter. Ruff recommends running this before the formatter to
+      # avoid conflicts when using the --fix flag
       - id: ruff
+        args:
+          - --fix
+      # Formatter
       - id: ruff-format

--- a/dbt/models/reporting/reporting.ratio_stats.py
+++ b/dbt/models/reporting/reporting.ratio_stats.py
@@ -4,14 +4,21 @@ sc.addPyFile(  # noqa: F821
     "s3://ccao-athena-dependencies-us-east-1/assesspy==1.2.0.zip"
 )
 
-import numpy as np  # noqa: E402
+import numpy as np  # noqa: I001 E402
 import pandas as pd  # noqa: E402
-from assesspy import boot_ci  # noqa: E402
-from assesspy import cod  # noqa: E402
-from assesspy import prd_met  # noqa: E402
-from assesspy import cod_ci as cod_boot  # noqa: E402
-from assesspy import cod_met, mki, mki_met, prb, prb_met, prd  # noqa: E402
-from assesspy import prd_ci as prd_boot  # noqa: E402
+from assesspy import (  # noqa: E402
+    boot_ci,  # noqa: E402
+    cod,  # noqa: E402
+    cod_ci as cod_boot,  # noqa: E402
+    cod_met,  # noqa: E402
+    mki,  # noqa: E402
+    mki_met,  # noqa: E402
+    prb,  # noqa: E402
+    prb_met,  # noqa: E402
+    prd,  # noqa: E402
+    prd_met,  # noqa: E402
+    prd_ci as prd_boot,  # noqa: E402
+)
 
 
 def median_boot(ratio, nboot=100, alpha=0.05):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,17 @@
 [tool.ruff]
 line-length = 79
 
+[tool.ruff.lint]
+extend-select = ["I"]
+
+[tool.ruff.lint.isort]
+# Disambiguate between the subdirectory called "dbt" and the third-party
+# package. So far we never import from the dbt/ subdirectory outside it, so
+# we instruct the linter to always treat the symbol "dbt" as a third-party
+# package. Note that this could cause problems in the future if we ever
+# decide we want to import code from dbt/ to a context outside of it
+known-third-party = ["dbt"]
+
 [tool.sqlfluff.core]
 dialect = "athena"
 exclude_rules = "ambiguous.column_count, structure.column_order, RF04, ST05"


### PR DESCRIPTION
This PR updates our ruff config to enable sorting Python imports, which is disabled by default. We also update the linter pre-commit step to use the `--fix` flag, which enables autofixing for linter errors ([docs](https://docs.astral.sh/ruff/linter/#fixes)).

Note that I cancelled the `build-and-test-dbt` workflow, since this PR changes the `ratio_stats` script and I didn't want to bother rerunning it. Merging this PR should also rerun `ratio_stats` in prod; since we have high-availability enabled, this shouldn't cause a problem, but I'll plan to merge at a slow time and babysit the deployment just in case.

Closes https://github.com/ccao-data/data-architecture/issues/581.