### PR TITLE
Fix Python import order in `socrata/socrata_upload.py`

### DIFF
--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -1,11 +1,12 @@
-import os
-import requests
-import time
-from dbt.cli.main import dbtRunner
 import contextlib
 import io
 import json
+import os
+import time
+
 import pandas as pd
+import requests
+from dbt.cli.main import dbtRunner
 from pyathena import connect
 from pyathena.pandas.cursor import PandasCursor
 


### PR DESCRIPTION
In https://github.com/ccao-data/data-architecture/pull/566 we added the script `socrata/socrata_upload.py`, which included some Python imports that were not properly sorted according to Python style guidelines. At the time the branch was created, ruff wasn't properly sorting our imports, a bug that we fixed in https://github.com/ccao-data/data-architecture/pull/582. The timing of these two PRs was mismatched such that `socrata_upload.py` snuck in without its imports being properly formatted, causing unrelated PRs to fail when linting that script ([see here for an example](https://github.com/ccao-data/data-architecture/actions/runs/10746131829/job/29806483280)).

This PR fixes the sort order in `socrata_upload.py`, which should prevent other PRs from being blocked by related linter errors.

Note that `build-and-test-dbt` is currently failing because it wants to rebuild `ratio_stats` due to the ongoing deployment of https://github.com/ccao-data/data-architecture/pull/582. We should be good to merge this as long as the `pre-commit` workflow passes.