### PR TITLE
Add scripts and schemas for iasWorld test and legacy files

### DIFF
--- a/dbt/models/ccao/docs.md
+++ b/dbt/models/ccao/docs.md
@@ -1,10 +1,27 @@
-# class_dict
+# cc_dli_senfrr
 
-{% docs table_class_dict %}
-Classification codes and descriptions for real property. Derived from the
-[public PDF](https://prodassets.cookcountyassessor.com/s3fs-public/form_documents/Definitions%20for%20Classifications_2023.pdf).
+{% docs table_cc_dli_senfrr %}
+Legacy senior freeze exemption data pulled by BoT. Provided via MV 08/18/2024.
 
-**Primary Key**: `class_code`
+**Primary Key**: `pin`, `year`
+{% enddocs %}
+
+# cc_pifdb_piexemptre_dise
+
+{% docs table_cc_pifdb_piexemptre_dise %}
+Legacy homestead (senior) exemption data pulled by BoT. Provided via
+MV 08/18/2024.
+
+**Primary Key**: `pin`, `year`
+{% enddocs %}
+
+# cc_pifdb_piexemptre_sted
+
+{% docs table_cc_pifdb_piexemptre_sted %}
+Legacy disabled persons and veterans exemption data pulled by BoT. Provided via
+MV 08/18/2024.
+
+**Primary Key**: `pin`, `year`
 {% enddocs %}
 
 # commercial_valuation

--- a/dbt/models/ccao/schema.yml
+++ b/dbt/models/ccao/schema.yml
@@ -8,6 +8,15 @@ sources:
         tags:
           - type_ic
 
+      - name: cc_dli_senfrr
+        description: '{{ doc("table_cc_dli_senfrr") }}'
+
+      - name: cc_pifdb_piexemptre_dise
+        description: '{{ doc("table_cc_pifdb_piexemptre_dise") }}'
+
+      - name: cc_pifdb_piexemptre_sted
+        description: '{{ doc("table_cc_pifdb_piexemptre_sted") }}'
+
       - name: hie
         description: '{{ doc("table_hie") }}'
         tags:

--- a/dbt/models/iasworld_test/schema.yml
+++ b/dbt/models/iasworld_test/schema.yml
@@ -1,0 +1,122 @@
+sources:
+  - name: iasworld_test
+    loaded_at_field: date_parse(loaded_at, '%Y-%m-%d %H:%i:%S.%f')
+    tags:
+      - load_auto
+      - type_res
+
+    tables:
+      - name: addn
+        description: |
+          Test environment version of the production
+          [`addn` table](#!/source/source.ccao_data_athena.iasworld.addn)
+
+      - name: addrindx
+        description: |
+          Test environment version of the production
+          [`addrindx` table](#!/source/source.ccao_data_athena.iasworld.addrindx)
+
+      - name: aprval
+        description: |
+          Test environment version of the production
+          [`aprval` table](#!/source/source.ccao_data_athena.iasworld.aprval)
+
+      - name: asmt_hist
+        description: |
+          Test environment version of the production
+          [`asmt_hist` table](#!/source/source.ccao_data_athena.iasworld.asmt_hist)
+
+      - name: cname
+        description: |
+          Test environment version of the production
+          [`cname` table](#!/source/source.ccao_data_athena.iasworld.cname)
+
+      - name: comnt
+        description: |
+          Test environment version of the production
+          [`comnt` table](#!/source/source.ccao_data_athena.iasworld.comnt)
+
+      - name: cvleg
+        description: |
+          Test environment version of the production
+          [`cvleg` table](#!/source/source.ccao_data_athena.iasworld.cvleg)
+
+      - name: cvown
+        description: |
+          Test environment version of the production
+          [`cvown` table](#!/source/source.ccao_data_athena.iasworld.cvown)
+
+      - name: cvtran
+        description: |
+          Test environment version of the production
+          [`cvtran` table](#!/source/source.ccao_data_athena.iasworld.cvtran)
+
+      - name: dweldat
+        description: |
+          Test environment version of the production
+          [`dweldat` table](#!/source/source.ccao_data_athena.iasworld.dweldat)
+
+      - name: enter
+        description: |
+          Test environment version of the production
+          [`enter` table](#!/source/source.ccao_data_athena.iasworld.enter)
+
+      - name: exadmn
+        description: |
+          Test environment version of the production
+          [`exadmn` table](#!/source/source.ccao_data_athena.iasworld.exadmn)
+
+      - name: exapp
+        description: |
+          Test environment version of the production
+          [`exapp` table](#!/source/source.ccao_data_athena.iasworld.exapp)
+
+      - name: exdet
+        description: |
+          Test environment version of the production
+          [`exdet` table](#!/source/source.ccao_data_athena.iasworld.exdet)
+
+      - name: htdates
+        description: |
+          Test environment version of the production
+          [`htdates` table](#!/source/source.ccao_data_athena.iasworld.htdates)
+
+      - name: htpar
+        description: |
+          Test environment version of the production
+          [`htpar` table](#!/source/source.ccao_data_athena.iasworld.htpar)
+
+      - name: land
+        description: |
+          Test environment version of the production
+          [`land` table](#!/source/source.ccao_data_athena.iasworld.land)
+
+      - name: legdat
+        description: |
+          Test environment version of the production
+          [`legdat` table](#!/source/source.ccao_data_athena.iasworld.legdat)
+
+      - name: oby
+        description: |
+          Test environment version of the production
+          [`oby` table](#!/source/source.ccao_data_athena.iasworld.oby)
+
+      - name: owndat
+        description: |
+          Test environment version of the production
+          [`owndat` table](#!/source/source.ccao_data_athena.iasworld.owndat)
+
+      - name: pardat
+        description: |
+          Test environment version of the production
+          [`pardat` table](#!/source/source.ccao_data_athena.iasworld.pardat)
+
+      - name: permit
+        description: |
+          Test environment version of the production
+          [`permit` table](#!/source/source.ccao_data_athena.iasworld.permit)
+
+      - name: sales
+        description: |
+          Test environment version of the production
+          [`sales` table](#!/source/source.ccao_data_athena.iasworld.sales)

--- a/dbt/seeds/ccao/docs.md
+++ b/dbt/seeds/ccao/docs.md
@@ -17,38 +17,18 @@ Reason codes pertian to changes in AV.
 **Primary Key**: `reascd`
 {% enddocs %}
 
-# cc_dli_senfrr
-
-{% docs table_cc_dli_senfrr %}
-Legacy senior freeze exemption data pulled by BoT. Provided via MV 08/18/2024.
-
-**Primary Key**: `pin`, `year`
-{% enddocs %}
-
-# cc_pifdb_piexemptre_dise
-
-{% docs table_cc_pifdb_piexemptre_dise %}
-Legacy homestead (senior) exemption data pulled by BoT. Provided via
-MV 08/18/2024.
-
-**Primary Key**: `pin`, `year`
-{% enddocs %}
-
-# cc_pifdb_piexemptre_sted
-
-{% docs table_cc_pifdb_piexemptre_sted %}
-Legacy disabled persons and veterans exemption data pulled by BoT. Provided via
-MV 08/18/2024.
-
-**Primary Key**: `pin`, `year`
-{% enddocs %}
-
 # class_dict
 
 {% docs seed_class_dict %}
 Table containing a translation for property class codes to human-readable class
 descriptions. Also describes which classes are included in residential
 regressions and reporting classes.
+
+Derived from the 2023
+[PDF](https://prodassets.cookcountyassessor.com/s3fs-public/form_documents/Definitions%20for%20Classifications_2023.pdf)
+
+**Primary Key**: `class_code`
+{% enddocs %}
 
 To find the level of assessment (LoA) for each class, see the `ccao.loa` table.
 

--- a/dbt/seeds/ccao/docs.md
+++ b/dbt/seeds/ccao/docs.md
@@ -17,6 +17,32 @@ Reason codes pertian to changes in AV.
 **Primary Key**: `reascd`
 {% enddocs %}
 
+# cc_dli_senfrr
+
+{% docs table_cc_dli_senfrr %}
+Legacy senior freeze exemption data pulled by BoT. Provided via MV 08/18/2024.
+
+**Primary Key**: `pin`, `year`
+{% enddocs %}
+
+# cc_pifdb_piexemptre_dise
+
+{% docs table_cc_pifdb_piexemptre_dise %}
+Legacy homestead (senior) exemption data pulled by BoT. Provided via
+MV 08/18/2024.
+
+**Primary Key**: `pin`, `year`
+{% enddocs %}
+
+# cc_pifdb_piexemptre_sted
+
+{% docs table_cc_pifdb_piexemptre_sted %}
+Legacy disabled persons and veterans exemption data pulled by BoT. Provided via
+MV 08/18/2024.
+
+**Primary Key**: `pin`, `year`
+{% enddocs %}
+
 # class_dict
 
 {% docs seed_class_dict %}

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-legacy.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-legacy.R
@@ -92,7 +92,7 @@ cc_dli_senfrr <- map_dfr(files_cc_dli_senfrr$Key, \(f) {
       first_app_received_date = lubridate::ymd(first_app_received_date),
       base_value_year_class = str_sub(base_value_year_class, 4, 6),
       qualified_date = lubridate::ymd(qualified_date),
-      source_file = {{ file }}
+      source_file = {{ f }}
     ) %>%
     select(-X32)
 })
@@ -173,7 +173,7 @@ cc_pifdb_piexemptre_sted <- map_dfr(files_cc_pifdb_piexemptre_sted$Key, \(f) {
       applicant_zip = str_sub(applicant_zip, 5, 9),
       birth_date = lubridate::mdy(birth_date),
       maintenance_date = na_if(maintenance_date, "000000000"),
-      source_file = {{ file }}
+      source_file = {{ f }}
     ) %>%
     select(-filler)
 })
@@ -246,7 +246,7 @@ cc_pifdb_piexemptre_dise <- map_dfr(files_cc_pifdb_piexemptre_dise$Key, \(f) {
         \(x) ifelse(substr(x, 1, 1) == "9", paste0("19", x), paste0("20", x))
       ),
       date_entered = lubridate::ymd(paste0("2", date_entered)),
-      source_file = {{ file }}
+      source_file = {{ f }}
     ) %>%
     select(-filler)
 })

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-legacy.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-legacy.R
@@ -27,9 +27,9 @@ files_cc_dli_senfrr <- aws.s3::get_bucket_df(
 # They were cleaned by searching for pipes between fixed column-wise character
 # positions and replacing them with the intended character.
 # Can't be read as a FWF like the ones below because some rows have extra chars
-cc_dli_senfrr <- map_dfr(files_cc_dli_senfrr$Key, \(file) {
+cc_dli_senfrr <- map_dfr(files_cc_dli_senfrr$Key, \(f) {
   aws.s3::s3read_using(
-    object = file,
+    object = f,
     bucket = AWS_S3_RAW_BUCKET,
     FUN = readr::read_delim,
     delim = "|",
@@ -38,12 +38,13 @@ cc_dli_senfrr <- map_dfr(files_cc_dli_senfrr$Key, \(file) {
       "pin", "year", "tax_year", "tax_type", "rec_code",
       "base_value_year_manual_calculation_ind", "base_value_year",
       "base_value_year_total_eav", "cur_year_total_eav", "cur_year_final_eav",
-      "birth_date","applicant_old_name", "applicant_address", "applicant_city",
+      "birth_date", "applicant_old_name", "applicant_address", "applicant_city",
       "applicant_state", "applicant_zip", "applicant_status",
-      "first_app_received_date", "qualified_date", "homeowner_base_year_eq_factor",
-      "bldg_units", "building_shares", "base_value_year_class",
-      "num_units_w_homeowner_exemption", "num_units_w_homestead_exemption",
-      "num_shares_with_senior_freeze", "coop_senior_shares", "pct_senior_shares",
+      "first_app_received_date", "qualified_date",
+      "homeowner_base_year_eq_factor", "bldg_units", "building_shares",
+      "base_value_year_class", "num_units_w_homeowner_exemption",
+      "num_units_w_homestead_exemption", "num_shares_with_senior_freeze",
+      "coop_senior_shares", "pct_senior_shares",
       "num_shares", "pct_of_shares", "sf_percent"
     ),
     col_types = cols(
@@ -97,11 +98,10 @@ cc_dli_senfrr <- map_dfr(files_cc_dli_senfrr$Key, \(file) {
 })
 
 # Write the files to S3, partitioned by year
-remote_file_warehouse_cc_dli_senfrr <- file.path(output_bucket, "cc_dli_senfrr")
 cc_dli_senfrr %>%
   group_by(year) %>%
   arrow::write_dataset(
-    path = remote_file_warehouse_cc_dli_senfrr,
+    path = file.path(output_bucket, "cc_dli_senfrr"),
     format = "parquet",
     hive_style = TRUE,
     compression = "zstd"
@@ -116,9 +116,9 @@ files_cc_pifdb_piexemptre_sted <- aws.s3::get_bucket_df(
 ) %>%
   filter(Size > 0)
 
-cc_pifdb_piexemptre_sted <- map_dfr(files_cc_pifdb_piexemptre_sted$Key, \(file) {
+cc_pifdb_piexemptre_sted <- map_dfr(files_cc_pifdb_piexemptre_sted$Key, \(f) {
   aws.s3::s3read_using(
-    object = file,
+    object = f,
     bucket = AWS_S3_RAW_BUCKET,
     FUN = readr::read_fwf,
     trim_ws = TRUE,
@@ -179,13 +179,12 @@ cc_pifdb_piexemptre_sted <- map_dfr(files_cc_pifdb_piexemptre_sted$Key, \(file) 
 })
 
 # Write the files to S3, partitioned by year
-remote_file_warehouse_cc_pifdb_piexemptre_sted <- file.path(
-  output_bucket, "cc_pifdb_piexemptre_sted"
-)
 cc_pifdb_piexemptre_sted %>%
   group_by(year) %>%
   arrow::write_dataset(
-    path = remote_file_warehouse_cc_pifdb_piexemptre_sted,
+    path = file.path(
+      output_bucket, "cc_pifdb_piexemptre_sted"
+    ),
     format = "parquet",
     hive_style = TRUE,
     compression = "zstd"
@@ -200,9 +199,9 @@ files_cc_pifdb_piexemptre_dise <- aws.s3::get_bucket_df(
 ) %>%
   filter(Size > 0)
 
-cc_pifdb_piexemptre_dise <- map_dfr(files_cc_pifdb_piexemptre_dise$Key, \(file) {
+cc_pifdb_piexemptre_dise <- map_dfr(files_cc_pifdb_piexemptre_dise$Key, \(f) {
   aws.s3::s3read_using(
-    object = file,
+    object = f,
     bucket = AWS_S3_RAW_BUCKET,
     FUN = readr::read_fwf,
     trim_ws = TRUE,
@@ -253,13 +252,12 @@ cc_pifdb_piexemptre_dise <- map_dfr(files_cc_pifdb_piexemptre_dise$Key, \(file) 
 })
 
 # Write the files to S3, partitioned by year
-remote_file_warehouse_cc_pifdb_piexemptre_dise <- file.path(
-  output_bucket, "cc_pifdb_piexemptre_dise"
-)
 cc_pifdb_piexemptre_dise %>%
   group_by(year) %>%
   arrow::write_dataset(
-    path = remote_file_warehouse_cc_pifdb_piexemptre_dise,
+    path = file.path(
+      output_bucket, "cc_pifdb_piexemptre_dise"
+    ),
     format = "parquet",
     hive_style = TRUE,
     compression = "zstd"

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-legacy.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-legacy.R
@@ -1,0 +1,266 @@
+library(arrow)
+library(aws.s3)
+library(dplyr)
+library(purrr)
+library(readr)
+library(snakecase)
+library(stringr)
+library(tidyr)
+source("utils.R")
+
+AWS_S3_RAW_BUCKET <- Sys.getenv("AWS_S3_RAW_BUCKET")
+AWS_S3_WAREHOUSE_BUCKET <- Sys.getenv("AWS_S3_WAREHOUSE_BUCKET")
+output_bucket <- file.path(AWS_S3_WAREHOUSE_BUCKET, "ccao", "legacy")
+
+
+##### CC_DLI_SENFRR #####
+files_cc_dli_senfrr <- aws.s3::get_bucket_df(
+  bucket = AWS_S3_RAW_BUCKET,
+  prefix = "ccao/legacy/CC_DLI_SENFRR",
+  max = Inf
+) %>%
+  filter(Size > 0)
+
+# Read the files into a single tibble. NOTE: these files are pipe-delimited
+# and have been MANUALLY CLEANED to remove some errant pipes that were in the
+# address fields. These extra pipes prevented proper reading with read_delim.
+# They were cleaned by searching for pipes between fixed column-wise character
+# positions and replacing them with the intended character.
+# Can't be read as a FWF like the ones below because some rows have extra chars
+cc_dli_senfrr <- map_dfr(files_cc_dli_senfrr$Key, \(file) {
+  aws.s3::s3read_using(
+    object = file,
+    bucket = AWS_S3_RAW_BUCKET,
+    FUN = readr::read_delim,
+    delim = "|",
+    trim_ws = TRUE,
+    col_names = c(
+      "pin", "year", "tax_year", "tax_type", "rec_code",
+      "base_value_year_manual_calculation_ind", "base_value_year",
+      "base_value_year_total_eav", "cur_year_total_eav", "cur_year_final_eav",
+      "birth_date","applicant_old_name", "applicant_address", "applicant_city",
+      "applicant_state", "applicant_zip", "applicant_status",
+      "first_app_received_date", "qualified_date", "homeowner_base_year_eq_factor",
+      "bldg_units", "building_shares", "base_value_year_class",
+      "num_units_w_homeowner_exemption", "num_units_w_homestead_exemption",
+      "num_shares_with_senior_freeze", "coop_senior_shares", "pct_senior_shares",
+      "num_shares", "pct_of_shares", "sf_percent"
+    ),
+    col_types = cols(
+      pin = col_character(),
+      year = col_character(),
+      tax_year = col_character(),
+      tax_type = col_character(),
+      rec_code = col_character(),
+      base_value_year_manual_calculation_ind = col_character(),
+      base_value_year = col_character(),
+      base_value_year_total_eav = col_integer(),
+      cur_year_total_eav = col_integer(),
+      cur_year_final_eav = col_integer(),
+      birth_date = col_character(),
+      applicant_old_name = col_character(),
+      applicant_address = col_character(),
+      applicant_city = col_character(),
+      applicant_state = col_character(),
+      applicant_zip = col_character(),
+      applicant_status = col_character(),
+      first_app_received_date = col_character(),
+      qualified_date = col_character(),
+      homeowner_base_year_eq_factor = col_double(),
+      bldg_units = col_integer(),
+      building_shares = col_integer(),
+      base_value_year_class = col_character(),
+      num_units_w_homeowner_exemption = col_integer(),
+      num_units_w_homestead_exemption = col_integer(),
+      num_shares_with_senior_freeze = col_integer(),
+      coop_senior_shares = col_integer(),
+      pct_senior_shares = col_integer(),
+      num_shares = col_integer(),
+      pct_of_shares = col_integer(),
+      sf_percent = col_integer()
+    )
+  ) %>%
+    mutate(
+      across(
+        c(year, tax_year),
+        \(x) ifelse(substr(x, 1, 1) == "9", paste0("19", x), paste0("20", x))
+      ),
+      across(starts_with("applicant_"), \(x) str_trim(str_squish(x))),
+      applicant_zip = str_sub(applicant_zip, 1, 5),
+      birth_date = lubridate::mdy(birth_date),
+      first_app_received_date = lubridate::ymd(first_app_received_date),
+      base_value_year_class = str_sub(base_value_year_class, 4, 6),
+      qualified_date = lubridate::ymd(qualified_date),
+      source_file = {{ file }}
+    ) %>%
+    select(-X32)
+})
+
+# Write the files to S3, partitioned by year
+remote_file_warehouse_cc_dli_senfrr <- file.path(output_bucket, "cc_dli_senfrr")
+cc_dli_senfrr %>%
+  group_by(year) %>%
+  arrow::write_dataset(
+    path = remote_file_warehouse_cc_dli_senfrr,
+    format = "parquet",
+    hive_style = TRUE,
+    compression = "zstd"
+  )
+
+
+##### CC_PIFDB_PIEXEMPTRE_STED #####
+files_cc_pifdb_piexemptre_sted <- aws.s3::get_bucket_df(
+  bucket = AWS_S3_RAW_BUCKET,
+  prefix = "ccao/legacy/CC_PIFDB_PIEXEMPTRE_STED",
+  max = Inf
+) %>%
+  filter(Size > 0)
+
+cc_pifdb_piexemptre_sted <- map_dfr(files_cc_pifdb_piexemptre_sted$Key, \(file) {
+  aws.s3::s3read_using(
+    object = file,
+    bucket = AWS_S3_RAW_BUCKET,
+    FUN = readr::read_fwf,
+    trim_ws = TRUE,
+    col_positions = readr::fwf_cols(
+      pin = c(1, 14),
+      year = c(16, 17),
+      tax_year = c(19, 20),
+      tax_type = c(22, 22),
+      segment_code = c(24, 24),
+      coop_status = c(26, 26),
+      birth_date = c(28, 35),
+      response = c(37, 37),
+      print_indicator = c(39, 39),
+      year_applied = c(41, 45),
+      applicant_name = c(47, 68),
+      applicant_address = c(70, 91),
+      applicant_city = c(93, 104),
+      applicant_state = c(106, 107),
+      applicant_zip = c(109, 117),
+      batch_number = c(119, 123),
+      maintenance_date = c(125, 133),
+      filler = c(135, 235)
+    ),
+    col_types = cols(
+      pin = col_character(),
+      year = col_character(),
+      tax_year = col_character(),
+      tax_type = col_character(),
+      segment_code = col_character(),
+      coop_status = col_character(),
+      birth_date = col_character(),
+      response = col_character(),
+      print_indicator = col_character(),
+      year_applied = col_character(),
+      applicant_name = col_character(),
+      applicant_address = col_character(),
+      applicant_city = col_character(),
+      applicant_state = col_character(),
+      applicant_zip = col_character(),
+      batch_number = col_integer(),
+      maintenance_date = col_character(),
+      filler = col_character()
+    )
+  ) %>%
+    mutate(
+      across(
+        c(year, tax_year),
+        \(x) ifelse(substr(x, 1, 1) == "9", paste0("19", x), paste0("20", x))
+      ),
+      across(starts_with("applicant_"), \(x) str_trim(str_squish(x))),
+      year_applied = str_sub(year_applied, 2, 5),
+      applicant_zip = str_sub(applicant_zip, 5, 9),
+      birth_date = lubridate::mdy(birth_date),
+      maintenance_date = na_if(maintenance_date, "000000000"),
+      source_file = {{ file }}
+    ) %>%
+    select(-filler)
+})
+
+# Write the files to S3, partitioned by year
+remote_file_warehouse_cc_pifdb_piexemptre_sted <- file.path(
+  output_bucket, "cc_pifdb_piexemptre_sted"
+)
+cc_pifdb_piexemptre_sted %>%
+  group_by(year) %>%
+  arrow::write_dataset(
+    path = remote_file_warehouse_cc_pifdb_piexemptre_sted,
+    format = "parquet",
+    hive_style = TRUE,
+    compression = "zstd"
+  )
+
+
+##### CC_PIFDB_PIEXEMPTRE_DISE #####
+files_cc_pifdb_piexemptre_dise <- aws.s3::get_bucket_df(
+  bucket = AWS_S3_RAW_BUCKET,
+  prefix = "ccao/legacy/CC_PIFDB_PIEXEMPTRE_DISE",
+  max = Inf
+) %>%
+  filter(Size > 0)
+
+cc_pifdb_piexemptre_dise <- map_dfr(files_cc_pifdb_piexemptre_dise$Key, \(file) {
+  aws.s3::s3read_using(
+    object = file,
+    bucket = AWS_S3_RAW_BUCKET,
+    FUN = readr::read_fwf,
+    trim_ws = TRUE,
+    col_positions = readr::fwf_cols(
+      pin = c(1, 14),
+      year = c(16, 17),
+      tax_year = c(19, 20),
+      tax_type = c(22, 22),
+      segment_code = c(24, 24),
+      exemption_amount_indicator = c(26, 26),
+      returning_vet_value = c(28, 38),
+      disabled_person_value = c(40, 50),
+      disabled_vet_gte_30 = c(52, 62),
+      disabled_vet_gte_50 = c(64, 74),
+      batch_number = c(76, 80),
+      used_id = c(82, 88),
+      date_entered = c(90, 96),
+      disabled_vet_gte_70 = c(98, 108),
+      filler = c(110, 235)
+    ),
+    col_types = cols(
+      pin = col_character(),
+      year = col_character(),
+      tax_year = col_character(),
+      tax_type = col_character(),
+      segment_code = col_character(),
+      exemption_amount_indicator = col_character(),
+      returning_vet_value = col_integer(),
+      disabled_person_value = col_integer(),
+      disabled_vet_gte_30 = col_integer(),
+      disabled_vet_gte_50 = col_integer(),
+      batch_number = col_integer(),
+      used_id = col_integer(),
+      date_entered = col_character(),
+      disabled_vet_gte_70 = col_integer(),
+      filler = col_character()
+    )
+  ) %>%
+    mutate(
+      across(
+        c(year, tax_year),
+        \(x) ifelse(substr(x, 1, 1) == "9", paste0("19", x), paste0("20", x))
+      ),
+      date_entered = lubridate::ymd(paste0("2", date_entered)),
+      source_file = {{ file }}
+    ) %>%
+    select(-filler)
+})
+
+# Write the files to S3, partitioned by year
+remote_file_warehouse_cc_pifdb_piexemptre_dise <- file.path(
+  output_bucket, "cc_pifdb_piexemptre_dise"
+)
+cc_pifdb_piexemptre_dise %>%
+  group_by(year) %>%
+  arrow::write_dataset(
+    path = remote_file_warehouse_cc_pifdb_piexemptre_dise,
+    format = "parquet",
+    hive_style = TRUE,
+    compression = "zstd"
+  )


### PR DESCRIPTION
This PR adds:

- Scripts to parse and upload legacy mainframe fixed-width files to Athena
- dbt schema entries to expose the resulting legacy file tables in our dbt docs
- dbt schema entries for tables from the iasWorld test environment