### PR TITLE
Move `comdat.bldgval` test back onto the correct column

### DIFF
--- a/dbt/models/iasworld/schema/iasworld.comdat.yml
+++ b/dbt/models/iasworld/schema/iasworld.comdat.yml
@@ -43,8 +43,6 @@ sources:
             description: Gross building value
           - name: bldgval
             description: Building value
-          - name: bld_modelid
-            description: '{{ doc("column_bld_modelid") }}'
             data_tests:
               - accepted_range:
                   name: iasworld_comdat_bldgval_between_0_and_1b
@@ -54,6 +52,8 @@ sources:
                   config: *unique-conditions
                   meta:
                     description: bldgval should be between 0 and 1,000,000,000
+          - name: bld_modelid
+            description: '{{ doc("column_bld_modelid") }}'
           - name: bldnum
             description: Building number
           - name: busla


### PR DESCRIPTION
Our nightly data tests are [currently failing](https://github.com/ccao-data/data-architecture/actions/runs/10825411156/job/30034328842#step:5:720) because https://github.com/ccao-data/data-architecture/pull/578 accidentally moved a test from `comdat.bldgval` onto `comdat.bld_modelid`. This PR fixes that mistake and unblocks our tests in the process.

Confirmation that this change causes the test to pass instead of erroring out:

```
$ dbt test --select iasworld_comdat_bldgval_between_0_and_1b
17:00:21  Running with dbt=1.8.3
17:00:22  Registered adapter: athena=1.8.2
17:00:26  Found 104 models, 9 seeds, 440 data tests, 164 sources, 10 exposures, 502 macros
17:00:26
17:00:29  Concurrency: 16 threads (target='dev')
17:00:29
17:00:29  1 of 1 START test iasworld_comdat_bldgval_between_0_and_1b ..................... [RUN]
17:00:32  1 of 1 PASS iasworld_comdat_bldgval_between_0_and_1b ........................... [PASS in 2.75s]
17:00:32
17:00:32  Finished running 1 test in 0 hours 0 minutes and 6.33 seconds (6.33s).
17:00:32
17:00:32  Completed successfully
17:00:32
17:00:32  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```