### PR TITLE
Two small tweaks to data tests and QC reports

### DIFF
--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -363,8 +363,10 @@ sources:
                 # Codes ending in 999 are dummy codes used for some purpose,
                 # although we do not yet know what it is
                 where: |
-                  (taxyr BETWEEN '2010' AND CAST(YEAR(NOW()) AS varchar))
-                  AND (nbhd NOT LIKE '%999')
+                  CAST(taxyr AS int) BETWEEN {{ var('data_test_iasworld_year_start') }} AND {{ var('data_test_iasworld_year_end') }}
+                  AND cur = 'Y'
+                  AND deactivat IS NULL
+                  AND nbhd NOT LIKE '%999'
               meta:
                 category: relationships
                 description: nbhd code not valid

--- a/dbt/scripts/export_qc_town_close_reports.py
+++ b/dbt/scripts/export_qc_town_close_reports.py
@@ -87,7 +87,7 @@ def is_tri(township_code: str, year: int) -> bool:
         raise ValueError(f"'{township_code}' is not a valid township code")
     # 2024 is the City reassessment year (tri code 1), so
     # ((2024 - 2024) % 3) + 1 == 1, and so on for the other two tris
-    return str((year - 2024 % 3) + 1) == tri
+    return str(((year - 2024) % 3) + 1) == tri
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Background

This PR makes two small fixes to data tests and QC reports that I caught while producing artifacts for Jefferson:

* Updates the `config.where` clause for `iasworld_pardat_nbhd_matches_spatial_town_nbhd` to filter for years using the standard `data_test_iasworld_year_start` and `data_test_iasworld_year_end` variables
* Tweaks the `is_tri()` function logic to return the correct output for tri towns in the `export_qc_town_close_reports` script

## Testing

Evidence that these changes work:

### `iasworld_pardat_nbhd_matches_spatial_town_nbhd`

```
$ dbt test --select iasworld_pardat_nbhd_matches_spatial_town_nbhd --store-failures
...
21:36:17  Completed with 1 error and 0 warnings:
21:36:17
21:36:17  Failure in test iasworld_pardat_nbhd_matches_spatial_town_nbhd (models/iasworld/schema/iasworld.pardat.yml)
21:36:17    Got 15 results, configured to fail if != 0
21:36:17
21:36:17    compiled code at target/compiled/ccao_data_athena/models/iasworld/schema/iasworld.pardat.yml/iasworld_pardat_nbhd_matches_spatial_town_nbhd.sql
21:36:17
21:36:17    See test failures:
  ------------------------------------------------------------------------------------------------------------
  select * from "awsdatacatalog"."z_dev_jecochr_test_failure"."iasworld_pardat_nbhd_matches_spatial_town_nbhd"
  ------------------------------------------------------------------------------------------------------------
21:36:17
21:36:17  Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
```
In the Athena console:

```
> select distinct(taxyr) from z_dev_jecochr_test_failure.iasworld_pardat_nbhd_matches_spatial_town_nbhd
```

| # | taxyr |
| -- | ----- |
| 1 | 2024 |

### `export_qc_town_close_reports.is_tri`

It would be nice if we had some unit tests for this function, but in the meantime, here are some manual tests:

```
> is_tri('71', 2024)
True
> is_tri('71', 2023)
False
> is_tri('39', 2023)
True
> is_tri('39', 2024)
False
```
