### PR TITLE
Improve sales val dbt docs

### DIFF
--- a/dbt/models/sale/schema.yml
+++ b/dbt/models/sale/schema.yml
@@ -16,7 +16,7 @@ sources:
           - name: rolling_window
             description: |
               Rolling window period used to calculate grouping statistics
-              for flagging this sale. As of Sep 2024, ~1 year is used.
+              for flagging this sale. As of Sep 2024, ~1 year is the rolling window.
               The month of the sale and the prior 11 months are used.
           - name: run_id
             description: '{{ doc("shared_column_sv_run_id") }}'

--- a/dbt/models/sale/schema.yml
+++ b/dbt/models/sale/schema.yml
@@ -27,11 +27,11 @@ sources:
           - name: sv_is_ptax_outlier
             description: '{{ doc("shared_column_sv_is_ptax_outlier") }}'
           - name: sv_outlier_reason1
-            description: '{{ doc("shared_column_sv_outlier_reason1") }}'
+            description: '{{ doc("shared_column_sv_outlier_reason") }}'
           - name: sv_outlier_reason2
-            description: '{{ doc("shared_column_sv_outlier_reason2") }}'
+            description: '{{ doc("shared_column_sv_outlier_reason") }}'
           - name: sv_outlier_reason3
-            description: '{{ doc("shared_column_sv_outlier_reason3") }}'
+            description: '{{ doc("shared_column_sv_outlier_reason") }}'
           - name: version
             description: '{{ doc("shared_column_sv_version") }}'
 

--- a/dbt/models/sale/schema.yml
+++ b/dbt/models/sale/schema.yml
@@ -15,8 +15,9 @@ sources:
               PTAX-203 form (regardless of statistical deviation)
           - name: rolling_window
             description: |
-              Rolling window period used to calculate statistics
-              for flagging this sale
+              Rolling window period used to calculate grouping statistics
+              for flagging this sale. As of Sep 2024, ~1 year is used.
+              The month of the sale and the prior 11 months are used.
           - name: run_id
             description: '{{ doc("shared_column_sv_run_id") }}'
           - name: sv_is_heuristic_outlier
@@ -26,11 +27,11 @@ sources:
           - name: sv_is_ptax_outlier
             description: '{{ doc("shared_column_sv_is_ptax_outlier") }}'
           - name: sv_outlier_reason1
-            description: '{{ doc("shared_column_sv_outlier_reason") }}'
+            description: '{{ doc("shared_column_sv_outlier_reason1") }}'
           - name: sv_outlier_reason2
-            description: '{{ doc("shared_column_sv_outlier_reason") }}'
+            description: '{{ doc("shared_column_sv_outlier_reason2") }}'
           - name: sv_outlier_reason3
-            description: '{{ doc("shared_column_sv_outlier_reason") }}'
+            description: '{{ doc("shared_column_sv_outlier_reason3") }}'
           - name: version
             description: '{{ doc("shared_column_sv_version") }}'
 

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1329,9 +1329,10 @@ with `sv_is_ptax_outlier` (using OR logic).
 A null value represents an observation that, due to
 filters on type of sale or time frame of sale, is
 excluded completely from the sales-val model pipeline
-and therefor does recieve a boolean value.
+and therefore does receive a boolean value.
 
-NOTE: Outlier flags only exist for sales _after_ 2014.
+NOTE: Outlier flags only exist for sales _after_ 2013.
+Sales before 2014 will have a null value for this column.
 {% enddocs %}
 
 ## sv_is_ptax_outlier
@@ -1347,43 +1348,11 @@ See [model-sales-val](https://github.com/ccao-data/model-sales-val) for more det
 ## sv_outlier_reason
 
 {% docs shared_column_sv_outlier_reason %}
-Heuristic or model used to flag an outlier.
 
-See the [model-sales-val](https://github.com/ccao-data/model-sales-val)
-repository for a list of possible flags.
-{% enddocs %}
-
-## sv_outlier_reason1
-
-{% docs shared_column_sv_outlier_reason1 %}
 One of three possible reasons that a sale is
 flagged as on outlier. The priority for
 sv_outlier_reason$n column filling is
-ptax outlier > price outlier > characteric outlier.
-
-See the [model-sales-val](https://github.com/ccao-data/model-sales-val)
-repository for a list of possible flags.
-{% enddocs %}
-
-## sv_outlier_reason2
-
-{% docs shared_column_sv_outlier_reason2 %}
-One of three possible reasons that a sale is
-flagged as on outlier. The priority for
-sv_outlier_reason$n column filling is
-ptax outlier > price outlier > characteric outlier.
-
-See the [model-sales-val](https://github.com/ccao-data/model-sales-val)
-repository for a list of possible flags.
-{% enddocs %}
-
-## sv_outlier_reason3
-
-{% docs shared_column_sv_outlier_reason3 %}
-One of three possible reasons that a sale is
-flagged as on outlier. The priority for
-sv_outlier_reason$n column filling is
-ptax outlier > price outlier > characteric outlier.
+ptax outlier > price outlier > characteristic outlier.
 
 See the [model-sales-val](https://github.com/ccao-data/model-sales-val)
 repository for a list of possible flags.

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -879,7 +879,7 @@ Parcel has an active homeowner exemption
 
 {% docs shared_column_is_ahsap %}
 Affordable Housing Special Assessment Program indicator. For more information on
-AHSAP, see: https://www.cookcountyassessor.com/affordable-housing
+AHSAP, see: <https://www.cookcountyassessor.com/affordable-housing>
 {% enddocs %}
 
 ## is_common_area
@@ -1325,6 +1325,12 @@ Indicates an outlier sale not used in modeling or reporting.
 
 This variable combines `sv_is_heuristic_outlier`
 with `sv_is_ptax_outlier` (using OR logic).
+
+A null value represents an observation that, due to
+filters on type of sale or time frame of sale, is
+excluded completely from the sales-val model pipeline
+and therefor does recieve a boolean value.
+
 NOTE: Outlier flags only exist for sales _after_ 2014.
 {% enddocs %}
 
@@ -1342,6 +1348,42 @@ See [model-sales-val](https://github.com/ccao-data/model-sales-val) for more det
 
 {% docs shared_column_sv_outlier_reason %}
 Heuristic or model used to flag an outlier.
+
+See the [model-sales-val](https://github.com/ccao-data/model-sales-val)
+repository for a list of possible flags.
+{% enddocs %}
+
+## sv_outlier_reason1
+
+{% docs shared_column_sv_outlier_reason1 %}
+One of three possible reasons that a sale is
+flagged as on outlier. The priority for
+sv_outlier_reason$n column filling is
+ptax outlier > price outlier > characteric outlier.
+
+See the [model-sales-val](https://github.com/ccao-data/model-sales-val)
+repository for a list of possible flags.
+{% enddocs %}
+
+## sv_outlier_reason2
+
+{% docs shared_column_sv_outlier_reason2 %}
+One of three possible reasons that a sale is
+flagged as on outlier. The priority for
+sv_outlier_reason$n column filling is
+ptax outlier > price outlier > characteric outlier.
+
+See the [model-sales-val](https://github.com/ccao-data/model-sales-val)
+repository for a list of possible flags.
+{% enddocs %}
+
+## sv_outlier_reason3
+
+{% docs shared_column_sv_outlier_reason3 %}
+One of three possible reasons that a sale is
+flagged as on outlier. The priority for
+sv_outlier_reason$n column filling is
+ptax outlier > price outlier > characteric outlier.
 
 See the [model-sales-val](https://github.com/ccao-data/model-sales-val)
 repository for a list of possible flags.


### PR DESCRIPTION
The original intent of this PR was to improve the docs; specifically explaining the `null` case for `sv_is_outlier`.

However we also had not updated the docs to reflect the changes made in [this PR](https://github.com/ccao-data/model-sales-val/pull/132) from [this issue](https://github.com/ccao-data/model-sales-val/issues/124).
