### PR TITLE
Fix incorrect reference to athena results bucket in `export_models`

### DIFF
--- a/dbt/scripts/utils/export.py
+++ b/dbt/scripts/utils/export.py
@@ -104,7 +104,7 @@ def export_models(
     conn = pyathena.connect(
         s3_staging_dir=os.getenv(
             "AWS_ATHENA_S3_STAGING_DIR",
-            "s3://ccao-dbt-athena-results-us-east-1",
+            "s3://ccao-athena-results-us-east-1",
         ),
         region_name=os.getenv("AWS_ATHENA_REGION_NAME", "us-east-1"),
     )


### PR DESCRIPTION
I noticed while setting up the `export_qc_town_close_reports` script on the VM that we have a typo in the `s3_staging_dir` config value. This is causing the creation of a duplicate S3 bucket that doesn't actually need to exist, and that the VM doesn't have permissions to access. This PR fixes this typo so that we can get rid of the duplicate bucket; once this is merged, I'll go ahead and delete the bucket.