### PR TITLE
Tweak the output of the `--print-table-refresh-command` flag for QC reports

### DIFF
--- a/dbt/README.md
+++ b/dbt/README.md
@@ -799,10 +799,10 @@ You should see output like this, which you can run in the context of the
 repository on the server in order to refresh iasWorld tables:
 
 ```
-ssh into the server and run the following commands:
+Run the following commands on the Data Team server:
 
 cd /path/to/service-spark-iasworld/
-docker-compose up -d
+docker compose up -d
 docker exec spark-node-master ./submit.sh --json-string --no-run-github-workflow
 '{"aprval": {"table_name": "iasworld.aprval", "min_year": 2024, "cur": ["Y"], ...
 ```

--- a/dbt/scripts/export_qc_town_close_reports.py
+++ b/dbt/scripts/export_qc_town_close_reports.py
@@ -193,10 +193,10 @@ def main():
 
             iasworld_deps[table_name] = formatted_dep
 
-        print("ssh into the server and run the following commands:")
+        print("Run the following commands on the Data Team server:")
         print()
         print("cd /home/shiny-server/services/service-spark-iasworld")
-        print("docker-compose up -d")
+        print("docker compose up -d")
         print(
             "docker exec spark-node-master ./submit.sh "
             "--no-run-github-workflow "


### PR DESCRIPTION
I noticed while doing a QC town close export run with @wrridgeway today that the output that the `export_qc_town_close_reports.py` script prints to the console when the `--print-table-refresh-command` flag is set is slightly incorrect in two ways:

1. It implies that the caller needs to shell into the server, whereas I am the only team member who needs to do this
2. It emits a legacy `docker-compose` CLI command instead of the newer `docker compose`

This PR fixes those two problems so that the `--print-table-refresh-command` output is more correct. We also update the docs in `dbt/README.md` to match this change.