### PR TITLE
Create CDU codes dbt seed and add CDU descriptions to `default.vw_pin_status`

### DIFF
--- a/dbt/macros/aggregate_cdu.sql
+++ b/dbt/macros/aggregate_cdu.sql
@@ -1,10 +1,20 @@
 -- Macro that aggregates CDUs to PIN-level. Strips out duplicate CDUs.
 {% macro aggregate_cdu(source_model, cdu_column) %}
     select
-        parid,
-        taxyr,
-        array_join(array_sort(array_distinct(array_agg({{ cdu_column }}))), ', ') as cdu
-    from {{ source_model }}
-    where {{ cdu_column }} is not null and cur = 'Y' and deactivat is null
-    group by parid, taxyr
+        source.parid,
+        source.taxyr,
+        array_join(
+            array_sort(array_distinct(array_agg(upper(source.{{ cdu_column }})))), ', '
+        ) as cdu_code,
+        array_join(
+            array_sort(array_distinct(array_agg(cdus.cdu_description))), ', '
+        ) as cdu_description
+    from {{ source_model }} as source
+    left join
+        {{ ref("ccao.cdu") }} as cdus on upper(source.{{ cdu_column }}) = cdus.cdu_code
+    where
+        source.{{ cdu_column }} is not null
+        and source.cur = 'Y'
+        and source.deactivat is null
+    group by source.parid, source.taxyr
 {% endmacro %}

--- a/dbt/models/default/default.vw_pin_status.sql
+++ b/dbt/models/default/default.vw_pin_status.sql
@@ -110,9 +110,12 @@ SELECT
     pdat.class = 'RR' AS is_railroad,
     ptst.test_type IS NOT NULL AS is_weird,
     ptst.test_type AS weird_flag_reason,
-    oby.cdu AS oby_cdu,
-    cdat.cdu AS comdat_cdu,
-    ddat.cdu AS dweldat_cdu,
+    oby.cdu_code AS oby_cdu_code,
+    oby.cdu_description AS oby_cdu_description,
+    cdat.cdu_code AS comdat_cdu_code,
+    cdat.cdu_description AS comdat_cdu_description,
+    ddat.cdu_code AS dweldat_cdu_code,
+    ddat.cdu_description AS dweldat_cdu_description,
     pdat.note2 AS pardat_note,
     pdat.class = '999' AS is_filler_class,
     pdat.parid LIKE '%999%' AS is_filler_pin
@@ -159,7 +162,7 @@ LEFT JOIN ({{ aggregate_cdu(
     AND pdat.taxyr = cdat.taxyr
 LEFT JOIN ({{ aggregate_cdu(
     source_model = source('iasworld', 'dweldat'),
-    cdu_column = 'cdu'
+    cdu_column = 'user16'
     ) }}) AS ddat
     ON pdat.parid = ddat.parid
     AND pdat.taxyr = ddat.taxyr

--- a/dbt/models/default/schema/default.vw_pin_status.yml
+++ b/dbt/models/default/schema/default.vw_pin_status.yml
@@ -5,10 +5,14 @@ models:
     columns:
       - name: class
         description: '{{ doc("shared_column_class") }}'
-      - name: comdat_cdu
+      - name: comdat_cdu_code
         description: CDU from `iasworld.comdat` table
-      - name: dweldat_cdu
+      - name: comdat_cdu_description
+        description: CDU code description for `comdat_cdu_description`
+      - name: dweldat_cdu_code
         description: CDU from `iasworld.dweldat` table
+      - name: dweldat_cdu_description
+        description: CDU code description for `dweldat_cdu_description`
       - name: is_ahsap
         description: '{{ doc("shared_column_is_ahsap") }}'
       - name: is_common_area
@@ -40,8 +44,10 @@ models:
         description: Parcel is in `ccao.pin_test`
       - name: is_zero_bill
         description: Parcel with a $0 property tax bill indicator
-      - name: oby_cdu
+      - name: oby_cdu_code
         description: CDU from `iasworld.oby` table
+      - name: oby_cdu_description
+        description: CDU code description for `oby_cdu_code`
       - name: pardat_note
         description: Pardat note field 2
       - name: parking_space_flag_reason

--- a/dbt/seeds/ccao/ccao.cdu.csv
+++ b/dbt/seeds/ccao/ccao.cdu.csv
@@ -1,8 +1,8 @@
 cdu_code,cdu_description
 AI,Affordable Housing LIHTC Program/Index Based Restriction/Special Assessment Program
-AI1,Affordable Housing Special Assessment Program – 15% Tier
-AI2,Affordable Housing Special Assessment Program – 35% Tier
-AI3,Affordable Housing Special Assessment Program – Low Affordability Community
+AI1,Affordable Housing Special Assessment Program - 15% Tier
+AI2,Affordable Housing Special Assessment Program - 35% Tier
+AI3,Affordable Housing Special Assessment Program - Low Affordability Community
 AI4,Affordable Housing LIHTC Program
 AP,Class 9 - Apartments
 AR,Air Rights

--- a/dbt/seeds/ccao/ccao.cdu.csv
+++ b/dbt/seeds/ccao/ccao.cdu.csv
@@ -1,0 +1,43 @@
+cdu_code,cdu_description
+AI,Affordable Housing LIHTC Program/Index Based Restriction/Special Assessment Program
+AI1,Affordable Housing Special Assessment Program – 15% Tier
+AI2,Affordable Housing Special Assessment Program – 35% Tier
+AI3,Affordable Housing Special Assessment Program – Low Affordability Community
+AI4,Affordable Housing LIHTC Program
+AP,Class 9 - Apartments
+AR,Air Rights
+AV,Average
+AX,Affordable Housing
+BB,Bed & Breakfast
+BF,6C- Brownfield
+CB,7B - Commercial Incentive
+CC,Class C - Commercial Incentive
+CL,Class C - Industrial Incentive
+CM,7A - Commercial Incentive
+CO,Cooperative
+CV,Class 5-90 Property
+EX,Exempt
+FR,Fair
+FV,Federal Veterans
+GD,Good
+GR,Garage
+LC,Class L - Commercial Landmark
+LD,Class L - Industrial Landmark
+LI,Class L - Industrial Landmark
+LL,Class L - Commercial Landmark
+LM,Class L - Multifamily Landmark
+LP,Class L - Not-for-Profit Landmark
+LR,Landmark Renovation
+MH,Model Home
+PB,6B - Industrial Incentive
+PR,Poor
+PX,Partial Exemption
+RC,Class 8- Commercial-Industrial Incentive
+RS,Recent Sale
+S,Class S - Multifamily
+SA,7A - Industrial Incentive
+SB,7B - Industrial Incentive
+SR,SRO
+UN,Unsound
+VG,Very Good
+VP,Very Poor

--- a/dbt/seeds/ccao/docs.md
+++ b/dbt/seeds/ccao/docs.md
@@ -17,6 +17,16 @@ Reason codes pertian to changes in AV.
 **Primary Key**: `reascd`
 {% enddocs %}
 
+# cdu
+
+{% docs seed_cdu %}
+Table containing CDU (Condition, Desirability, and Utility) codes and
+descriptions. CDUs come the `user16` columns in `comdat`, `dweldat`, and `oby`
+tables in `iasworld`.
+
+**Primary Key**: `cdu_code`
+{% enddocs %}
+
 # class_dict
 
 {% docs seed_class_dict %}

--- a/dbt/seeds/ccao/docs.md
+++ b/dbt/seeds/ccao/docs.md
@@ -21,7 +21,7 @@ Reason codes pertian to changes in AV.
 
 {% docs seed_cdu %}
 Table containing CDU (Condition, Desirability, and Utility) codes and
-descriptions. CDUs come the `user16` columns in `comdat`, `dweldat`, and `oby`
+descriptions. CDUs come from the `user16` columns in `comdat`, `dweldat`, and `oby`
 tables in `iasworld`.
 
 **Primary Key**: `cdu_code`

--- a/dbt/seeds/ccao/schema.yml
+++ b/dbt/seeds/ccao/schema.yml
@@ -9,6 +9,13 @@ seeds:
         reascd: string
         description: string
 
+  - name: ccao.cdu
+    description: '{{ doc("seed_cdu") }}'
+    config:
+      column_types:
+        cdu_code: string
+        cdu_description: string
+
   - name: ccao.class_dict
     description: '{{ doc("seed_class_dict") }}'
     config:


### PR DESCRIPTION
This PR:
 - Changes the `dweldat` column feeding `dweldat_cdu_code` in `default.vw_pin_status` to `user16`
 - Adds a CDU codes dbt seed with up-to-date CDU codes
 - Joins code descriptions onto `default.vw_pin_status`