### PR TITLE
Add comment about manual cleaning to `ccao-legacy.R` script

### DIFF
--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-legacy.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-legacy.R
@@ -272,6 +272,9 @@ files_cc_pifdb_piexemptre_ownr <- aws.s3::get_bucket_df(
 ) %>%
   filter(Size > 0)
 
+# Read the files into a single tibble. NOTE: these files are fixed-width
+# and have been MANUALLY CLEANED to remove some ASCII null characters that were
+# being used instead of spaces in the base year field
 cc_pifdb_piexemptre_ownr <- map_dfr(files_cc_pifdb_piexemptre_ownr$Key, \(f) {
   print(glue::glue("Transforming {f}"))
   aws.s3::s3read_using(


### PR DESCRIPTION
As part of the ongoing exemption comparison work, I had to manually clean the file that represented an export of the `OWNR ` table from the AS/400 to strip out some ASCII null characters that were being used instead of spaces (and thereby causing `reader::read_fwf()` to read the wrong column positions for those rows). This PR adds a single comment to the `ccao-legacy.R` script that processes that export to note for posterity that the export has been manually edited.