### PR TITLE
Exclude new uv venv path from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
         entry: >-
           sqlfmt -v dbt
             --exclude dbt/venv/**/*
+            --exclude dbt/.venv/**/*
             --exclude dbt/models/**/*
             --exclude dbt/target/**/*
             --exclude dbt/dbt_packages/**/*


### PR DESCRIPTION
This PR updates our pre-commit config to exclude the [new virtualenv path that we recommend folks use with uv](https://github.com/ccao-data/data-architecture/tree/master/dbt#install-dependencies) from linting. Without this change, sqlfmt will format files in the dbt virtualenv that uv creates for anyone who is using our new virtualenv system.