### PR TITLE
Rename permit job code fields to better align with iasWorld

### DIFF
--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -64,13 +64,13 @@ SELECT
     address.address_suffix_1,
     address.address_suffix_2,
     permit.user21 AS applicant_name,
-    permit.user42 AS job_code,
+    permit.why AS job_code_primary,
+    permit.user42 AS job_code_secondary,
     permit.user43 AS work_description,
     permit.user6 AS improvement_code_1,
     permit.user7 AS improvement_code_2,
     permit.user8 AS improvement_code_3,
     permit.user9 AS improvement_code_4,
-    permit.why AS permit_type,
     permit.id1 AS filing_type,
     permit.note3 AS notes
 FROM active_permits AS permit


### PR DESCRIPTION
This PR fixes a small mismatch in the `default.vw_pin_permit` view, wherein two fields (`permit_type` and `job_code`) were present in the view but had no docs while two other fields (`job_code_secondary` and `job_code_primary`) had docs but were not present in the view.

The key problem here is a renaming of field mappings that I neglected to complete in the docs:

| iasWorld fieldname | iasWorld display name | First draft view fieldname | Final draft view fieldname |
| ------------------- | ---------------------- | -------------------------- | -------------------------- |
| `WHY`                    | Pri Job Desc                | `job_code_primary`           | `permit_type`                    |
| `USER42`               | Sec Job Desc              | `job_code_secondary`      | `job_code`                         |

Looking on this choice, however, I think it's probably better for these fields to hew closer to the iasWorld display names, so this PR switches the names in the model to match the documentation.