### PR TITLE
Fix keypin column in commercial valuation data

### DIFF
--- a/etl/renv.lock
+++ b/etl/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.4.1",
+    "Version": "4.4.2",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -50,7 +50,7 @@
     },
     "MASS": {
       "Package": "MASS",
-      "Version": "7.3-60.2",
+      "Version": "7.3-61",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -61,11 +61,11 @@
         "stats",
         "utils"
       ],
-      "Hash": "2f342c46163b0b54d7b64d1f798e2c78"
+      "Hash": "0cafd6f0500e5deba33be22c46bf6055"
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.7-0",
+      "Version": "1.7-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -78,7 +78,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "1920b2f11133b12350024297d8a4ff4a"
+      "Hash": "5122bb14d8736372411f955e1b16bc8a"
     },
     "MatrixModels": {
       "Package": "MatrixModels",
@@ -375,7 +375,7 @@
     },
     "boot": {
       "Package": "boot",
-      "Version": "1.3-30",
+      "Version": "1.3-31",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -383,7 +383,7 @@
         "graphics",
         "stats"
       ],
-      "Hash": "96abeed416a286d4a0f52e550b612343"
+      "Hash": "de2a4646c18661d6a0a08ec67f40b7ed"
     },
     "brio": {
       "Package": "brio",
@@ -1887,7 +1887,7 @@
     },
     "nlme": {
       "Package": "nlme",
-      "Version": "3.1-164",
+      "Version": "3.1-166",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1897,7 +1897,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "a623a2239e642806158bc4dc3f51565d"
+      "Hash": "ccbb8846be320b627e6aa2b4616a2ded"
     },
     "nloptr": {
       "Package": "nloptr",

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-commercial_valuation.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-commercial_valuation.R
@@ -212,5 +212,6 @@ mutate(
   select(all_of(sort(names(.)))) %>%
   relocate(c(keypin, pins, township, year)) %>%
   relocate(c(file, sheet), .after = last_col()) %>%
+  distinct() %>%
   group_by(year) %>%
   write_partitions_to_s3(output_bucket, is_spatial = FALSE, overwrite = TRUE)

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-commercial_valuation.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-commercial_valuation.R
@@ -150,19 +150,12 @@ list.files(
   select(where(~ !all(is.na(.x)))) %>%
   # Add useful information to output and clean-up columns ----
   mutate(
+    keypin = str_trim(keypin),
     keypin = str_pad(keypin, side = "left", width = 14, pad = "0"),
-    keypin = ifelse(
-      nchar(keypin) == 14,
-      paste(
-        substr(keypin, 1, 2),
-        substr(keypin, 3, 4),
-        substr(keypin, 5, 7),
-        substr(keypin, 8, 10),
-        substr(keypin, 11, 14),
-        sep = "-"
-      ),
-      keypin
-    ),
+    keypin = map(keypin, \(x) {
+      ifelse(nchar(x) == 14, pin_format_pretty(x, full_length = TRUE), x)
+    }),
+    keypin = str_pad(keypin, side = "right", width = 18, pad = "0")),
     year = str_extract(file, "[0-9]{4}"),
     township = str_replace_all(
       str_extract(

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-commercial_valuation.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-commercial_valuation.R
@@ -155,7 +155,7 @@ list.files(
     keypin = map(keypin, \(x) {
       ifelse(nchar(x) == 14, pin_format_pretty(x, full_length = TRUE), x)
     }),
-    keypin = str_pad(keypin, side = "right", width = 18, pad = "0")),
+    keypin = str_pad(keypin, side = "right", width = 18, pad = "0"),
     year = str_extract(file, "[0-9]{4}"),
     township = str_replace_all(
       str_extract(


### PR DESCRIPTION
While adding commercial data documentation to the wiki I was trying to determine if there is a way to define primary keys for the data (I couldn't). I did, however, determine that there were some pretty bad values for `keypin` in the data. We try to clean this data as little as possible, but given the importance of `keypin`, it feels prudent to make sure we don't have rows with random notes or "TOTAL PINS" as `keypin`.

This PR reduces the size of the dataset by about 500 rows and cleans they `keypin` column in about 1000 more.