### PR TITLE
Fix `select_data_test_iasworld` selector by using set intersection

### DIFF
--- a/dbt/selectors.yml
+++ b/dbt/selectors.yml
@@ -3,15 +3,16 @@ selectors:
     description: Selector for running data tests on iasWorld tables
     definition:
       union:
-        - method: resource_type
-          value: test
-        - method: tag
-          value: data_test_iasworld
-          # Only run tests that exclusively reference selected nodes. Useful
-          # for avoiding an edge case where a test whose base model is not
-          # selected can run because it has an argument that references a model
-          # that _is_ selected.
-          indirect_selection: cautious
+        - intersection:
+          - method: resource_type
+            value: test
+          - method: tag
+            value: data_test_iasworld
+            # Only run tests that exclusively reference selected nodes. Useful
+            # for avoiding an edge case where a test whose base model is not
+            # selected can run because it has an argument that references a model
+            # that _is_ selected.
+            indirect_selection: cautious
         - exclude:
           - method: tag
             value: data_test_iasworld_exclude_from_workbook


### PR DESCRIPTION
This PR fixes a bug in our `select_data_test_iasworld` selector that I introduced in https://github.com/ccao-data/data-architecture/pull/638. The `resource_type:test` filter should be joined to the `tag:data_test_iasworld` filter using an [intersection](https://docs.getdbt.com/reference/node-selection/set-operators#intersections) rather than a [union](https://docs.getdbt.com/reference/node-selection/set-operators#unions). If we use a union instead, the selector will return _all_ data tests instead of only data tests tagged with `data_test_iasworld`. I noticed this while debugging a [failing workflow](https://github.com/ccao-data/data-architecture/actions/runs/11919381878/job/33218963393) that was running the wrong number of tests. I mixed this up because `union` has a special meaning the case of the [existing `exclude` filter](https://docs.getdbt.com/reference/node-selection/yaml-selectors#exclude), since that filter always returns a set difference.

I double-checked this change by inspecting the output of this query and confirming that the list of tests looked correct:

```
dbt list -q --selector select_data_test_iasworld
```

I also compared this to the non-YAML version of the selector to confirm they produce identical results:

```
dbt list -q --select tag:data_test_iasworld,resource_type:test --exclude tag:data_test_iasworld_exclude_from_workbook
```
