### PR TITLE
Remove rowid from `default.vw_pin_universe`

### DIFF
--- a/dbt/models/default/default.vw_pin_universe.sql
+++ b/dbt/models/default/default.vw_pin_universe.sql
@@ -31,7 +31,6 @@ WITH pardat_adjusted_years AS (
 
 SELECT
     -- Main PIN-level attribute data from iasWorld
-    CONCAT(par.parid, par.taxyr) AS row_id,
     par.parid AS pin,
     SUBSTR(par.parid, 1, 10) AS pin10,
     par.taxyr AS year,


### PR DESCRIPTION
This column was only needed in order to populate the open data asset Parcel Universe with a row id column, which is done. Moving forward row id will be generated on the fly by the github action used to update the open data asset.