### PR TITLE
Fix socrata api github action primary key handling

### DIFF
--- a/dbt/models/default/exposures.yml
+++ b/dbt/models/default/exposures.yml
@@ -75,8 +75,7 @@ exposures:
       test_row_count: true
       asset_id: wvhk-k5uv
       primary_key:
-        - doc_no
-        - pin
+        - sale_key
     description: |
       Parcel sales for real property in Cook County, from 1999 to present.
 

--- a/dbt/models/default/exposures.yml
+++ b/dbt/models/default/exposures.yml
@@ -93,7 +93,7 @@ exposures:
       name: Data Department
     meta:
       test_row_count: true
-      asset_id: nj4t-kc8j
+      asset_id: 4u8x-wdnz
       primary_key:
         - pin
         - year

--- a/dbt/models/default/exposures.yml
+++ b/dbt/models/default/exposures.yml
@@ -93,7 +93,7 @@ exposures:
       name: Data Department
     meta:
       test_row_count: true
-      asset_id: 4u8x-wdnz
+      asset_id: nj4t-kc8j
       primary_key:
         - pin
         - year

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -84,12 +84,12 @@ def build_query(
     columns = cursor.execute("show columns from " + athena_asset).as_pandas()
 
     # Limit pull to columns present in open data asset
-    new_url = (
+    asset_url = (
         "https://datacatalog.cookcountyil.gov/resource/"
         + asset_id
         + ".json?$limit=1"
     )
-    asset_columns = requests.get(new_url).json()[0].keys()
+    asset_columns = requests.get(asset_url).json()[0].keys()
 
     columns = columns[columns["column"].isin(asset_columns)]
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -89,6 +89,7 @@ def build_query(
         + asset_id
         + ".json?$limit=1"
     )
+    print(requests.get(asset_url).json())
     asset_columns = requests.get(asset_url).json()[0].keys()
     columns = columns[columns["column"].isin(asset_columns)]
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -114,13 +114,10 @@ def build_query(
         query = query
 
     elif years is not None and not township:
-        query += " WHERE year = %(year)s LIMIT 10000"
+        query += " WHERE year = %(year)s"
 
     elif years is not None and township is not None:
-        query += (
-            " WHERE year = %(year)s"
-            + " AND township_code = %(township)s LIMIT 10000"
-        )
+        query += " WHERE year = %(year)s" + " AND township_code = %(township)s"
 
     return query
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -89,8 +89,14 @@ def build_query(
         + asset_id
         + ".json?$limit=1"
     )
-    print(requests.get(asset_url).json())
-    asset_columns = requests.get(asset_url).json()[0].keys()
+
+    asset_columns = (
+        requests.get(
+            asset_url, headers={"X-App-Token": os.getenv("SOCRATA_APP_TOKEN")}
+        )
+        .json()[0]
+        .keys()
+    )
     columns = columns[columns["column"].isin(asset_columns)]
 
     # Array type columns are not compatible with the json format needed for

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -89,9 +89,7 @@ def build_query(
         + asset_id
         + ".json?$limit=1"
     )
-    print(asset_url)
     asset_columns = requests.get(asset_url).json()[0].keys()
-
     columns = columns[columns["column"].isin(asset_columns)]
 
     # Array type columns are not compatible with the json format needed for

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -24,7 +24,7 @@ def get_asset_info(socrata_asset):
     Simple helper function to retrieve asset-specific information from dbt.
     """
 
-    os.chdir("./dbt")
+    os.chdir("../dbt")
 
     DBT = dbtRunner()
     dbt_list_args = [
@@ -89,6 +89,7 @@ def build_query(
         + asset_id
         + ".json?$limit=1"
     )
+    print(asset_url)
     asset_columns = requests.get(asset_url).json()[0].keys()
 
     columns = columns[columns["column"].isin(asset_columns)]
@@ -328,8 +329,10 @@ def socrata_upload(
 
 # %%
 socrata_upload(
-    socrata_asset=os.getenv("SOCRATA_ASSET"),
-    overwrite=os.getenv("OVERWRITE"),
-    years=str(os.getenv("YEARS")).split(","),
-    by_township=os.getenv("BY_TOWNSHIP"),
+    socrata_asset="Parcel Sales",
+    overwrite="false",
+    years="2023",
+    by_township="true",
 )
+
+# %%

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -72,7 +72,10 @@ def build_query(athena_asset, row_identifier, years=None, township=None):
     passed to `row_identifiers`.
     """
 
-    row_identifier = f"CONCAT(CAST({' AS varchar), CAST('.join(row_identifier)} AS varchar)) AS row_id"
+    if len(row_identifier) > 1:
+        row_identifier = f"CONCAT(CAST({' AS varchar), CAST('.join(row_identifier)} AS varchar)) AS row_id"
+    else:
+        row_identifier = f"CAST({row_identifier[0]} AS varchar) AS row_id"
 
     # Retrieve column names and types from Athena
     columns = cursor.execute("show columns from " + athena_asset).as_pandas()

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -72,7 +72,7 @@ def build_query(athena_asset, row_identifier, years=None, township=None):
     passed to `row_identifiers`.
     """
 
-    row_identifier = f"CONCAT({', '.join(row_identifier)}) AS row_id"
+    row_identifier = f"CONCAT(CAST({' AS varchar), CAST('.join(row_identifier)} AS varchar)) AS row_id"
 
     # Retrieve column names and types from Athena
     columns = cursor.execute("show columns from " + athena_asset).as_pandas()

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -1,3 +1,4 @@
+# %%
 import contextlib
 import io
 import json
@@ -79,6 +80,29 @@ def build_query(athena_asset, row_identifier, years=None, township=None):
 
     # Retrieve column names and types from Athena
     columns = cursor.execute("show columns from " + athena_asset).as_pandas()
+
+    new_columns = [
+        "pin",
+        "year",
+        "township_code",
+        "nbhd",
+        "class",
+        "sale_date",
+        "is_mydec_date",
+        "sale_price",
+        "doc_no",
+        "deed_type",
+        "mydec_deed_type",
+        "seller_name",
+        "is_multisale",
+        "num_parcels_sale",
+        "buyer_name",
+        "sale_filter_same_sale_within_365",
+        "sale_filter_less_than_10k",
+        "sale_filter_deed_type",
+    ]
+
+    columns = columns[columns["column"].isin(new_columns)]
 
     # Array type columns are not compatible with the json format needed for
     # Socrata uploads. Automatically convert any array type columns to string.
@@ -310,6 +334,7 @@ def socrata_upload(
     print(f"Total upload in {toc - tic:0.4f} seconds")
 
 
+# %%
 socrata_upload(
     socrata_asset=os.getenv("SOCRATA_ASSET"),
     overwrite=os.getenv("OVERWRITE"),

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -167,8 +167,9 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
     # We grab the data before uploading it so we can make sure timestamps are
     # properly formatted
     input_data = cursor.execute(sql_query, query_conditionals).as_pandas()
-    input_data = input_data.select_dtypes(include="datetime").applymap(
-        lambda x: x.strftime("%Y-%m-%d %X")
+    date_columns = input_data.select_dtypes(include="datetime").columns
+    input_data[date_columns] = input_data[date_columns].map(
+        lambda x: x.strftime("%Y-%m-%dT%X")
     )
     input_data = input_data.to_json(orient="records")
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -95,10 +95,13 @@ def build_query(athena_asset, row_identifier, years=None, township=None):
         query = query
 
     elif years is not None and not township:
-        query += " WHERE year = %(year)s"
+        query += " WHERE year = %(year)s LIMIT 10000"
 
     elif years is not None and township is not None:
-        query += " WHERE year = %(year)s" + " AND township_code = %(township)s"
+        query += (
+            " WHERE year = %(year)s"
+            + " AND township_code = %(township)s LIMIT 10000"
+        )
 
     return query
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -1,4 +1,3 @@
-# %%
 import contextlib
 import io
 import json
@@ -75,10 +74,15 @@ def build_query(
     passed to `row_identifiers`.
     """
 
-    if len(row_identifier) > 1:
-        row_identifier = f"CONCAT(CAST({' AS varchar), CAST('.join(row_identifier)} AS varchar)) AS row_id"
-    else:
-        row_identifier = f"CAST({row_identifier[0]} AS varchar) AS row_id"
+    row_identifier_sql_parts = [
+        f"CAST({col} AS varchar)" for col in row_identifier
+    ]
+    row_identifier_sql_joined = (
+        row_identifier_sql_parts[0]
+        if len(row_identifier_sql_parts) == 1
+        else f"CONCAT({', '.join(row_identifier_sql_parts)})"
+    )
+    row_identifier = f"{row_identifier_sql_joined} AS row_id"
 
     # Retrieve column names and types from Athena
     columns = cursor.execute("show columns from " + athena_asset).as_pandas()
@@ -332,7 +336,6 @@ def socrata_upload(
     print(f"Total upload in {toc - tic:0.4f} seconds")
 
 
-# %%
 socrata_upload(
     socrata_asset=os.getenv("SOCRATA_ASSET"),
     overwrite=os.getenv("OVERWRITE"),

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -24,7 +24,7 @@ def get_asset_info(socrata_asset):
     Simple helper function to retrieve asset-specific information from dbt.
     """
 
-    os.chdir("../dbt")
+    os.chdir("./dbt")
 
     DBT = dbtRunner()
     dbt_list_args = [
@@ -329,10 +329,8 @@ def socrata_upload(
 
 # %%
 socrata_upload(
-    socrata_asset="Parcel Sales",
-    overwrite="false",
-    years="2023",
-    by_township="true",
+    socrata_asset=os.getenv("SOCRATA_ASSET"),
+    overwrite=os.getenv("OVERWRITE"),
+    years=str(os.getenv("YEARS")).split(","),
+    by_township=os.getenv("BY_TOWNSHIP"),
 )
-
-# %%


### PR DESCRIPTION
Well, this PR seems to address the issues that were blocking deployment of out Socrata SODA API github action from working on `default.vw_pin_sale` and its Open Data asset "Parcel Sales", but the outcome doesn't bode well for deploying the API script as an alternative for the socrata agent running on the server.

I can run the github action now [without any errors](https://github.com/ccao-data/data-architecture/actions/runs/12127852104/job/33813006378) _on small samples of data_. Anything large, we get our [connection reset](https://github.com/ccao-data/data-architecture/actions/runs/12127715772/job/33812565042) by Socrata's server. Perhaps I'm misunderstanding what's happening in those logs, but if I'm not, I'll have to reach out to them and see if there's any solution for this issue. In the meantime, these changes should get merged into master.

One more important thing to note: `default.vw_pin_sale` is no longer unique by pin and document number. We need to fix this.