### PR TITLE
Update docs to reflect new card code 5C

### DIFF
--- a/dbt/models/iasworld/columns.md
+++ b/dbt/models/iasworld/columns.md
@@ -228,8 +228,15 @@ Reason code for change of value.
 Possible values for this variable are:
 
 - `4` = Regular reduction (lasts until next triennial reassessment)
-- `5` = One year only market value relief (occupancy/vacancy reduction)
-- `5B` = One year only market value relief, issued by the Board of Review
+- `4B` = Regular reduction issued by the Board of Review (lasts until next
+  triennial reassessment)
+- `5` = One year only market value relief, implemented as an occupancy/vacancy
+  reduction
+- `5B` = One year only market value relief, implemented as an occupancy/vacancy
+  reduction, and issued by the Board of Review
+- `5C` = One year only market value relief, _not_ implemented as an
+  occupancy/vacancy reduction, and issued by the Board of Review
+
 {% enddocs %}
 
 ## cityname


### PR DESCRIPTION
This PR updates our docs for the `chgrsn`/`mktrsn` fields to reflect the new 5C value, which indicates a one-year Board reduction that is _not_ implemented via occupancy.

Note that I also double-checked our tests and QC reports to confirm that nothing else needs to change based on this new code.