### PR TITLE
Test urllib fix

### DIFF
--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -187,41 +187,21 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
         for i in range(0, input_data.shape[0], 10000):
             print(print_message)
             print(f"Rows {i + 1}-{i + 10000}")
-            if method == "put":
-                response = session.put(
-                    url=url,
-                    data=input_data.iloc[i : i + 10000].to_json(
-                        orient="records"
-                    ),
-                    headers={"X-App-Token": app_token},
-                )
-
-            elif method == "post":
-                response = session.post(
-                    url=url,
-                    data=input_data.iloc[i : i + 10000].to_json(
-                        orient="records"
-                    ),
-                    headers={"X-App-Token": app_token},
-                )
+            response = getattr(session, method)(
+                url=url,
+                data=input_data.iloc[i : i + 10000].to_json(orient="records"),
+                headers={"X-App-Token": app_token},
+            )
 
             print(response.content)
 
     else:
         print(print_message)
-        if method == "put":
-            response = session.put(
-                url=url,
-                data=input_data.to_json(orient="records"),
-                headers={"X-App-Token": app_token},
-            )
-
-        elif method == "post":
-            response = session.post(
-                url=url,
-                data=input_data.to_json(orient="records"),
-                headers={"X-App-Token": app_token},
-            )
+        response = getattr(session, method)(
+            url=url,
+            data=input_data.to_json(orient="records"),
+            headers={"X-App-Token": app_token},
+        )
 
         print(response.content)
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -95,19 +95,16 @@ def build_query(
     # Retrieve column names and types from Athena
     columns = cursor.execute("show columns from " + athena_asset).as_pandas()
 
-    # Limit pull to columns present in open data asset
-    asset_url = (
-        "https://datacatalog.cookcountyil.gov/resource/"
-        + asset_id
-        + ".json?$limit=1"
-    )
-
+    # Limit pull to columns present in open data asset - shouldn't change anything, but prevents failure if columns have become misaligned.
     asset_columns = (
-        s.get(
-            asset_url, headers={"X-App-Token": os.getenv("SOCRATA_APP_TOKEN")}
+        requests.get(
+            f"https://datacatalog.cookcountyil.gov/resource/{asset_id}"
         )
-        .json()[0]
-        .keys()
+        .headers["X-SODA2-Fields"]
+        .replace('"', "")
+        .strip("[")
+        .strip("]")
+        .split(",")
     )
     columns = columns[columns["column"].isin(asset_columns)]
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -2,6 +2,7 @@ import contextlib
 import io
 import json
 import os
+import socket
 import time
 
 import pandas as pd
@@ -9,6 +10,17 @@ import requests
 from dbt.cli.main import dbtRunner
 from pyathena import connect
 from pyathena.pandas.cursor import PandasCursor
+from urllib3.connection import HTTPConnection
+
+HTTPConnection.default_socket_options = (
+    HTTPConnection.default_socket_options
+    + [
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+        (socket.SOL_TCP, socket.TCP_KEEPIDLE, 45),
+        (socket.SOL_TCP, socket.TCP_KEEPINTVL, 10),
+        (socket.SOL_TCP, socket.TCP_KEEPCNT, 6),
+    ]
+)
 
 # Connect to Athena
 cursor = connect(

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -139,12 +139,7 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
     # Load environmental variables
     app_token = os.getenv("SOCRATA_APP_TOKEN")
 
-    url = (
-        "https://datacatalog.cookcountyil.gov/resource/"
-        + asset_id
-        + ".json?$$app_token="
-        + app_token
-    )
+    url = "https://datacatalog.cookcountyil.gov/resource/" + asset_id + ".json"
 
     print_message = "Overwriting" if overwrite else "Updating"
 
@@ -186,7 +181,7 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
         headers={"X-App-Token": app_token},
     ).raise_for_status()
 
-    session.get(url=url).raise_for_status()
+    session.get(url=url, headers={"X-App-Token": app_token}).raise_for_status()
 
     if input_data.shape[0] > 10000:
         for i in range(0, input_data.shape[0], 10000):
@@ -198,6 +193,7 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
                     data=input_data.iloc[i : i + 10000].to_json(
                         orient="records"
                     ),
+                    headers={"X-App-Token": app_token},
                 )
 
             elif method == "post":
@@ -206,6 +202,7 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
                     data=input_data.iloc[i : i + 10000].to_json(
                         orient="records"
                     ),
+                    headers={"X-App-Token": app_token},
                 )
 
             print(response.content)
@@ -216,12 +213,14 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
             response = session.put(
                 url=url,
                 data=input_data.to_json(orient="records"),
+                headers={"X-App-Token": app_token},
             )
 
         elif method == "post":
             response = session.post(
                 url=url,
                 data=input_data.to_json(orient="records"),
+                headers={"X-App-Token": app_token},
             )
 
         print(response.content)

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -12,7 +12,6 @@ from pyathena.pandas.cursor import PandasCursor
 
 # Create a session object so HTTP requests can be pooled
 session = requests.Session()
-session.verify = True
 session.auth = (
     str(os.getenv("SOCRATA_USERNAME")),
     str(os.getenv("SOCRATA_PASSWORD")),

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -195,7 +195,7 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
     if input_data.shape[0] > 10000:
         for i in range(0, input_data.shape[0], 10000):
             print(print_message)
-            print(f"Rows {i} - {i + 10000}.")
+            print(f"Rows {i + 1}-{i + 10000}")
             if method == "put":
                 response = s.put(
                     url=url,

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -1,3 +1,4 @@
+# %%
 import contextlib
 import io
 import json
@@ -13,7 +14,10 @@ from pyathena.pandas.cursor import PandasCursor
 # Create a session object so HTTP requests can be pooled
 s = requests.Session()
 s.verify = True
-s.auth = (os.getenv("SOCRATA_USERNAME"), os.getenv("SOCRATA_PASSWORD"))
+s.auth = (
+    str(os.getenv("SOCRATA_USERNAME")),
+    str(os.getenv("SOCRATA_PASSWORD")),
+)
 
 # Connect to Athena
 cursor = connect(
@@ -23,6 +27,7 @@ cursor = connect(
 ).cursor(unload=True)
 
 
+# %%
 def get_asset_info(socrata_asset):
     """
     Simple helper function to retrieve asset-specific information from dbt.

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -10,8 +10,10 @@ from dbt.cli.main import dbtRunner
 from pyathena import connect
 from pyathena.pandas.cursor import PandasCursor
 
+# Create a session object so HTTP requests can be pooled
 s = requests.Session()
 s.verify = True
+s.auth = (os.getenv("SOCRATA_USERNAME"), os.getenv("SOCRATA_PASSWORD"))
 
 # Connect to Athena
 cursor = connect(
@@ -137,7 +139,6 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
 
     # Load environmental variables
     app_token = os.getenv("SOCRATA_APP_TOKEN")
-    auth = (os.getenv("SOCRATA_USERNAME"), os.getenv("SOCRATA_PASSWORD"))
 
     url = (
         "https://datacatalog.cookcountyil.gov/resource/"
@@ -181,7 +182,6 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
     s.get(
         url=url,
         data=input_data,
-        auth=auth,
     ).raise_for_status()
 
     print(print_message)
@@ -189,14 +189,12 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
         response = s.put(
             url=url,
             data=input_data,
-            auth=auth,
         )
 
     elif method == "post":
         response = s.post(
             url=url,
             data=input_data,
-            auth=auth,
         )
 
     return response

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -194,9 +194,8 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
 
     if input_data.shape[0] > 10000:
         for i in range(0, input_data.shape[0], 10000):
-            print([i, i + 10000])
-
             print(print_message)
+            print(f"Rows {i} - {i + 10000}.")
             if method == "put":
                 response = s.put(
                     url=url,

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -184,7 +184,7 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
             + asset_id
             + ".json?$limit=1"
         ),
-        headers={"X-App-Token": os.getenv("SOCRATA_APP_TOKEN")},
+        headers={"X-App-Token": app_token},
     ).raise_for_status()
 
     session.get(url=url).raise_for_status()

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -183,23 +183,12 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
 
     session.get(url=url, headers={"X-App-Token": app_token}).raise_for_status()
 
-    if input_data.shape[0] > 10000:
-        for i in range(0, input_data.shape[0], 10000):
-            print(print_message)
-            print(f"Rows {i + 1}-{i + 10000}")
-            response = getattr(session, method)(
-                url=url,
-                data=input_data.iloc[i : i + 10000].to_json(orient="records"),
-                headers={"X-App-Token": app_token},
-            )
-
-            print(response.content)
-
-    else:
+    for i in range(0, input_data.shape[0], 10000):
         print(print_message)
+        print(f"Rows {i + 1}-{i + 10000}")
         response = getattr(session, method)(
             url=url,
-            data=input_data.to_json(orient="records"),
+            data=input_data.iloc[i : i + 10000].to_json(orient="records"),
             headers={"X-App-Token": app_token},
         )
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -11,9 +11,9 @@ from pyathena import connect
 from pyathena.pandas.cursor import PandasCursor
 
 # Create a session object so HTTP requests can be pooled
-s = requests.Session()
-s.verify = True
-s.auth = (
+session = requests.Session()
+session.verify = True
+session.auth = (
     str(os.getenv("SOCRATA_USERNAME")),
     str(os.getenv("SOCRATA_PASSWORD")),
 )
@@ -178,7 +178,7 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
     )
 
     # Raise URL status if it's bad
-    s.get(
+    session.get(
         (
             "https://datacatalog.cookcountyil.gov/resource/"
             + asset_id
@@ -187,14 +187,14 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
         headers={"X-App-Token": os.getenv("SOCRATA_APP_TOKEN")},
     ).raise_for_status()
 
-    s.get(url=url).raise_for_status()
+    session.get(url=url).raise_for_status()
 
     if input_data.shape[0] > 10000:
         for i in range(0, input_data.shape[0], 10000):
             print(print_message)
             print(f"Rows {i + 1}-{i + 10000}")
             if method == "put":
-                response = s.put(
+                response = session.put(
                     url=url,
                     data=input_data.iloc[i : i + 10000].to_json(
                         orient="records"
@@ -202,7 +202,7 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
                 )
 
             elif method == "post":
-                response = s.post(
+                response = session.post(
                     url=url,
                     data=input_data.iloc[i : i + 10000].to_json(
                         orient="records"
@@ -214,13 +214,13 @@ def upload(method, asset_id, sql_query, overwrite, year=None, township=None):
     else:
         print(print_message)
         if method == "put":
-            response = s.put(
+            response = session.put(
                 url=url,
                 data=input_data.to_json(orient="records"),
             )
 
         elif method == "post":
-            response = s.post(
+            response = session.post(
                 url=url,
                 data=input_data.to_json(orient="records"),
             )


### PR DESCRIPTION
This PR makes sure all column names are retrieved from an open data asset and that if any chunk sent to socrata is larger than 10,000 rows it gets sub-chunked into chunks with less than 10k rows.

It also uses a [session object from the requests library](https://requests.readthedocs.io/en/latest/user/advanced/) in order to pool connections. We were getting 500 errors in the past, possibly because too many requests were being sent, and switching to connection pooling resolved that.