### PR TITLE
Add line 9 ptax info to `default.vw_pin_sale`

### DIFF
--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -162,6 +162,22 @@ mydec_sales AS (
             NULLIF(TRIM(buyer_name), '') AS buyer_name,
             COALESCE(line_7_property_advertised = 1, FALSE)
                 AS mydec_property_advertised,
+            COALESCE(line_9_no_changes = 1, FALSE)
+                AS mydec_line_9_no_changes,
+            COALESCE(line_9_demolitiondamage = 1, FALSE)
+                AS mydec_line_9_demolition_damage,
+            COALESCE(line_9_additions = 1, FALSE)
+                AS mydec_line_9_additions,
+            COALESCE(line_9_major_remodeling = 1, FALSE)
+                AS mydec_line_9_major_remodeling,
+            COALESCE(line_9_new_construction = 1, FALSE)
+                AS mydec_line_9_new_construction,
+            COALESCE(line_9_other_change = 1, FALSE)
+                AS mydec_line_9_other_change,
+            COALESCE(line_9_other_description, FALSE)
+                AS mydec_line_9_other_description,
+            COALESCE(line_9_date_of_significant_change, FALSE)
+                AS mydec_line_9_date_of_significant_change,
             COALESCE(line_10a = 1, FALSE)
                 AS mydec_is_installment_contract_fulfilled,
             COALESCE(line_10b = 1, FALSE)
@@ -305,6 +321,14 @@ SELECT
     mydec_sales.mydec_deed_type,
     mydec_sales.sale_filter_ptax_flag,
     mydec_sales.mydec_property_advertised,
+    mydec_sales.mydec_line_9_no_changes,
+    mydec_sales.mydec_line_9_demolition_damage,
+    mydec_sales.mydec_line_9_additions,
+    mydec_sales.mydec_line_9_major_remodeling,
+    mydec_sales.mydec_line_9_new_construction,
+    mydec_sales.mydec_line_9_other_change,
+    mydec_sales.mydec_line_9_other_description,
+    mydec_sales.mydec_line_9_date_of_significant_change,
     mydec_sales.mydec_is_installment_contract_fulfilled,
     mydec_sales.mydec_is_sale_between_related_individuals_or_corporate_affiliates, -- noqa
     mydec_sales.mydec_is_transfer_of_less_than_100_percent_interest,

--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -174,8 +174,8 @@ mydec_sales AS (
                 AS mydec_line_9_new_construction,
             COALESCE(line_9_other_change = 1, FALSE)
                 AS mydec_line_9_other_change,
-            COALESCE(line_9_other_description, FALSE)
-                AS mydec_line_9_other_description,
+            COALESCE(line_9_other_change_description, FALSE)
+                AS mydec_line_9_other_change_description,
             COALESCE(line_9_date_of_significant_change, FALSE)
                 AS mydec_line_9_date_of_significant_change,
             COALESCE(line_10a = 1, FALSE)
@@ -327,7 +327,7 @@ SELECT
     mydec_sales.mydec_line_9_major_remodeling,
     mydec_sales.mydec_line_9_new_construction,
     mydec_sales.mydec_line_9_other_change,
-    mydec_sales.mydec_line_9_other_description,
+    mydec_sales.mydec_line_9_other_change_description,
     mydec_sales.mydec_line_9_date_of_significant_change,
     mydec_sales.mydec_is_installment_contract_fulfilled,
     mydec_sales.mydec_is_sale_between_related_individuals_or_corporate_affiliates, -- noqa

--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -174,9 +174,9 @@ mydec_sales AS (
                 AS mydec_line_9_new_construction,
             COALESCE(line_9_other_change = 1, FALSE)
                 AS mydec_line_9_other_change,
-            COALESCE(line_9_other_change_description, NULL)
+            line_9_other_change_description
                 AS mydec_line_9_other_change_description,
-            COALESCE(line_9_date_of_significant_change, NULL)
+            line_9_date_of_significant_change
                 AS mydec_line_9_date_of_significant_change,
             COALESCE(line_10a = 1, FALSE)
                 AS mydec_is_installment_contract_fulfilled,

--- a/dbt/models/default/default.vw_pin_sale.sql
+++ b/dbt/models/default/default.vw_pin_sale.sql
@@ -174,9 +174,9 @@ mydec_sales AS (
                 AS mydec_line_9_new_construction,
             COALESCE(line_9_other_change = 1, FALSE)
                 AS mydec_line_9_other_change,
-            COALESCE(line_9_other_change_description, FALSE)
+            COALESCE(line_9_other_change_description, NULL)
                 AS mydec_line_9_other_change_description,
-            COALESCE(line_9_date_of_significant_change, FALSE)
+            COALESCE(line_9_date_of_significant_change, NULL)
                 AS mydec_line_9_date_of_significant_change,
             COALESCE(line_10a = 1, FALSE)
                 AS mydec_is_installment_contract_fulfilled,

--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -17,6 +17,22 @@ models:
         description: Indicator for whether or not the observation uses the MyDec sale date
       - name: mydec_deed_type
         description: Deed type from MyDec, more granular than CCAO deed type
+      - name: mydec_line_9_additions
+        description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
+      - name: mydec_line_9_date_of_significant_change
+        description: The date of the change to the property.
+      - name: mydec_line_9_demolition_damage
+        description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
+      - name: mydec_line_9_major_remodeling
+        description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
+      - name: mydec_line_9_new_construction
+        description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
+      - name: mydec_line_9_no_changes
+        description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
+      - name: mydec_line_9_other_change
+        description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
+      - name: mydec_line_9_other_description
+        description: This field is used to describe the work done from mydec_line_9_other_change.
       - name: nbhd
         description: '{{ doc("shared_column_nbhd_code") }}'
       - name: num_parcels_sale

--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -35,7 +35,7 @@ models:
       - name: mydec_line_9_other_change
         description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
       - name: mydec_line_9_other_description
-        description: This field is used to describe the work done from mydec_line_9_other_change.
+        description: This field describes the work done from mydec_line_9_other_change.
       - name: nbhd
         description: '{{ doc("shared_column_nbhd_code") }}'
       - name: num_parcels_sale

--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -28,7 +28,10 @@ models:
       - name: mydec_line_9_new_construction
         description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
       - name: mydec_line_9_no_changes
-        description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
+        description: >
+          Binary indicator on the ptax-203 form. Indicates "no changes to the property" when coded as 1. A value of 0 may indicate either
+          the presence of changes (subcategories coded as 1) or an unclear status, as many cases have no subcategories coded as 1 despite
+          this being 0.
       - name: mydec_line_9_other_change
         description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
       - name: mydec_line_9_other_description


### PR DESCRIPTION
This PR adds line_9 ptax form columns to `default.vw_pin_sale`. We also add some docs for the columns in the schema directory.

Not sure if all columns should be added or just a subset. Currently I've added them all. Let me know @ccao-jardine @Damonamajor 