### PR TITLE
Update PUMA geoids for IHS data join

### DIFF
--- a/dbt/models/location/docs.md
+++ b/dbt/models/location/docs.md
@@ -20,8 +20,8 @@ parcel centroids.
 {% docs table_census_2020 %}
 Decennial Census geographies (tracts, block groups, etc.) intersected with
 parcel centroids from *all* years, not just those that existed in 2020. In
-actuality, we use 2022 geoids didn't update until then (currently applies just
-to IHS Housing Index data).
+actuality, we use 2022 since geoids didn't update until then (currently applies
+just to IHS Housing Index data).
 
 **Primary Key**: `pin10`, `year`
 {% enddocs %}

--- a/dbt/models/location/docs.md
+++ b/dbt/models/location/docs.md
@@ -15,15 +15,13 @@ parcel centroids.
 **Primary Key**: `pin10`, `year`
 {% enddocs %}
 
-# census_2010
+# census_2020
 
-{% docs table_census_2010 %}
+{% docs table_census_2020 %}
 Decennial Census geographies (tracts, block groups, etc.) intersected with
-parcel centroids from *all* years, not just those that existed in 2010. In
-actuality, we use 2012 since we don't have 2010 PUMA shapefiles. The
-purpose of this table is to be able to join data that uses static census
-geography over time to parcels from all years (currently just IHS Housing
-Index data).
+parcel centroids from *all* years, not just those that existed in 2020. In
+actuality, we use 2022 geoids didn't update until then (currently applies just
+to IHS Housing Index data).
 
 **Primary Key**: `pin10`, `year`
 {% enddocs %}

--- a/dbt/models/location/docs.md
+++ b/dbt/models/location/docs.md
@@ -20,8 +20,9 @@ parcel centroids.
 {% docs table_census_2020 %}
 Decennial Census geographies (tracts, block groups, etc.) intersected with
 parcel centroids from *all* years, not just those that existed in 2020. In
-actuality, we use 2022 since geoids didn't update until then (currently applies
-just to IHS Housing Index data).
+actuality, we use 2022 since geoids didn't update until then. The purpose of
+this table is to be able to join data that uses static census geography over time
+to parcels from all years (currently applies just to IHS Housing Index data).
 
 **Primary Key**: `pin10`, `year`
 {% enddocs %}

--- a/dbt/models/location/location.census_2020.sql
+++ b/dbt/models/location/location.census_2020.sql
@@ -1,5 +1,5 @@
--- This view only exists since the IHS House Price Index continues to use 2010
--- geoids past 2020.
+-- This view only exists since the IHS House Price Index uses 2020 geoids for
+-- for all years.
 
 {{
     config(
@@ -67,7 +67,7 @@ distinct_joined AS (
             ST_POINT(dp.x_3435, dp.y_3435),
             ST_GEOMFROMBINARY(cen.geometry_3435)
         )
-    WHERE cen.year = '2012' -- PUMA spatial data isn't available before 2012
+    WHERE cen.year = '2022' -- PUMA spatial data isn't available before 2012
     GROUP BY dp.x_3435, dp.y_3435, cen.year
 )
 

--- a/dbt/models/location/location.census_2020.sql
+++ b/dbt/models/location/location.census_2020.sql
@@ -67,7 +67,7 @@ distinct_joined AS (
             ST_POINT(dp.x_3435, dp.y_3435),
             ST_GEOMFROMBINARY(cen.geometry_3435)
         )
-    WHERE cen.year = '2022' -- PUMA spatial data isn't available before 2012
+    WHERE cen.year = '2022' -- PUMA geoids changed in 2022
     GROUP BY dp.x_3435, dp.y_3435, cen.year
 )
 

--- a/dbt/models/location/schema.yml
+++ b/dbt/models/location/schema.yml
@@ -5,8 +5,8 @@ models:
   - name: location.census
     description: '{{ doc("table_census") }}'
 
-  - name: location.census_2010
-    description: '{{ doc("table_census_2010") }}'
+  - name: location.census_2020
+    description: '{{ doc("table_census_2020") }}'
 
   - name: location.census_acs5
     description: '{{ doc("table_census_acs5") }}'

--- a/dbt/models/model/model.vw_pin_shared_input.sql
+++ b/dbt/models/model/model.vw_pin_shared_input.sql
@@ -74,13 +74,12 @@ housing_index AS (
         ihs.year,
         -- This is quarterly data and needs to be averaged annually
         AVG(CAST(ihs.ihs_index AS DOUBLE)) AS ihs_avg_year_index
-    FROM {{ source('other', 'ihs_index') }} AS ihs
-    LEFT JOIN
-        (SELECT DISTINCT
-            pin10,
-            census_puma_geoid
-        FROM {{ ref('location.census_2020') }}) AS puma
-        ON ihs.geoid = puma.census_puma_geoid
+    FROM (SELECT DISTINCT
+        pin10,
+        census_puma_geoid
+    FROM {{ ref('location.census_2020') }}) AS puma
+    LEFT JOIN {{ source('other', 'ihs_index') }} AS ihs
+        ON puma.census_puma_geoid = ihs.geoid
     GROUP BY puma.pin10, ihs.year
 ),
 

--- a/dbt/models/model/model.vw_pin_shared_input.sql
+++ b/dbt/models/model/model.vw_pin_shared_input.sql
@@ -63,19 +63,21 @@ acs5 AS (
     WHERE geography = 'tract'
 ),
 
-/* This CTAS uses location.census_2010 rather than joining onto a specific year
-from location.census because we need to join 2010 PUMA geometry to *all*
-parcels, not just those that existed in 2010 (or, in our case, 2012 since we
-don't have 2010 PUMA shapefiles). This is specific to the IHS data since it
+/* This CTAS uses location.census_2020 rather than joining onto a specific year
+from location.census because we need to join 2020 PUMA geometry to *all*
+parcels, not just those that existed in 2020 (or, in our case, 2022 since we
+don't have 2020 PUMA shapefiles). This is specific to the IHS data since it
 exists for many years but uses static geography. */
 housing_index AS (
     SELECT
         puma.pin10,
         ihs.year,
+        -- This is quarterly data and needs to be averaged annually
         AVG(CAST(ihs.ihs_index AS DOUBLE)) AS ihs_avg_year_index
     FROM {{ source('other', 'ihs_index') }} AS ihs
-    LEFT JOIN {{ ref('location.census_2010') }} AS puma
+    LEFT JOIN {{ ref('location.census_2020') }} AS puma
         ON ihs.geoid = puma.census_puma_geoid
+        AND ihs.year = puma.year
     GROUP BY puma.pin10, ihs.year
 ),
 

--- a/dbt/models/model/model.vw_pin_shared_input.sql
+++ b/dbt/models/model/model.vw_pin_shared_input.sql
@@ -80,6 +80,8 @@ housing_index AS (
     FROM {{ ref('location.census_2020') }}) AS puma
     LEFT JOIN {{ source('other', 'ihs_index') }} AS ihs
         ON puma.census_puma_geoid = ihs.geoid
+    -- Use ihs.year since the IHS time horizon is larger than that for available
+    -- census shapefiles
     GROUP BY puma.pin10, ihs.year
 ),
 


### PR DESCRIPTION
Right now `model.vw_pin_shared_input` is not being properly filled by `other.ihs_index`. This is because IHS has switched from using 2010 PUMA geoids to 2020 puma geoids, and we were using 2010 geoids to join these two tables together. This PR replaces `location.census_2010` with `location.census_2020` in order to make this join can function as it did previously.

```
library(DBI)
library(dplyr)
library(noctua)
library(mapview)
library(sf)

noctua_options(cache_size = 10, unload = TRUE)

AWS_ATHENA_CONN_NOCTUA <- dbConnect(
  noctua::athena(),
  rstudio_conn_tab = FALSE
)

dbGetQuery(
  conn = AWS_ATHENA_CONN_NOCTUA,
  "SELECT
    meta_pin,
    loc_longitude,
    loc_latitude,
    loc_census_acs5_puma_geoid
FROM z_ci_665_investigate_join_that_is_dropping_ihs_index_data_model.vw_pin_shared_input
where other_ihs_avg_year_index is null and loc_latitude is not null
    and meta_year = '2022'"
) %>%
  st_as_sf(coords = c("loc_longitude", "loc_latitude"), crs = st_crs(4326)) %>%
  mapview()
```

returns only geoids from the loop, [which is expected](https://price-index.housingstudies.org/), and fringes of the county.

![image](https://github.com/user-attachments/assets/110bf5bd-392c-4f7a-808f-617cfb268b68)
