### PR TITLE
Reduce threshold for row count test on `default.vw_card_res_char`

### DIFF
--- a/dbt/models/default/schema/default.vw_card_res_char.yml
+++ b/dbt/models/default/schema/default.vw_card_res_char.yml
@@ -112,7 +112,7 @@ models:
     data_tests:
       - row_count:
           name: default_vw_card_res_char_row_count
-          above: 28450044 # as of 2024-11-14
+          above: 28450039 # as of 2024-12-06
       - unique_combination_of_columns:
           name: default_vw_card_res_char_unique_by_pin_card_and_year
           combination_of_columns:


### PR DESCRIPTION
This PR fixes our [failing data integrity tests](https://github.com/ccao-data/data-architecture/actions/runs/12189451367/job/34004613229#step:7:275) by slightly reducing the threshold for the `row_count` test on `default.vw_card_res_char`.

The `default_vw_card_res_char_row_count` test first failed during the scheduled weekly data integrity tests on [11/25/24](https://github.com/ccao-data/data-architecture/actions/runs/12008766106/job/33472098003#step:7:265). The most recent confirmed pass prior to this date was during the scheduled run on [11/18/24](https://github.com/ccao-data/data-architecture/actions/runs/11891194724/job/33131443902#step:7:80). Here are the steps I took to build confidence that the test started failing due to changes in the underlying iasWorld data, and not in our models:

* I looked at [every commit that occurred in this date range](https://github.com/ccao-data/data-architecture/commits/master/?since=2024-11-18&until=2024-11-25) and compared them to the [dependency graph](https://ccao-data.github.io/data-architecture/#!/overview?g_v=1&g_i=%2Bdefault.vw_card_res_char) for `default.vw_card_res_char` to confirm that we didn't modify anything in the dependency chain during the date range
* I looked at the history for the [`default.vw_card_res_char` query](https://github.com/ccao-data/data-architecture/commits/master/dbt/models/default/default.vw_card_res_char.sql) and its [schema file](https://github.com/ccao-data/data-architecture/commits/master/dbt/models/default/schema/default.vw_card_res_char.yml), as well as its only model dependency `default.vw_pin_land` ([query](https://github.com/ccao-data/data-architecture/commits/master/dbt/models/default/default.vw_pin_land.sql) and [schema](https://github.com/ccao-data/data-architecture/commits/master/dbt/models/default/schema/default.vw_pin_land.yml)), and confirmed that nothing changed during the date range
* I checked out [the commit that would have been the head of the main branch when tests last passed](https://github.com/ccao-data/data-architecture/commit/e755ada923fa08df41f1d50ae60160d847408865), rebuilt `default.vw_card_res_char` and its dependencies in my dev environment, and confirmed that the test still fails

I'm happy to do more investigation into why this count changed if you have ideas, but given that it's just a change in 5 rows and that it almost certainly occurred in the underlying iasWorld data, I think A) it's not a big deal and B) I don't have any immediate ideas as to how we could investigate the iasWorld changes further.

See [this workflow run](https://github.com/ccao-data/data-architecture/actions/runs/12202382925/job/34042942589) for confirmation that the changes now cause the weekly data integrity tests to pass.