### PR TITLE
Make `vw_pin_appeal` unique by `pin`, `year`, `case_no`

### DIFF
--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -3,6 +3,8 @@
 -- CTE so that we can join reason descriptions onto cleaned reason codes and
 -- drop some dupes from htpar.
 WITH reasons AS (
+    -- Select distinct rows to deduplicate a few appeals that got published twice by accident,
+    -- otherwise we wouldn't expect any dupes in this query
     SELECT DISTINCT
         htpar.parid,
         htpar.taxyr,

--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -1,6 +1,7 @@
 -- View containing appeals by PIN
 
--- CTE so that we can join reason descriptions onto cleaned reason codes.
+-- CTE so that we can join reason descriptions onto cleaned reason codes and
+-- drop some dupes from htpar.
 WITH reasons AS (
     SELECT DISTINCT
         htpar.parid,
@@ -49,6 +50,7 @@ WITH reasons AS (
     WHERE htpar.cur = 'Y'
         AND htpar.deactivat IS NULL
         AND htpar.caseno IS NOT NULL
+        AND htpar.heartyp IN ('A', 'C')
 
 )
 

--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -123,4 +123,4 @@ LEFT JOIN {{ ref('ccao.htpar_reascd') }} AS reascd3
 WHERE reasons.cur = 'Y'
     AND reasons.caseno IS NOT NULL
     AND reasons.deactivat IS NULL
-    AND reasons.heartyp IN ('A', 'O', 'E', 'EE', 'P', 'S')
+    AND reasons.heartyp IN ('A', 'C')

--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -111,7 +111,9 @@ SELECT
         WHEN reasons.hrstatus = 'X' THEN 'closed pending c of e'
     END AS status
 FROM reasons
-LEFT JOIN {{ source('iasworld', 'pardat') }} AS pardat
+-- This is an INNER JOIN since there are apparently parcels in htpar that are
+-- not in pardat. See 31051000511064, 2008.
+INNER JOIN {{ source('iasworld', 'pardat') }} AS pardat
     ON reasons.parid = pardat.parid
     AND reasons.taxyr = pardat.taxyr
     AND pardat.cur = 'Y'

--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -123,4 +123,6 @@ LEFT JOIN {{ ref('ccao.htpar_reascd') }} AS reascd3
 WHERE reasons.cur = 'Y'
     AND reasons.caseno IS NOT NULL
     AND reasons.deactivat IS NULL
-    AND reasons.heartyp IN ('O', 'E', 'EE', 'P', 'S')
+    AND (
+        reasons.heartyp IN ('O', 'E', 'EE', 'P', 'S') OR reasons.heartyp IS NULL
+    )

--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -123,3 +123,4 @@ LEFT JOIN {{ ref('ccao.htpar_reascd') }} AS reascd3
 WHERE reasons.cur = 'Y'
     AND reasons.caseno IS NOT NULL
     AND reasons.deactivat IS NULL
+    AND reasons.heartyp IN ('O', 'E', 'EE', 'P', 'S')

--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -1,10 +1,19 @@
 -- View containing appeals by PIN
 
--- This CTE exists only so that we can join reason descriptions onto cleaned
--- reason codes.
+-- CTE so that we can join reason descriptions onto cleaned reason codes.
 WITH reasons AS (
-    SELECT
-        htpar.*,
+    SELECT DISTINCT
+        htpar.parid,
+        htpar.taxyr,
+        htpar.caseno,
+        htpar.user38,
+        htpar.user104,
+        htpar.resact,
+        htpar.hrstatus,
+        htpar.cpatty,
+        -- user125 isn't used in the view, but it's FilingID and we want to
+        -- include it to make sure we're only dropping true dupes using DISTINCT
+        htpar.user125,
         -- Reason codes come from different columns before and after 2020
         CASE
             WHEN htpar.taxyr <= '2020'
@@ -37,6 +46,11 @@ WITH reasons AS (
                 THEN REGEXP_REPLACE(htpar.user101, '[^[:alnum:]]', '')
         END AS reason_code3
     FROM {{ source('iasworld', 'htpar') }} AS htpar
+    WHERE htpar.cur = 'Y'
+        AND htpar.deactivat IS NULL
+        AND htpar.caseno IS NOT NULL
+        AND htpar.heartyp IN ('A', 'C')
+
 )
 
 SELECT
@@ -120,7 +134,3 @@ LEFT JOIN {{ ref('ccao.htpar_reascd') }} AS reascd2
     ON reasons.reason_code2 = reascd2.reascd
 LEFT JOIN {{ ref('ccao.htpar_reascd') }} AS reascd3
     ON reasons.reason_code3 = reascd3.reascd
-WHERE reasons.cur = 'Y'
-    AND reasons.caseno IS NOT NULL
-    AND reasons.deactivat IS NULL
-    AND reasons.heartyp IN ('A', 'C')

--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -123,6 +123,4 @@ LEFT JOIN {{ ref('ccao.htpar_reascd') }} AS reascd3
 WHERE reasons.cur = 'Y'
     AND reasons.caseno IS NOT NULL
     AND reasons.deactivat IS NULL
-    AND (
-        reasons.heartyp IN ('O', 'E', 'EE', 'P', 'S') OR reasons.heartyp IS NULL
-    )
+    AND reasons.heartyp IN ('A', 'O', 'E', 'EE', 'P', 'S')

--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -3,8 +3,8 @@
 -- CTE so that we can join reason descriptions onto cleaned reason codes and
 -- drop some dupes from htpar.
 WITH reasons AS (
-    -- Select distinct rows to deduplicate a few appeals that got published twice by accident,
-    -- otherwise we wouldn't expect any dupes in this query
+    -- Select distinct rows to deduplicate a few appeals that got published
+    -- twice by accident, otherwise we wouldn't expect any dupes in this query
     SELECT DISTINCT
         htpar.parid,
         htpar.taxyr,

--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -49,7 +49,6 @@ WITH reasons AS (
     WHERE htpar.cur = 'Y'
         AND htpar.deactivat IS NULL
         AND htpar.caseno IS NOT NULL
-        AND htpar.heartyp IN ('A', 'C')
 
 )
 

--- a/dbt/models/default/docs.md
+++ b/dbt/models/default/docs.md
@@ -51,7 +51,7 @@ reason, and results.
 - This view is _not_ unique by PIN and year, as a single PIN can have an
   appeal and CofE/omitted assessment in a given year.
 
-**Primary Key**: `year`, `pin`, `case_no`, `appeal_type`
+**Primary Key**: `year`, `pin`, `case_no`
 {% enddocs %}
 
 # vw_pin_condo_char

--- a/dbt/models/default/docs.md
+++ b/dbt/models/default/docs.md
@@ -51,7 +51,7 @@ reason, and results.
 - This view is _not_ unique by PIN and year, as a single PIN can have an
   appeal and CofE/omitted assessment in a given year.
 
-**Primary Key**: `year`, `pin`, `case_no`
+**Primary Key**: `year`, `pin`, `case_no`, `appeal_type`
 {% enddocs %}
 
 # vw_pin_condo_char

--- a/dbt/models/default/exposures.yml
+++ b/dbt/models/default/exposures.yml
@@ -11,6 +11,7 @@ exposures:
       test_row_count: true
       asset_id: y282-6ig3
       primary_key:
+        - case_no
         - pin
         - year
     description: |

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -45,7 +45,7 @@ models:
     data_tests:
       - row_count:
           name: default_vw_pin_appeal_row_count
-          above: 8815299 # as of 2024-11-14
+          above: 8757924 # as of 2024-12-09
       - unique_combination_of_columns:
           name: default_vw_pin_appeal_unique_by_14_digit_pin_year_caseno
           combination_of_columns:

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -45,7 +45,7 @@ models:
     data_tests:
       - row_count:
           name: default_vw_pin_appeal_row_count
-          above: 8757924 # as of 2024-12-09
+          above: 8755522 # as of 2024-12-09
       - unique_combination_of_columns:
           name: default_vw_pin_appeal_unique_by_14_digit_pin_year_caseno
           combination_of_columns:

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -46,6 +46,12 @@ models:
       - row_count:
           name: default_vw_pin_appeal_row_count
           above: 8815299 # as of 2024-11-14
+      - unique_combination_of_columns:
+          name: default_vw_pin_appeal_unique_by_14_digit_pin_year_caseno
+          combination_of_columns:
+            - pin
+            - year
+            - case_no
 
 unit_tests:
   - name: default_vw_pin_appeal_class_strips_non_alphanumerics

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -65,7 +65,7 @@ unit_tests:
           - {parid: "123", taxyr: "2024", cur: "Y", deactivat: null, class: "2.1-1)A"}
       - input: source("iasworld", "htpar")
         rows:
-          - {parid: "123", taxyr: "2024", cur: "Y", deactivat: null, cpatty: "1", caseno: "1"}
+          - {parid: "123", taxyr: "2024", cur: "Y", deactivat: null, cpatty: "1", caseno: "1", heartyp: "A", user125: "A", user38: "CC", user104: "A", resact: "A", hrstatus: "A", user100: "A", user101: "A", user89: "A"}
       - input: source("iasworld", "legdat")
         rows:
           - {parid: "123", taxyr: "2024", cur: "Y", deactivat: null}

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -65,7 +65,7 @@ unit_tests:
           - {parid: "123", taxyr: "2024", cur: "Y", deactivat: null, class: "2.1-1)A"}
       - input: source("iasworld", "htpar")
         rows:
-          - {parid: "123", taxyr: "2024", cur: "Y", deactivat: null, cpatty: "1", caseno: "1", heartyp: "A", user125: "A", user38: "CC", user104: "A", resact: "A", hrstatus: "A", user100: "A", user101: "A", user89: "A"}
+          - {parid: "123", taxyr: "2024", cur: "Y", deactivat: null, cpatty: "1", caseno: "1", heartyp: "A"}
       - input: source("iasworld", "legdat")
         rows:
           - {parid: "123", taxyr: "2024", cur: "Y", deactivat: null}

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -52,7 +52,6 @@ models:
             - pin
             - year
             - case_no
-            - appeal_type
 
 unit_tests:
   - name: default_vw_pin_appeal_class_strips_non_alphanumerics

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -78,6 +78,3 @@ unit_tests:
       - input: ref("ccao.htpar_reascd")
         rows:
           - {reascd: "28"}
-    expect:
-      rows:
-        - {class: "211A"}

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -52,6 +52,7 @@ models:
             - pin
             - year
             - case_no
+            - appeal_type
 
 unit_tests:
   - name: default_vw_pin_appeal_class_strips_non_alphanumerics

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -49,9 +49,9 @@ models:
       - unique_combination_of_columns:
           name: default_vw_pin_appeal_unique_by_14_digit_pin_year_caseno
           combination_of_columns:
+            - case_no
             - pin
             - year
-            - case_no
 
 unit_tests:
   - name: default_vw_pin_appeal_class_strips_non_alphanumerics

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -78,3 +78,6 @@ unit_tests:
       - input: ref("ccao.htpar_reascd")
         rows:
           - {reascd: "28"}
+    expect:
+      rows:
+        - {class: "211A"}

--- a/dbt/models/iasworld/columns.md
+++ b/dbt/models/iasworld/columns.md
@@ -413,6 +413,23 @@ Grade
 Group adjustment value
 {% enddocs %}
 
+## heartyp
+
+{% docs column_heartyp %}
+Appeal hearing type.
+
+Possible values for this variable are:
+
+- `A` = Current year appeal
+- `C` = Current appeal & certificate of error
+- `O` = Omitted Assessment
+- `E` = Certificate of error only
+- `EE` = Erroneous Exemptions
+- `P` = PTAB Refund
+- `S` = Specific Objection
+
+{% enddocs %}
+
 ## hga
 
 {% docs column_hga %}

--- a/dbt/models/iasworld/columns.md
+++ b/dbt/models/iasworld/columns.md
@@ -424,9 +424,9 @@ Possible values for this variable are:
 - `C` = Current appeal & certificate of error
 - `O` = Omitted Assessment
 - `E` = Certificate of error only
-- `EE` = Erroneous Exemptions
-- `P` = PTAB Refund
-- `S` = Specific Objection
+- `EE` = Erroneous exemption
+- `P` = PTAB refund
+- `S` = Specific objection
 
 {% enddocs %}
 

--- a/dbt/models/iasworld/schema/iasworld.htpar.yml
+++ b/dbt/models/iasworld/schema/iasworld.htpar.yml
@@ -101,7 +101,7 @@ sources:
           - name: hearoff
             description: Hearing official code
           - name: heartyp
-            description: Hearing type
+            description: '{{ doc("column_heartyp") }}'
           - name: heartypjur
             description: Hearing type jurisdiction
           - name: hrmult


### PR DESCRIPTION
`default.vw_pin_appeal` is not unique by `pin`, `year`, `case_no` as our docs suggest it should be. There are actual duplicates in `iasworld.htpar` that need to be removed. While I was trying to sort this out, Mirella told me we should also be much more parsimonious in terms of which values for `htpar.heartyp` we include in order to exclude things like PTAB adjustments and erroneous exemptions.

> Yes, the only hearing types you should be pulling if you are strictly focusing on appeal data are the ones listed below:
> 
> ![image](https://github.com/user-attachments/assets/5e39d8f8-b5e6-481e-afb3-78f867f71706)
> 
> O = Omitted Assessments, which are new for 2024 and by next year, there will the following new ones as well as others that will be used by the Tax side:
> 
> E = COE only
> 
> EE = Erroneous Exemptions (will likely change it to avoid conflict with E)
> 
> P = PTAB Refunds (Treasurer)
> 
> S = Specific Objections (Treasurer)

(After some initial confusion on my part, I confirmed she meant "only include 'A' and 'C'")

```
with new as (select year, count(*) as new from z_dev_wridgeway_default.vw_pin_appeal group by year),
old as (select year, count(*) as old from default.vw_pin_appeal group by year)

select new.year, new.new, old.old, new.new - old.old as diff from new
left join old on new.year = old.year
```

year | new | old | diff
-- | -- | -- | --
2024 | 405164 | 435781 | -30617
2023 | 243427 | 273843 | -30416
2022 | 302331 | 302820 | -489
2021 | 373640 | 373991 | -351
2020 | 238032 | 238034 | -2
2019 | 389870 | 391241 | -1371
2018 | 531406 | 534183 | -2777
2017 | 370217 | 373983 | -3766
2016 | 446840 | 451081 | -4241
2015 | 522393 | 526499 | -4106
2014 | 340849 | 345294 | -4445
2013 | 412460 | 416041 | -3581
2012 | 392624 | 392637 | -13
2011 | 317394 | 323076 | -5682
2010 | 353612 | 359586 | -5974
2009 | 449028 | 454532 | -5504
2008 | 315669 | 321696 | -6027
2007 | 336394 | 342098 | -5704
2006 | 355976 | 359159 | -3183
2005 | 232970 | 237025 | -4055
2004 | 288567 | 294421 | -5854
2003 | 318327 | 320938 | -2611
2002 | 232716 | 235919 | -3203
2001 | 198419 | 200379 | -1960
2000 | 230578 | 232583 | -2005
1999 | 156619 | 158653 | -2034

```
select pin, year, case_no
from z_ci_make_vw_pin_appeal_unique_default.vw_pin_appeal
group by pin, year, case_no
having(count(*) > 1)
```

yields zero rows.