### PR TITLE
Tweak thresholds and number of allowed dupes for duplicate tests against sale views

### DIFF
--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -78,9 +78,9 @@ models:
           combination_of_columns:
             - pin
             - year
-          allowed_duplicates: 2
+          allowed_duplicates: 5
           config:
-            error_if: ">4500"
+            error_if: ">1000"
       - row_count:
           name: default_vw_pin_sale_row_count
           above: 2496073 # as of 2024-11-14

--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -80,7 +80,7 @@ models:
             - year
           allowed_duplicates: 2
           config:
-            error_if: ">5000"
+            error_if: ">4500"
       - row_count:
           name: default_vw_pin_sale_row_count
           above: 2496073 # as of 2024-11-14

--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -80,7 +80,7 @@ models:
             - year
           allowed_duplicates: 2
           config:
-            error_if: ">7319"
+            error_if: ">5000"
       - row_count:
           name: default_vw_pin_sale_row_count
           above: 2496073 # as of 2024-11-14

--- a/dbt/models/default/schema/default.vw_pin_sale_combined.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale_combined.yml
@@ -87,9 +87,10 @@ models:
           combination_of_columns:
             - pin
             - year
+            - source
           allowed_duplicates: 2
           config:
-            error_if: ">7319"
+            error_if: ">5000"
       - row_count:
           name: default_vw_pin_sale_combined_row_count
           above: 2496073 # as of 2024-11-14

--- a/dbt/models/default/schema/default.vw_pin_sale_combined.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale_combined.yml
@@ -87,10 +87,9 @@ models:
           combination_of_columns:
             - pin
             - year
-            - source
           allowed_duplicates: 2
           config:
-            error_if: ">5000"
+            error_if: ">7500"
       - row_count:
           name: default_vw_pin_sale_combined_row_count
           above: 2496073 # as of 2024-11-14

--- a/dbt/models/default/schema/default.vw_pin_sale_combined.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale_combined.yml
@@ -87,9 +87,9 @@ models:
           combination_of_columns:
             - pin
             - year
-          allowed_duplicates: 2
+          allowed_duplicates: 5
           config:
-            error_if: ">7500"
+            error_if: ">1500"
       - row_count:
           name: default_vw_pin_sale_combined_row_count
           above: 2496073 # as of 2024-11-14


### PR DESCRIPTION
Currently, the error threshold for `vw_pin_sale_combined` is so close to the total count of failing records that if any new records with dupes get added (even if the dupes are expected) [it will cause the whole test to fail](https://github.com/ccao-data/data-architecture/actions/runs/12234395035/job/34123504238#step:7:274). On the other hand, the threshold for `vw_pin_sale` is much higher than the actual count, such that we might accidentally miss a problem if it's subtle enough. Both of these cases are problems since we only want the test to fail if we've changed something with the view that causes us to create artificial dupes. This PR bumps the number of allowed dupes for both tests and lines their thresholds up more consistently with the current number of failures, with the goal of having them only fail if a large number of unexpected duplicates appears all at once.

I think it's somewhat of a structural problem with these tests that a large batch of new sales could cause them to fail, simply due to the fact that we expect some duplicates beyond the threshold. IMO, a deeper fix would be to figure out a test that checks what we want to check (did we make a change to the view that introduces a lot of unexpected dupes?) without surfacing problems in the underlying data that we have no control over. For now, however, I think the easiest thing to do is just tweak the thresholds.