### PR TITLE
Fix dbt docs deployment for new Ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -31,14 +31,16 @@ jobs:
         uses: actions/setup-node@v4
 
       - name: Install docs build dependencies
-        run: |
-          npm install -g @mermaid-js/mermaid-cli
-          npx puppeteer browsers install chrome-headless-shell
+        run: npm install -g @mermaid-js/mermaid-cli
 
       - name: Prepare Mermaid assets for docs
         run: |
           for file in assets/*.mmd; do
-            mmdc -i "$file" -o "${file/.mmd/.svg}"
+            # Confine the mermaid process to an AppArmor profile, necessary on
+            # Ubuntu >= 23.10 to work around new AppArmor rules that block the
+            # Puppeteer sanbox (used by mermaid) from working. See:
+            # https://github.com/mermaid-js/mermaid-cli/issues/730#issuecomment-2408615110
+            aa-exec --profile=chrome mmdc -i "$file" -o "${file/.mmd/.svg}"
           done
         working-directory: ${{ env.PROJECT_DIR }}
         shell: bash

--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -31,7 +31,9 @@ jobs:
         uses: actions/setup-node@v4
 
       - name: Install docs build dependencies
-        run: npm install -g @mermaid-js/mermaid-cli
+        run: |
+          npm install -g @mermaid-js/mermaid-cli
+          npx puppeteer browsers install chrome-headless-shell
 
       - name: Prepare Mermaid assets for docs
         run: |

--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -38,7 +38,7 @@ jobs:
           for file in assets/*.mmd; do
             # Confine the mermaid process to an AppArmor profile, necessary on
             # Ubuntu >= 23.10 to work around new AppArmor rules that block the
-            # Puppeteer sanbox (used by mermaid) from working. See:
+            # Puppeteer sandbox (used by mermaid) from working. See:
             # https://github.com/mermaid-js/mermaid-cli/issues/730#issuecomment-2408615110
             aa-exec --profile=chrome mmdc -i "$file" -o "${file/.mmd/.svg}"
           done


### PR DESCRIPTION
Now that our GitHub runners are on Ubuntu 24.04, the Mermaid diagram generation in our dbt docs deployment pipeline [is breaking](https://github.com/ccao-data/data-architecture/actions/runs/12362955038/job/34503342849#step:6:28) due to [an obscure AppArmor rule change](https://github.com/mermaid-js/mermaid-cli/issues/730#issuecomment-2408615110) that affects Puppeteer sandboxes. This PR implements the recommended solution from that issue by using [`aa-exec`](https://manpages.ubuntu.com/manpages/noble/man1/aa-exec.1.html) to confine the Mermaid process to a dedicated profile.

Full disclosure: I don't totally understand what's going on with this AppArmor rule change, but I think the stakes are pretty low, since we're only using Puppeteer via [mermaid](https://github.com/mermaid-js/mermaid-cli) to load diagrams and save them to SVG, meaning we shouldn't be browsing the public internet or running untrusted code anyway. This also seems to be the recommended solution according to a Mermaid maintainer, per the link above.

See [this workflow run](https://github.com/ccao-data/data-architecture/actions/runs/12363184962/job/34504016234) for evidence that this change resolves the problem.