### PR TITLE
673 add dbt data integrity tests to the model database tables

### DIFF
--- a/dbt/models/model/docs.md
+++ b/dbt/models/model/docs.md
@@ -77,7 +77,7 @@ If hyperparameters are blank for a given run, then that parameter was not used.
 Range of hyperparameters searched by a given model run (`run_id`)
 during cross-validation.
 
-**Primary Key**: `year`, `run_id`
+**Primary Key**: `year`, `run_id`, `parameter_name`
 {% enddocs %}
 
 # parameter_search

--- a/dbt/models/model/docs.md
+++ b/dbt/models/model/docs.md
@@ -34,7 +34,7 @@ Overall feature importance by model run (`run_id`).
 Includes metrics such as gain, cover, and frequency. This is the output
 of the built-in LightGBM/XGBoost feature importance methods.
 
-**Primary Key**: `year`, `run_id`, `model_predictor_name_all`
+**Primary Key**: `year`, `run_id`, `model_predictor_all_name`
 {% enddocs %}
 
 # final_model
@@ -113,7 +113,7 @@ The stages are:
 Identical to `model.performance`, but additionally broken out by quantile.
 
 **Primary Key**: `year`, `run_id`, `stage`, `triad_code`, `geography_type`,
-`geography_id`, `by_class`, `quantile`
+`geography_id`, `class`, `quantile`, `num_quantile`
 {% enddocs %}
 
 # shap

--- a/dbt/models/model/docs.md
+++ b/dbt/models/model/docs.md
@@ -113,7 +113,7 @@ The stages are:
 Identical to `model.performance`, but additionally broken out by quantile.
 
 **Primary Key**: `year`, `run_id`, `stage`, `triad_code`, `geography_type`,
-`geography_id`, `class`, `quantile`, `num_quantile`
+`geography_id`, `quantile`
 {% enddocs %}
 
 # shap

--- a/dbt/models/model/docs.md
+++ b/dbt/models/model/docs.md
@@ -99,7 +99,7 @@ Includes breakouts for many levels of geography, as well as different "stages".
 The stages are:
 
 - `test` - Performance on the out-of-sample test set (typically the
-  most recent 10% of sales)
+  most recent 10% of sales)s
 - `assessment` - Performance on the most recent year of sales (after being
   trained on all sales, so in-sample)
 
@@ -113,7 +113,7 @@ The stages are:
 Identical to `model.performance`, but additionally broken out by quantile.
 
 **Primary Key**: `year`, `run_id`, `stage`, `triad_code`, `geography_type`,
-`geography_id`, `by_class`, `quantile`
+`geography_id`, `by_class`, `num_quantile`, `quantile`
 {% enddocs %}
 
 # shap

--- a/dbt/models/model/docs.md
+++ b/dbt/models/model/docs.md
@@ -113,7 +113,7 @@ The stages are:
 Identical to `model.performance`, but additionally broken out by quantile.
 
 **Primary Key**: `year`, `run_id`, `stage`, `triad_code`, `geography_type`,
-`geography_id`, `quantile`
+`geography_id`, `by_class`, `quantile`
 {% enddocs %}
 
 # shap

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -6,59 +6,152 @@ sources:
         description: '{{ doc("table_assessment_card") }}'
         tags:
           - load_auto
-
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_assessment_card_unique_by_pin_card_and_year
+              combination_of_columns:
+                - meta_pin
+                - meta_card_num
+                - meta_year
+                - run_id
+                
       - name: assessment_pin
         description: '{{ doc("table_assessment_pin") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_assessment_pin_unique_by_pin_and_year
+              combination_of_columns:
+                - meta_pin
+                - meta_year
+                - run_id
         tags:
           - load_auto
 
       - name: feature_importance
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_feature_importance_unique_by_pin_and_year_model_predictor_all_name
+              combination_of_columns:
+                - year
+                - run_id
+                - model_predictor_all_name
         description: '{{ doc("table_feature_importance") }}'
         tags:
           - load_auto
 
       - name: metadata
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_metadata_unique_by_pin_and_year_township_code_coverage
+              combination_of_columns:
+                - year
+                - run_id
         description: '{{ doc("table_metadata") }}'
         tags:
           - load_auto
 
       - name: parameter_final
         description: '{{ doc("table_parameter_final") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_parameter_final_unique_by_year_and_run_id
+              combination_of_columns:
+                - year
+                - run_id
         tags:
           - load_auto
 
       - name: parameter_range
         description: '{{ doc("table_parameter_range") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_parameter_range_unique_by_year_run_id
+              combination_of_columns:
+                - year
+                - run_id
         tags:
           - load_auto
 
       - name: parameter_search
         description: '{{ doc("table_parameter_search") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_parameter_search_unique_by_year_and_run_id
+              combination_of_columns:
+                - year
+                - run_id
+                - iteration
         tags:
           - load_auto
 
       - name: performance
         description: '{{ doc("table_performance") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_performance_unique_by_year_run_id_stage_triad_code_geography_type_geography_id_class
+              combination_of_columns:
+                - year
+                - run_id
+                - stage
+                - triad_code
+                - geography_type
+                - geography_id
+                - class
         tags:
           - load_auto
 
       - name: performance_quantile
         description: '{{ doc("table_performance_quantile") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_performance_quantile_unique_by_year_run_id_stage_triad_code_geography_type_geography_id_class_quantile_num_quantile
+              combination_of_columns:
+                - year
+                - run_id
+                - triad_code
+                - stage
+                - geography_type
+                - geography_id
+                - class
+                - num_quantile
+                - quantile
         tags:
           - load_auto
 
       - name: shap
         description: '{{ doc("table_shap") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_shap_unique_by_year_run_id_meta_pin_meta_card_num
+              combination_of_columns:
+                - year
+                - run_id
+                - meta_pin
+                - meta_card_num
         tags:
           - load_auto
 
       - name: test_card
         description: '{{ doc("table_test_card") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_test_card_unique_by_year_run_id_meta_pin_meta_card_num
+              combination_of_columns:
+                - year
+                - run_id
+                - meta_pin
+                - meta_card_num
         tags:
           - load_auto
 
       - name: timing
         description: '{{ doc("table_timing") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: model_timing_unique_by_year_run_id
+              combination_of_columns:
+                - year
+                - run_id
         tags:
           - load_auto
 
@@ -104,7 +197,6 @@ models:
       - name: note
         description: |
           Any notes or caveats associated with the model run
-
   - name: model.vw_pin_shared_input
     description: '{{ doc("view_vw_pin_shared_input") }}'
     columns:

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -150,7 +150,7 @@ sources:
         description: '{{ doc("table_shap") }}'
         data_tests:
           - unique_combination_of_columns:
-              name: model_shap_unique_by_year_run_id_meta_pin_meta_card_num
+              name: model_shap_unique_by_year_run_id_meta_pin_meta_and_card_num
               combination_of_columns:
                 - year
                 - run_id

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -132,7 +132,9 @@ sources:
                 - num_quantile
                 - quantile
               meta:
-                description: performance quantile should be unique by year, run_id, stage, triad_code, geography_type, geography_id, class, num_quantile, and quantile
+                description: >
+                  performance quantile should be unique by year, run_id, stage, triad_code,
+                  geography_type, geography_id, class, num_quantile, and quantile
         tags:
           - load_auto
 

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -120,7 +120,7 @@ sources:
         description: '{{ doc("table_performance_quantile") }}'
         data_tests:
           - unique_combination_of_columns:
-              name: model_performance_quantile_unique_by_year_run_id_stage_triad_code_geography_type_geography_id_class_quantile_num_quantile
+              name: model_performance_quantile_unique_by_year_run_id_stage_triad_code_geography_type_geography_id_quantile
               combination_of_columns:
                 - year
                 - run_id
@@ -128,13 +128,11 @@ sources:
                 - stage
                 - geography_type
                 - geography_id
-                - class
-                - num_quantile
                 - quantile
               meta:
                 description: >
                   performance quantile should be unique by year, run_id, stage, triad_code,
-                  geography_type, geography_id, class, num_quantile, and quantile
+                  geography_type, geography_id, and quantile
         tags:
           - load_auto
 

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -38,7 +38,7 @@ sources:
       - name: feature_importance
         data_tests:
           - unique_combination_of_columns:
-              name: model_feature_importance_unique_by_pin_and_year_model_predictor_all_name
+              name: model_feature_importance_unique
               combination_of_columns:
                 - year
                 - run_id
@@ -110,7 +110,7 @@ sources:
         description: '{{ doc("table_performance") }}'
         data_tests:
           - unique_combination_of_columns:
-              name: model_performance_unique_by_year_run_id_stage_triad_code_geography_type_geography_id_class
+              name: model_performance_unique
               combination_of_columns:
                 - year
                 - run_id
@@ -128,7 +128,7 @@ sources:
         description: '{{ doc("table_performance_quantile") }}'
         data_tests:
           - unique_combination_of_columns:
-              name: model_performance_quantile_unique_by_year_run_id_stage_triad_code_geography_type_geography_id_class_num_quantile_quantile
+              name: model_performance_quantile_unique
               combination_of_columns:
                 - year
                 - run_id
@@ -167,7 +167,7 @@ sources:
         description: '{{ doc("table_test_card") }}'
         data_tests:
           - unique_combination_of_columns:
-              name: model_test_card_unique_by_year_run_id_meta_pin_meta_card_num
+              name: model_test_card_unique
               combination_of_columns:
                 - year
                 - run_id

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -14,7 +14,6 @@ sources:
                 - meta_card_num
                 - meta_year
                 - run_id
-                
       - name: assessment_pin
         description: '{{ doc("table_assessment_pin") }}'
         data_tests:
@@ -26,7 +25,6 @@ sources:
                 - run_id
         tags:
           - load_auto
-
       - name: feature_importance
         data_tests:
           - unique_combination_of_columns:
@@ -38,7 +36,6 @@ sources:
         description: '{{ doc("table_feature_importance") }}'
         tags:
           - load_auto
-
       - name: metadata
         data_tests:
           - unique_combination_of_columns:
@@ -49,7 +46,6 @@ sources:
         description: '{{ doc("table_metadata") }}'
         tags:
           - load_auto
-
       - name: parameter_final
         description: '{{ doc("table_parameter_final") }}'
         data_tests:
@@ -60,7 +56,6 @@ sources:
                 - run_id
         tags:
           - load_auto
-
       - name: parameter_range
         description: '{{ doc("table_parameter_range") }}'
         data_tests:
@@ -71,7 +66,6 @@ sources:
                 - run_id
         tags:
           - load_auto
-
       - name: parameter_search
         description: '{{ doc("table_parameter_search") }}'
         data_tests:
@@ -83,7 +77,6 @@ sources:
                 - iteration
         tags:
           - load_auto
-
       - name: performance
         description: '{{ doc("table_performance") }}'
         data_tests:
@@ -99,7 +92,6 @@ sources:
                 - class
         tags:
           - load_auto
-
       - name: performance_quantile
         description: '{{ doc("table_performance_quantile") }}'
         data_tests:
@@ -117,7 +109,6 @@ sources:
                 - quantile
         tags:
           - load_auto
-
       - name: shap
         description: '{{ doc("table_shap") }}'
         data_tests:
@@ -130,7 +121,6 @@ sources:
                 - meta_card_num
         tags:
           - load_auto
-
       - name: test_card
         description: '{{ doc("table_test_card") }}'
         data_tests:
@@ -144,7 +134,6 @@ sources:
                 - meta_sale_document_num
         tags:
           - load_auto
-
       - name: timing
         description: '{{ doc("table_timing") }}'
         data_tests:

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -76,7 +76,7 @@ sources:
         description: '{{ doc("table_parameter_search") }}'
         data_tests:
           - unique_combination_of_columns:
-              name: model_parameter_search_unique_by_year_and_run_id
+              name: model_parameter_search_unique_by_year_run_id_and_iteration
               combination_of_columns:
                 - year
                 - run_id
@@ -141,6 +141,7 @@ sources:
                 - run_id
                 - meta_pin
                 - meta_card_num
+                - meta_sale_document_num
         tags:
           - load_auto
 

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -79,12 +79,11 @@ sources:
         description: '{{ doc("table_parameter_range") }}'
         data_tests:
           - unique_combination_of_columns:
-              name: model_parameter_range_unique_by_year_run_id
+              name: model_parameter_range_unique_by_year_run_id_and_parameter_name
               combination_of_columns:
                 - year
                 - run_id
-              config:
-                  error_if: ">84"
+                - parameter_name
               meta:
                 description: parameter range should be unique by year and run_id
         tags:

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -4,8 +4,6 @@ sources:
     tables:
       - name: assessment_card
         description: '{{ doc("table_assessment_card") }}'
-        tags:
-          - load_auto
         data_tests:
           - unique_combination_of_columns:
               name: model_assessment_card_unique_by_pin_card_and_year
@@ -14,6 +12,11 @@ sources:
                 - meta_card_num
                 - meta_year
                 - run_id
+              meta:
+                description: assessment card should be unique by pin, card, year, and run_id
+        tags:
+          - load_auto
+
       - name: assessment_pin
         description: '{{ doc("table_assessment_pin") }}'
         data_tests:
@@ -23,8 +26,11 @@ sources:
                 - meta_pin
                 - meta_year
                 - run_id
+              meta:
+                description: assessment pin should be unique by pin, year, and run_id
         tags:
           - load_auto
+
       - name: feature_importance
         data_tests:
           - unique_combination_of_columns:
@@ -33,19 +39,25 @@ sources:
                 - year
                 - run_id
                 - model_predictor_all_name
+              meta:
+                description: feature importance should be unique by year, run_id, and model_predictor_all_name
         description: '{{ doc("table_feature_importance") }}'
         tags:
           - load_auto
+
       - name: metadata
         data_tests:
           - unique_combination_of_columns:
-              name: model_metadata_unique_by_pin_and_year_township_code_coverage
+              name: model_metadata_unique_by_year_and_run_id
               combination_of_columns:
                 - year
                 - run_id
+              meta:
+                description: metadata should be unique by year and run_id
         description: '{{ doc("table_metadata") }}'
         tags:
           - load_auto
+
       - name: parameter_final
         description: '{{ doc("table_parameter_final") }}'
         data_tests:
@@ -54,8 +66,11 @@ sources:
               combination_of_columns:
                 - year
                 - run_id
+              meta:
+                description: parameter final should be unique by year and run_id
         tags:
           - load_auto
+
       - name: parameter_range
         description: '{{ doc("table_parameter_range") }}'
         data_tests:
@@ -64,8 +79,11 @@ sources:
               combination_of_columns:
                 - year
                 - run_id
+              meta:
+                description: parameter range should be unique by year and run_id
         tags:
           - load_auto
+
       - name: parameter_search
         description: '{{ doc("table_parameter_search") }}'
         data_tests:
@@ -75,8 +93,11 @@ sources:
                 - year
                 - run_id
                 - iteration
+              meta:
+                description: parameter search should be unique by year, run_id, and iteration
         tags:
           - load_auto
+
       - name: performance
         description: '{{ doc("table_performance") }}'
         data_tests:
@@ -90,8 +111,11 @@ sources:
                 - geography_type
                 - geography_id
                 - class
+              meta:
+                description: performance should be unique by year, run_id, stage, triad_code, geography_type, geography_id, and class
         tags:
           - load_auto
+
       - name: performance_quantile
         description: '{{ doc("table_performance_quantile") }}'
         data_tests:
@@ -107,8 +131,11 @@ sources:
                 - class
                 - num_quantile
                 - quantile
+              meta:
+                description: performance quantile should be unique by year, run_id, stage, triad_code, geography_type, geography_id, class, num_quantile, and quantile
         tags:
           - load_auto
+
       - name: shap
         description: '{{ doc("table_shap") }}'
         data_tests:
@@ -119,8 +146,11 @@ sources:
                 - run_id
                 - meta_pin
                 - meta_card_num
+              meta:
+                description: shap should be unique by year, run_id, meta_pin, and meta_card_num
         tags:
           - load_auto
+
       - name: test_card
         description: '{{ doc("table_test_card") }}'
         data_tests:
@@ -132,8 +162,11 @@ sources:
                 - meta_pin
                 - meta_card_num
                 - meta_sale_document_num
+              meta:
+                description: test card should be unique by year, run_id, meta_pin, meta_card_num, and meta_sale_document_num
         tags:
           - load_auto
+
       - name: timing
         description: '{{ doc("table_timing") }}'
         data_tests:
@@ -142,6 +175,8 @@ sources:
               combination_of_columns:
                 - year
                 - run_id
+              meta:
+                description: timing should be unique by year and run_id
         tags:
           - load_auto
 

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -12,6 +12,8 @@ sources:
                 - meta_card_num
                 - meta_year
                 - run_id
+              config:
+                  error_if: ">5748"
               meta:
                 description: assessment card should be unique by pin, card, year, and run_id
         tags:
@@ -26,6 +28,8 @@ sources:
                 - meta_pin
                 - meta_year
                 - run_id
+              config:
+                  error_if: ">2016"
               meta:
                 description: assessment pin should be unique by pin, year, and run_id
         tags:
@@ -79,6 +83,8 @@ sources:
               combination_of_columns:
                 - year
                 - run_id
+              config:
+                  error_if: ">84"
               meta:
                 description: parameter range should be unique by year and run_id
         tags:
@@ -93,6 +99,8 @@ sources:
                 - year
                 - run_id
                 - iteration
+              config:
+                  error_if: ">2136"
               meta:
                 description: parameter search should be unique by year, run_id, and iteration
         tags:
@@ -146,6 +154,8 @@ sources:
                 - run_id
                 - meta_pin
                 - meta_card_num
+              config:
+                  error_if: ">524"
               meta:
                 description: shap should be unique by year, run_id, meta_pin, and meta_card_num
         tags:
@@ -162,6 +172,8 @@ sources:
                 - meta_pin
                 - meta_card_num
                 - meta_sale_document_num
+              config:
+                  error_if: ">102422"
               meta:
                 description: test card should be unique by year, run_id, meta_pin, meta_card_num, and meta_sale_document_num
         tags:

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -128,7 +128,7 @@ sources:
         description: '{{ doc("table_performance_quantile") }}'
         data_tests:
           - unique_combination_of_columns:
-              name: model_performance_quantile_unique_by_year_run_id_stage_triad_code_geography_type_geography_id_quantile
+              name: model_performance_quantile_unique_by_year_run_id_stage_triad_code_geography_type_geography_id_class_num_quantile_quantile
               combination_of_columns:
                 - year
                 - run_id
@@ -136,11 +136,13 @@ sources:
                 - stage
                 - geography_type
                 - geography_id
+                - class
+                - num_quantile
                 - quantile
               meta:
                 description: >
                   performance quantile should be unique by year, run_id, stage, triad_code,
-                  geography_type, geography_id, and quantile
+                  geography_type, by_class, geography_id, num_quantile, and quantile
         tags:
           - load_auto
 

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -1,4 +1,5 @@
 # disable-check-sort-order
+# disable ANSIBLE
 sources:
   - name: model
     tables:

--- a/dbt/models/reporting/reporting.ratio_stats.py
+++ b/dbt/models/reporting/reporting.ratio_stats.py
@@ -4,9 +4,10 @@ sc.addPyFile("s3://ccao-athena-dependencies-us-east-1/assesspy==2.0.0.zip")
 
 from typing import Union
 
-import assesspy as ap
 import pandas as pd
 from pyspark.sql.functions import col, lit
+
+import assesspy as ap
 
 CCAO_LOWER_QUANTILE = 0.05
 CCAO_UPPER_QUANTILE = 0.95


### PR DESCRIPTION
Black will not allow assesspy to be unformatted. I'll leave that up, but seems unnecessary for this pull request.

These tests attempt to identify duplicated information in model tables. TLDR, almost everything fails. A lot of it feels to be from old data, however some of it relates to `2024` data and final models.

No idea what `ANSIBLE` is. When I run `ansible-lint models/model` it says that the files are fine.

Notes

1. **parameter_search**  
   - 2136 errors, many of which are from 2024.  
   - I'm not familiar with parameters, and there may be additional keys.

2. **model-timing**  
   - 2 errors: 
   -  relaxed-Tristan and stupefied-maya.  (Final runs from 2024).

3. **parameter_range**  
   - 84 errors.  
   - Becomes unique when including `parameter_type`.

4. **parameter_final**  
   - 1 error: clever-kyra.

5. **test_card**  
   - 102,422 errors.  
   - Tried including `doc_number` and/or `sale_date`, but it did not reduce to a reasonable level.

6. **feature_importance**  
   - 96 errors.  
   - Sad Rina appears to be double uploaded to S3.

7. **model_performance_quantile**  
   - 11,940,024 errors.  
   - Becomes unique when including `num_quantile`.
   - Including this linked to Assesspy and did weird stuff.

8. **shap**  
   - 524 errors.  
   - Not clear why - includes 2024 data.

9. **assessment_pin**  
   - 2016 errors.  
   - These are the only ones where we use meta_year rather than year
   - No errors when `meta_year = '2024'`.

10. **assessment_card**  
    - 5746 errors.  
    - No errors when `meta_year = '2024'`.


`township_code_coverage` is incorrect in docs

@dfsnow 