### PR TITLE
Create baby version of `default.vw_pin_universe`

### DIFF
--- a/dbt/models/default/default.vw_pin_universe_temp.sql
+++ b/dbt/models/default/default.vw_pin_universe_temp.sql
@@ -1,3 +1,3 @@
 -- Small, managable version of pin universe for the purporse of updating the
 -- Parcel Universe asset on open data.
-SELECT * FROM {{ ref('location.vw_pin10_location') }} LIMIT 100000
+SELECT * FROM {{ ref('default.vw_pin_universe') }} LIMIT 100000

--- a/dbt/models/default/default.vw_pin_universe_temp.sql
+++ b/dbt/models/default/default.vw_pin_universe_temp.sql
@@ -1,0 +1,3 @@
+-- Small, managable version of pin universe for the purporse of updating the
+-- Parcel Universe asset on open data.
+SELECT * FROM {{ ref('location.vw_pin10_location') }} LIMIT 100000


### PR DESCRIPTION
This is a stopgap measure to make updating the open data 'Parcel Universe' manageable. Presently it is so large that doing things like adding columns leads to the asset getting orphaned while attempting to load the data into memory, which is a prerequisite for publishing updates to the data. It might not ultimately work, but it's worth a try. Not a longterm solution as we plan to move to a one-year only version of Parcel Universe.

Shouldn't affect what the public sees on the open data portal.