### PR TITLE
Set threshold dynamically for `default.vw_card_res_char` row count test based on iasWorld data

### DIFF
--- a/dbt/models/default/schema/default.vw_card_res_char.yml
+++ b/dbt/models/default/schema/default.vw_card_res_char.yml
@@ -112,7 +112,7 @@ models:
     data_tests:
       - row_count:
           name: default_vw_card_res_char_row_count
-          above: 28450039 # as of 2024-12-06
+          above: 28450000 # as of 2024-12-23
       - unique_combination_of_columns:
           name: default_vw_card_res_char_unique_by_pin_card_and_year
           combination_of_columns:

--- a/dbt/models/default/schema/default.vw_card_res_char.yml
+++ b/dbt/models/default/schema/default.vw_card_res_char.yml
@@ -112,7 +112,13 @@ models:
     data_tests:
       - row_count:
           name: default_vw_card_res_char_row_count
-          above: 28450000 # as of 2024-12-23
+          above: >
+            (
+              SELECT COUNT(*)
+              FROM {{ source('iasworld', 'dweldat') }}
+              WHERE cur = 'Y'
+                AND deactivat IS NULL
+            )
       - unique_combination_of_columns:
           name: default_vw_card_res_char_unique_by_pin_card_and_year
           combination_of_columns:


### PR DESCRIPTION
The row count test for `default.vw_card_res_char` failed during [the most recent weekly data integrity test run](https://github.com/ccao-data/data-architecture/actions/runs/12465835312/job/34792318112#step:7:276). We saw a similar failure [two weeks ago](https://github.com/ccao-data/data-architecture/pull/672), which we believed to be caused by changes in the underlying iasWorld data. I followed a similar set of steps to investigate this week's failure, including checking out the [last commit that succeeded](https://github.com/ccao-data/data-architecture/actions/runs/12362767451) and rebuilding [the full set of view dependencies](https://ccao-data.github.io/data-architecture/#!/overview?g_v=1&g_i=%2Bdefault.vw_card_res_char) at that point in time to confirm that the test still fails. Based on this result, I believe that this most recent change in row count was also caused by changes in the underlying data.

Rather than continue to reduce a static threshold every time the underlying data change, this PR sets the threshold for the test dynamically based on the row count of the `iasworld.dweldat` table, which should encompass the same universe of data as `default.vw_card_res_char`.