### PR TITLE
Remove `default.vw_pin_universe_temp`

### DIFF
--- a/dbt/models/default/default.vw_pin_universe_temp.sql
+++ b/dbt/models/default/default.vw_pin_universe_temp.sql
@@ -1,3 +1,0 @@
--- Small, managable version of pin universe for the purporse of updating the
--- Parcel Universe asset on open data.
-SELECT * FROM {{ ref('default.vw_pin_universe') }} LIMIT 100000


### PR DESCRIPTION
Unfortunately, using this small version of the pin universe view didn't help update its associated open portal asset in the way I'd hoped.