### PR TITLE
Fix `minor_subclass` join in `qc.vw_ic_reference_all_towns_com_bldg_detail`

### DIFF
--- a/dbt/models/qc/qc.vw_ic_reference_all_towns_com_bldg_detail.sql
+++ b/dbt/models/qc/qc.vw_ic_reference_all_towns_com_bldg_detail.sql
@@ -84,7 +84,7 @@ LEFT JOIN {{ source('iasworld', 'pardat') }} AS pardat
 LEFT JOIN {{ ref('ccao.commercial_major_subclass') }} AS major_subclass
     ON comdat.user12 = major_subclass.code
 LEFT JOIN {{ ref('ccao.commercial_minor_subclass') }} AS minor_subclass
-    ON comdat.user12 = minor_subclass.code
+    ON comdat.user13 = minor_subclass.code
 WHERE comdat.cur = 'Y'
     AND comdat.deactivat IS NULL
     AND pardat.class NOT BETWEEN '200' AND '299'


### PR DESCRIPTION
IC identified a small bug in one of the reference queries we started exporting for them in https://github.com/ccao-data/data-architecture/pull/678: We're joining the `ccao.commercial_minor_subclass` table to the _major_ subclass code rather than the minor code, which is producing the wrong human-readable descriptions for minor subclasses. This PR is a one-line change that fixes that bug.

I tested this change by rerunning the table and confirming the output for the `minor_subclass` column displays the correct human-readable description.