### PR TITLE
Remove `-Inf` from `sales.mydec`

### DIFF
--- a/etl/scripts-ccao-data-warehouse-us-east-1/sale/sale-mydec.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/sale/sale-mydec.R
@@ -95,6 +95,10 @@ map(files, clean_up) %>%
   # Because MyDec variables can be different across duplicate sales doc #s,
   # we'll take the max values
   mutate(across(all_of(mydec_vars), ~ max(.x, na.rm = TRUE))) %>%
+  # The max of an empty set is `-Inf`, but we want it to be null instead
+  # since `-Inf` is not semantically meaningful in our output data.
+  # Cast all `-Inf`s to null in case all values of a MyDec field were null
+  # across all dupes ahead of the `max()` call above
   mutate(across(all_of(mydec_vars), ~ na_if(.x, -Inf))) %>%
   distinct(
     document_number,

--- a/etl/scripts-ccao-data-warehouse-us-east-1/sale/sale-mydec.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/sale/sale-mydec.R
@@ -95,6 +95,7 @@ map(files, clean_up) %>%
   # Because MyDec variables can be different across duplicate sales doc #s,
   # we'll take the max values
   mutate(across(all_of(mydec_vars), ~ max(.x, na.rm = TRUE))) %>%
+  mutate(across(all_of(mydec_vars), ~ na_if(.x, -Inf))) %>%
   distinct(
     document_number,
     line_7_property_advertised,


### PR DESCRIPTION
We have ~150 `-Inf` values for the senior homestead exemption that are introduced by taking the max exemption values within sales in the mydec data when there are only `NULL`s:

![image](https://github.com/user-attachments/assets/2734f389-420f-4fc4-b8fd-f7d0dcff1973)

This didn't use to be an issue, but apparently the mydec data has some rows with NULL for exemption values now.

This PR makes sure any `-Inf` values are re-coded back to NULL for all exemption columns.