### PR TITLE
Ensure `reporting.vw_pin_most_recent_sale` rowcount is correct before ias rollover

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -35,6 +35,16 @@ vars:
   # but can also be use to select specific time frames for testing
   data_test_iasworld_year_end: 2030
 
+  # Latest year of iasWorld data available. Necessary since iasWorld does
+  # not rollover into the new year on January 1st, so the latest ias year lags
+  # the calendar year by a small amount. Use this instead of YEAR(CURRENT_DATE)
+  # if you want to query for the latest year of iasWorld data.
+  #
+  # WARNING: Be sure to rebuild all models that depend on this variable when
+  # you bump its value, since otherwise they will be stuck querying the prior
+  # year of data
+  latest_iasworld_data_year: 2024
+
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 models:

--- a/dbt/models/reporting/reporting.vw_pin_most_recent_sale.sql
+++ b/dbt/models/reporting/reporting.vw_pin_most_recent_sale.sql
@@ -4,7 +4,7 @@
 WITH all_pins AS (
     SELECT DISTINCT parid
     FROM {{ source('iasworld', 'pardat') }}
-    WHERE taxyr = CAST(YEAR(CURRENT_DATE) AS VARCHAR)
+    WHERE taxyr = '{{ var("latest_iasworld_data_year") }}'
         AND cur = 'Y'
         AND deactivat IS NULL
 ),

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -200,16 +200,19 @@ models:
   - name: reporting.vw_pin_most_recent_sale
     description: '{{ doc("view_vw_pin_most_recent_sale") }}'
     data_tests:
-      # These two tests make sure that the most recent sale view 1) contains
-      # sales at all and 2) allows in parcels without sales. The most recent
-      # sale view should contain one observation for each parcel in the county
-      # regardless of whether it has recently sold or not.
-      - value_is_present:
-          name: reporting_vw_pin_most_recent_sale_not_null
-          expression: sale_price IS NOT NULL
-      - value_is_present:
-          name: reporting_vw_pin_most_recent_sale_null
-          expression: sale_price IS NULL
+      - row_count:
+          name: reporting_vw_pin_most_recent_sale_rowcount
+          # Rowcount will typically exceed iasworld.pardat due to sales with
+          # PINs that are not in pardat, but at a minimum we want one row
+          # for each PIN that we know about in pardat
+          above: >
+            (
+              SELECT COUNT(DISTINCT parid)
+              FROM {{ source('iasworld', 'pardat') }}
+              WHERE cur = 'Y'
+                AND deactivat IS NULL
+                AND taxyr = '{{ var("latest_iasworld_data_year") }}'
+            )
       - unique_combination_of_columns:
           name: reporting_vw_pin_most_recent_sale_unique_by_pin
           combination_of_columns:


### PR DESCRIPTION
The `reporting.vw_pin_most_recent_sale` view currently has the wrong number of rows since its query filters `iasworld.pardat` by `YEAR(CURRENT_DATE)`, but we don't have 2025 data in iasWorld as the rollover hasn't happened yet. We got notified of this bug by our weekly tests, [which failed this morning](https://github.com/ccao-data/data-architecture/actions/runs/12631418748/job/35193128038#step:7:298).

This PR updates `reporting.vw_pin_most_recent_sale` so that it filters pardat by a new variable `latest_iasworld_data_year` that we can use to specify the latest year of iasWorld data. It also simplifies the rowcount tests for the model to be more accurate and easier to debug.

I'm a little uncertain about the design of this change, since it introduces a new config variable that we have to remember to update when the rollover happens. That's not ideal since it opens up the possibility that we forget to update the variable after the rollover and pin to old data for some amount of time. I'm open to better ideas if you have them! Still, I think this downside is preferable to the downside of the current design, where we're guaranteed to have an incorrect rowcount for the period between January 1st and the rollover.