### PR TITLE
Ensure socrata workflow inputs are handled correctly

### DIFF
--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -337,6 +337,6 @@ def socrata_upload(
 socrata_upload(
     socrata_asset=os.getenv("SOCRATA_ASSET"),
     overwrite=os.getenv("OVERWRITE"),
-    years=str(os.getenv("YEARS")).split(","),
+    years=str(os.getenv("YEARS").replace(" ", "")).split(","),
     by_township=os.getenv("BY_TOWNSHIP"),
 )

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -337,6 +337,6 @@ def socrata_upload(
 socrata_upload(
     socrata_asset=os.getenv("SOCRATA_ASSET"),
     overwrite=os.getenv("OVERWRITE"),
-    years=str(os.getenv("YEARS").replace(" ", "")).split(","),
+    years=str(os.getenv("YEARS")).replace(" ", "").split(","),
     by_township=os.getenv("BY_TOWNSHIP"),
 )

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -206,7 +206,7 @@ def generate_groups(athena_asset, years=None, by_township=False):
     if not years and by_township:
         raise ValueError("Cannot set 'by_township' when 'years' is None")
 
-    if years == "all":
+    if years == ["all"]:
         years = (
             cursor.execute(
                 "SELECT DISTINCT year FROM " + athena_asset + " ORDER BY year"

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -215,6 +215,8 @@ def generate_groups(athena_asset, years=None, by_township=False):
             .to_list()
         )
 
+    # Ensure township codes aren't available if they shouldn't be
+    township_codes = None
     if by_township:
         township_codes = (
             cursor.execute(

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -116,6 +116,8 @@ def build_query(
         + columns[columns["type"] == "array(varchar)"]["column"]
     )
 
+    print(f"The following columns will be updated: {columns}")
+
     query = f"SELECT {row_identifier}, {', '.join(columns['column'])} FROM {athena_asset}"
 
     if not years:

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -216,7 +216,7 @@ def generate_groups(athena_asset, years=None, by_township=False):
         )
 
     # Ensure township codes aren't available if they shouldn't be
-    township_codes = None
+    township_codes = []
     if by_township:
         township_codes = (
             cursor.execute(


### PR DESCRIPTION
The default workflow value for years, 'all', was not being handled correctly since it becomes a list during ingest. Additionally, spaces in the years input could lead to year values not being handled correctly.

Since the columns that get updated currently depend on how the response from the API and the column names of the athena view that feeds the asset match up, it'd be nice to be able to confirm that all expected columns are in fact going to be updated.