### PR TITLE
Clean up descriptions for parcel shape features so they are readable in model feature table

### DIFF
--- a/dbt/models/model/columns.md
+++ b/dbt/models/model/columns.md
@@ -39,22 +39,28 @@ angles in their geometry, e.g. `04-11-501-003` (a rhombus-shaped parcel).
 ## parcel_mrr_area_ratio
 
 {% docs column_parcel_mrr_area_ratio %}
-Ratio of the parcel's area to the area of its
-[minimum rotated bounding rectangle](https://en.wikipedia.org/wiki/Minimum_bounding_rectangle).
+Ratio of the parcel's area to the area of its minimum rotated bounding
+rectangle.
 
 The goal of this feature is to identify parcels with interior holes or strange
 concave shapes, e.g. `16-01-402-008` (basically a right angle parcel).
+
+[See here](https://en.wikipedia.org/wiki/Minimum_bounding_rectangle) for an
+explanation of minimum rotated bounding rectangles.
 {% enddocs %}
 
 ## parcel_mrr_side_ratio
 
 {% docs column_parcel_mrr_side_ratio %}
-Ratio of the longest to the shortest side of the parcel's
-[minimum rotated bounding rectangle](https://en.wikipedia.org/wiki/Minimum_bounding_rectangle).
+Ratio of the longest to the shortest side of the parcel's minimum rotated
+bounding rectangle.
 
 The goal of this feature is to identify parcels with consistent, square shapes.
 In practice, parcels with a high ratio tend to have long, extraneous
 elements/slivers, e.g. `02-23-311-027`.
+
+[See here](https://en.wikipedia.org/wiki/Minimum_bounding_rectangle) for an
+explanation of minimum rotated bounding rectangles.
 {% enddocs %}
 
 ## parcel_num_vertices


### PR DESCRIPTION
One small blocker for https://github.com/ccao-data/model-res-avm/pull/315: When we pull descriptions for the `Features Used` table in the model README, we grab the first sentence of the description (if a feature description contains multiple sentences). Two features, `shp_parcel_mrr_area_ratio` and `shp_parcel_mrr_side_ratio`, include Markdown-formatted links in the first sentence of their feature descriptions, but our `Features Used` table output can't parse Markdown. This PR moves those links to the last sentence of the feature descriptions so that the descriptions are compatible with the `Features Used` table for the model.