### PR TITLE
Ensure sales view row id is string

### DIFF
--- a/dbt/models/open_data/open_data.vw_parcel_sale.sql
+++ b/dbt/models/open_data/open_data.vw_parcel_sale.sql
@@ -2,7 +2,7 @@
 -- Some columns from the feeder view may not be present in this view.
 
 SELECT
-    sale_key AS row_id,
+    CAST(sale_key AS VARCHAR) AS row_id,
     pin,
     year,
     township_code,


### PR DESCRIPTION
Quick fix to https://github.com/ccao-data/data-architecture/pull/691 that makes sure the only row id that isn't a product of a `concat` operation is a string.

![image](https://github.com/user-attachments/assets/ead2914a-9b06-43a5-b748-1a8de5f28a8d)
