### PR TITLE
Ensure `recheck_year` has no non-numeric values

### DIFF
--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -32,7 +32,7 @@ SELECT
     COALESCE(permit.udate3, permit.wen) AS date_updated,
     permit.udate2 AS estimated_date_of_completion,
     permit.user31 AS assessment_year,
-    CAST(NULLIF(REGEXP_REPLACE(permit.recheck_year, '([^0-9])', ''), '') AS INT)
+    CAST(NULLIF(REGEXP_REPLACE(permit.user11, '([^0-9])', ''), '') AS INT)
         AS recheck_year,
     permit.flag AS status,
     permit.user18 AS assessable,

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -32,7 +32,7 @@ SELECT
     COALESCE(permit.udate3, permit.wen) AS date_updated,
     permit.udate2 AS estimated_date_of_completion,
     permit.user31 AS assessment_year,
-    CASE WHEN permit.user11 != 'null' THEN CAST(permit.user11 AS INT) END
+    CAST(NULLIF(REGEXP_REPLACE(permit.recheck_year, '([^0-9])', ''), '') AS INT)
         AS recheck_year,
     permit.flag AS status,
     permit.user18 AS assessable,

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -32,7 +32,8 @@ SELECT
     COALESCE(permit.udate3, permit.wen) AS date_updated,
     permit.udate2 AS estimated_date_of_completion,
     permit.user31 AS assessment_year,
-    permit.user11 AS recheck_year,
+    CASE WHEN permit.user11 != 'null' THEN CAST(permit.user11 AS INT) END
+        AS recheck_year,
     permit.flag AS status,
     permit.user18 AS assessable,
     permit.amount,


### PR DESCRIPTION
There are currently values of "null" in the permit view. Ideally this column should be able to be coerced into an integer without losing any data.

```
with results AS (
	select distinct recheck_year,
		'old' as old
	from default.vw_pin_permit
	union all
	select distinct CAST(recheck_year AS varchar),
		'new'
	from z_ci_remove_null_from_recheck_year_column_default.vw_pin_permit
)
select *
from results
order by old,
	recheck_year desc
```
recheck_year | old
-- | --
2505 | new
2025 | new
2024 | new
2023 | new
2022 | new
2021 | new
  | new
null | old
2505 | old
2025 | old
2024 | old
2023 | old
2022 | old
2021 | old
  | old
  | old
