### PR TITLE
Add uniqueness test for `default.vw_pin_permit` view

### DIFF
--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -59,3 +59,9 @@ models:
         description: '{{ doc("column_permit_status") }}'
       - name: work_description
         description: '{{ doc("column_permit_work_description") }}'
+    data_tests:
+      - unique_combination_of_columns:
+          name: default_vw_pin_permit_unique_by_pin_and_permit_number
+          combination_of_columns:
+            - pin
+            - permit_number


### PR DESCRIPTION
I noticed while reviewing https://github.com/ccao-data/data-architecture/pull/710 that our new open data asset relies on a definition of uniqueness for the `default.vw_pin_permit` view that is not guaranteed to hold. This PR adds a data integrity test for that assumption so that we will get alerted if any new data come in that violate it.

Note that we may want to add `date_issued` to this uniqueness definition as well (discussion here: https://github.com/ccao-data/data-architecture/pull/710#discussion_r1925696992) but I'm holding off on doing that until we resolve our discussion, since we'll also want to change the docs and the open data model definition if we decide to do that.