### PR TITLE
Fix missing years of filled location data

### DIFF
--- a/dbt/models/location/location.crosswalk_year_fill.sql
+++ b/dbt/models/location/location.crosswalk_year_fill.sql
@@ -50,7 +50,7 @@ Take this hypothetical row as an example:
 | ---- | ---------------- | ---------------- |
 | 2019 | 2015             | 2017             |
 
-This row means that for a PIN in year 2010, a data consumer can get a filled
+This row means that for a PIN in year 2019, a data consumer can get a filled
 value for a `location.census` feature by joining to the representation of that
 PIN in the `location.census` table with year 2015, and that this particular row
 of data in `location.census` uses a value that was recorded in the raw data in

--- a/dbt/models/location/location.crosswalk_year_fill.sql
+++ b/dbt/models/location/location.crosswalk_year_fill.sql
@@ -7,16 +7,42 @@ equivalent location data are filled thus:
    2021.
 2. Current data is filled BACKWARD to account for missing historical data.
 
-Note that we assume that source data are already forward-filled, i.e. that
-we have already completed step 1 for all data sources before they reach this
-query. As such, this query only completes step 2 of the above list, but its
-output data will be filled in both directions.
+We make two assumptions about input tables to this query:
 
-The various `year` columns have different meanings:
+1. The input data should already be forward-filled; that is to say, there
+   should be a representation for every `year` starting from the earliest year
+   of available data (i.e. the `data_year`) and going up through the current
+   year
+    * For example, if the first `data_year` is 2017, we expect there to be
+      records for all years from 2017 to present
+2. The input data should _not_ be backfilled; that is to say, the earliest
+   `year` of data in the input table should correspond to the earliest
+   `data_year`
+    * For example, if the first `data_year` is 2017, we expect there to be
+      no records with `year` values prior to 2017
+    * We make an exemption for input tables that contain multiple variables
+      (like `location.political`), in which case we expect the earliest `year`
+      to correspond to the earliest `data_year` among _all_ of the variables.
+      For example, if the earliest `chicago_ward_data_year` is 2017, but there
+      exists a row with an `evanston_ward_data_year` of 2016, then we assume
+      that the earliest `year` in the view will be 2016, and any rows with this
+      `year` will have a null value for `chicago_ward_data_year`
 
-* `year` is the PIN year
-* `*_fill_year` is the PIN year of a data source
-* `*_data_year` is the year of data that we filled using the data source
+Taken together, these two assumptions mean that this query _only_ performs
+backfilling for all input data, and leaves forward-filling to the queries
+that produce the input tables. This might seem like a strange choice, but it
+stems from the fact that we need to forward-fill different data sources
+slightly differently, while we perform backfilling in the same way across
+all data sources.
+
+The output of this query contains three different variations on "year" columns:
+
+1. `year` is the PIN year; there should be one `year` for every year that
+   exists in `spatial.parcel`
+2. `{feature_name}_fill_year` is the year of data for a PIN in the input data
+   that should be used to fill records with a given `year`
+3. `{feature_name}_data_year` is the original year in the raw data that
+   produced the value that exists in the fill year
 
 Take this hypothetical row as an example:
 
@@ -24,11 +50,11 @@ Take this hypothetical row as an example:
 | ---- | ---------------- | ---------------- |
 | 2019 | 2015             | 2017             |
 
-This row intends to communicate that for a PIN in year 2010, a data consumer
-can get a filled value for a `location.census` column by joining to the
-representation of that PIN in the `location.census` table with year 2015, and
-that this particular row of data in `location.census` uses a value that was
-recorded in the raw data in 2017.
+This row means that for a PIN in year 2010, a data consumer can get a filled
+value for a `location.census` feature by joining to the representation of that
+PIN in the `location.census` table with year 2015, and that this particular row
+of data in `location.census` uses a value that was recorded in the raw data in
+2017.
 
 So if we want to use the crosswalk to fill data in this case, we can write a
 query like this:
@@ -44,9 +70,9 @@ query like this:
 {{ config(materialized='table') }}
 
 {#-
-    These are all of the fields we want to fill, where each key is the name
-    of a table in the `location` schema and each value is a list of names of
-    `*_data_year` fields in that table that we want to use for filling
+    Mapping containing of the fields we want to fill, where each key is the
+    name of a table in the `location` schema and each value is a list of names
+    of `*_data_year` fields in that table that we want to use for filling
 -#}
 {%- set fields = {
     "census": ["census"],
@@ -84,13 +110,13 @@ query like this:
 
 /*
 For each year of data we have in `spatial.parcel`, get the corresponding
-PIN year and data year from our source tables. We expect that source tables
-will already be filled up to their earliest date of available data.
+fill year and data year for features in our input tables. We expect that input
+tables will already be filled up to their earliest date of available data.
 
 As an example, assume we have Census data for the year 2020, but no other years
 aside from that year; also, assume that we have parcel data for years
-2018-2022. In this hypothetical case, the output of this subquery will look
-like this if we filter for only Census-related fields:
+2018-2022. In this hypothetical case, the output of the `unfilled` subquery
+will look like this if we filter for only Census-related fields:
 
   | year | census_fill_year | census_data_year |
   | ---- | ---------------- | ---------------- |
@@ -104,12 +130,17 @@ WITH unfilled AS (
     SELECT
         pin.year,
         {% for tablename, fieldnames in fields.items() %}
+            {#
+                Preserve the outer loop indicator so that we can combine it
+                with the inner loop indicator to check whether the last
+                line of the block should end in a trailing comma
+            #}
             {%- set outer_loop_last = loop.last %}
             {% for fieldname in fieldnames %}
                 {%- set inner_loop_last = loop.last %}
                 {#
                     Use MAX to remove nulls in cases of years where some PINs
-                    have no match in the external data, since the DISTINCT
+                    have no match in the source data, since the DISTINCT
                     subqueries in the list of joins below will still return
                     those nulls
                 #}
@@ -120,11 +151,11 @@ WITH unfilled AS (
                     have a data year, since otherwise we risk pulling fill
                     years for years that don't actually have data. This is
                     a particular risk for tables that contain multiple
-                    data fields (i.e. `location.political`) because it's
-                    possible for one field to have data for a year while
-                    another field does not, in which case a naive `MAX(year)`
-                    call would pull a fill year for the first field even though
-                    data only exists for that year in the second field
+                    features (e.g. `location.political`) because it's
+                    possible for example field A to have data for a given year
+                    while example field B does not, in which case a naive
+                    `MAX(year)` call would pull a fill year for the field A
+                    even though data only exists for that year in field B
                 #}
                 MAX(
                     CASE
@@ -162,11 +193,12 @@ WITH unfilled AS (
 
 /*
 Now that we have all parcel years and the earliest year of data in our
-location data sources, we can fill in all parcel years before any data were
-recorded by using the earliest year of available data.
+location data sources, we can backfill years prior to the first year of
+available data by using that first year.
 
-Taking our earlier example again, here's the output we expect for only
-Census-related fields (note that the missing years 2018-2019 are now filled):
+Revisiting our example from the comment above the `unfilled` subquery, here's
+the output we expect for the final query for fields that use Census data years
+(note that the missing years 2018-2019 are now backfilled):
 
   | year | census_fill_year | census_data_year |
   | ---- | ---------------- | ---------------- |

--- a/dbt/models/location/location.crosswalk_year_fill.sql
+++ b/dbt/models/location/location.crosswalk_year_fill.sql
@@ -6,271 +6,184 @@ equivalent location data are filled thus:
 1. All historical data is filled FORWARD in time, i.e. data from 2020 fills
    2021.
 2. Current data is filled BACKWARD to account for missing historical data.
+
+Note that we assume that source data are already forward-filled, i.e. that
+we have already completed step 1 for all data sources before they reach this
+query. As such, this query only completes step 2 of the above list, but its
+output data will be filled in both directions.
+
+The various `year` columns have different meanings:
+
+* `year` is the PIN year
+* `*_fill_year` is the PIN year of a data source
+* `*_data_year` is the year of data that we filled using the data source
+
+Take this hypothetical row as an example:
+
+| year | census_fill_year | census_data_year |
+| ---- | ---------------- | ---------------- |
+| 2019 | 2015             | 2017             |
+
+This row intends to communicate that for a PIN in year 2010, a data consumer
+can get a filled value for a `location.census` column by joining to the
+representation of that PIN in the `location.census` table with year 2015, and
+that this particular row of data in `location.census` uses a value that was
+recorded in the raw data in 2017.
+
+So if we want to use the crosswalk to fill data in this case, we can write a
+query like this:
+
+    SELECT *
+    FROM spatial.parcel AS pin
+    INNER JOIN location.crosswalk_year_fill AS cyf
+        ON pin.year = cyf.year
+    LEFT JOIN location.census AS census
+        ON pin.pin10 = census.pin10
+        AND cyf.census_fill_year = census.year
 */
 {{ config(materialized='table') }}
 
+{#-
+    These are all of the fields we want to fill, where each key is the name
+    of a table in the `location` schema and each value is a list of names of
+    `*_data_year` fields in that table that we want to use for filling
+-#}
+{%- set fields = {
+    "census": ["census"],
+    "census_acs5": ["census_acs5"],
+    "political": [
+        "cook_board_of_review_district",
+        "cook_commissioner_district",
+        "cook_judicial_district",
+        "ward_chicago",
+        "ward_evanston"
+    ],
+    "chicago": [
+        "chicago_community_area",
+        "chicago_industrial_corridor",
+        "chicago_police_district"
+    ],
+    "economy": [
+        "econ_coordinated_care_area",
+        "econ_enterprise_zone",
+        "econ_industrial_growth_zone",
+        "econ_qualified_opportunity_zone",
+        "econ_central_business_district"
+    ],
+    "environment": [
+        "env_flood_fema",
+        "env_flood_fs",
+        "env_ohare_noise_contour",
+        "env_airport_noise"
+    ],
+    "school": ["school"],
+    "tax": ["tax"],
+    "access": ["access_cmap_walk"],
+    "other": ["misc_subdivision"]
+} -%}
+
+/*
+For each year of data we have in `spatial.parcel`, get the corresponding
+PIN year and data year from our source tables. We expect that source tables
+will already be filled up to their earliest date of available data.
+
+As an example, assume we have Census data for the year 2020, but no other years
+aside from that year; also, assume that we have parcel data for years
+2018-2022. In this hypothetical case, the output of this subquery will look
+like this if we filter for only Census-related fields:
+
+  | year | census_fill_year | census_data_year |
+  | ---- | ---------------- | ---------------- |
+  | 2018 |                  |                  |
+  | 2019 |                  |                  |
+  | 2020 | 2020             | 2020             |
+  | 2021 | 2021             | 2020             |
+  | 2022 | 2022             | 2020             |
+*/
 WITH unfilled AS (
     SELECT
         pin.year,
-        MAX(census.census_data_year)
-            AS census_data_year,
-        MAX(census_acs5.census_acs5_data_year)
-            AS census_acs5_data_year,
-        MAX(political.cook_board_of_review_district_data_year)
-            AS cook_board_of_review_district_data_year,
-        MAX(political.cook_commissioner_district_data_year)
-            AS cook_commissioner_district_data_year,
-        MAX(political.cook_judicial_district_data_year)
-            AS cook_judicial_district_data_year,
-        MAX(political.ward_chicago_data_year)
-            AS ward_chicago_data_year,
-        MAX(political.ward_evanston_data_year)
-            AS ward_evanston_data_year,
-        MAX(chicago.chicago_community_area_data_year)
-            AS chicago_community_area_data_year,
-        MAX(chicago.chicago_industrial_corridor_data_year)
-            AS chicago_industrial_corridor_data_year,
-        MAX(chicago.chicago_police_district_data_year)
-            AS chicago_police_district_data_year,
-        MAX(economy.econ_coordinated_care_area_data_year)
-            AS econ_coordinated_care_area_data_year,
-        MAX(economy.econ_enterprise_zone_data_year)
-            AS econ_enterprise_zone_data_year,
-        MAX(economy.econ_industrial_growth_zone_data_year)
-            AS econ_industrial_growth_zone_data_year,
-        MAX(economy.econ_qualified_opportunity_zone_data_year)
-            AS econ_qualified_opportunity_zone_data_year,
-        MAX(economy.econ_central_business_district_data_year)
-            AS econ_central_business_district_data_year,
-        MAX(environment.env_flood_fema_data_year)
-            AS env_flood_fema_data_year,
-        MAX(environment.env_flood_fs_data_year)
-            AS env_flood_fs_data_year,
-        MAX(environment.env_ohare_noise_contour_data_year)
-            AS env_ohare_noise_contour_data_year,
-        MAX(environment.env_airport_noise_data_year)
-            AS env_airport_noise_data_year,
-        MAX(school.school_data_year)
-            AS school_data_year,
-        MAX(tax.tax_data_year)
-            AS tax_data_year,
-        MAX(access.access_cmap_walk_data_year)
-            AS access_cmap_walk_data_year,
-        MAX(other.misc_subdivision_data_year)
-            AS misc_subdivision_data_year
-
+        {% for tablename, fieldnames in fields.items() %}
+            {%- set outer_loop_last = loop.last %}
+            {% for fieldname in fieldnames %}
+                {%- set inner_loop_last = loop.last %}
+                    {#-
+                        Use MAX to remove nulls in cases of years where some PINs
+                        have no match in the external data, since the DISTINCT
+                        subqueries in the list of joins below will still return
+                        those nulls
+                    -#}
+                MAX({{ tablename }}.year) AS {{ fieldname }}_fill_year,
+                MAX({{ tablename }}.{{ fieldname }}_data_year)
+                    AS {{ fieldname }}_data_year
+                {%- if not outer_loop_last or not inner_loop_last -%}
+                    ,
+                {%- endif -%}
+            {% endfor %}
+        {% endfor %}
     FROM (
         SELECT DISTINCT year
         FROM {{ source('spatial', 'parcel') }}
     ) AS pin
-    LEFT JOIN (
-        SELECT DISTINCT
-            year,
-            census_data_year
-        FROM {{ ref('location.census') }}
-    ) AS census ON pin.year = census.year
-    LEFT JOIN (
-        SELECT DISTINCT
-            year,
-            census_acs5_data_year
-        FROM {{ ref('location.census_acs5') }}
-    ) AS census_acs5 ON pin.year = census_acs5.year
-    LEFT JOIN (
-        SELECT DISTINCT
-            year,
-            cook_board_of_review_district_data_year,
-            cook_commissioner_district_data_year,
-            cook_judicial_district_data_year,
-            ward_chicago_data_year,
-            ward_evanston_data_year
-        FROM {{ ref('location.political') }}
-    ) AS political ON pin.year = political.year
-    LEFT JOIN (
-        SELECT DISTINCT
-            year,
-            chicago_community_area_data_year,
-            chicago_industrial_corridor_data_year,
-            chicago_police_district_data_year
-        FROM {{ ref('location.chicago') }}
-    ) AS chicago ON pin.year = chicago.year
-    LEFT JOIN (
-        SELECT DISTINCT
-            year,
-            econ_coordinated_care_area_data_year,
-            econ_enterprise_zone_data_year,
-            econ_industrial_growth_zone_data_year,
-            econ_qualified_opportunity_zone_data_year,
-            econ_central_business_district_data_year
-        FROM {{ ref('location.economy') }}
-    ) AS economy ON pin.year = economy.year
-
-    LEFT JOIN (
-        SELECT DISTINCT
-            year,
-            env_flood_fema_data_year,
-            env_flood_fs_data_year,
-            env_ohare_noise_contour_data_year,
-            env_airport_noise_data_year
-        FROM {{ ref('location.environment') }}
-    ) AS environment ON pin.year = environment.year
-    LEFT JOIN (
-        SELECT DISTINCT
-            year,
-            school_data_year
-        FROM {{ ref('location.school') }}
-    ) AS school ON pin.year = school.year
-    LEFT JOIN (
-        SELECT DISTINCT
-            year,
-            tax_data_year
-        FROM {{ ref('location.tax') }}
-    ) AS tax ON pin.year = tax.year
-    LEFT JOIN (
-        SELECT DISTINCT
-            year,
-            access_cmap_walk_data_year
-        FROM {{ ref('location.access') }}
-    ) AS access ON pin.year = access.year
-    LEFT JOIN (
-        SELECT DISTINCT
-            year,
-            misc_subdivision_data_year
-        FROM {{ ref('location.other') }}
-    ) AS other ON pin.year = other.year
+    {% for tablename, fieldnames in fields.items() %}
+        LEFT JOIN (
+            SELECT DISTINCT
+                year,
+                {% for fieldname in fieldnames %}
+                    {{ fieldname }}_data_year
+                    {%- if not loop.last -%}
+                        ,
+                    {%- endif -%}
+                {% endfor %}
+            FROM {{ ref('location.' + tablename) }}
+        ) AS {{ tablename }}
+            ON pin.year = {{ tablename }}.year
+    {% endfor %}
     GROUP BY pin.year
 )
 
+/*
+Now that we have all parcel years and the earliest year of data in our
+location data sources, we can fill in all parcel years before any data were
+recorded by using the earliest year of available data.
+
+Taking our earlier example again, here's the output we expect for only
+Census-related fields (note that the missing years 2018-2019 are now filled):
+
+  | year | census_fill_year | census_data_year |
+  | ---- | ---------------- | ---------------- |
+  | 2018 | 2020             | 2020             |
+  | 2019 | 2020             | 2020             |
+  | 2020 | 2020             | 2020             |
+  | 2021 | 2021             | 2020             |
+  | 2022 | 2022             | 2020             |
+*/
 SELECT
     unfilled.year,
-    COALESCE(
-        census_data_year, LAST_VALUE(census_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS census_data_year,
-    COALESCE(
-        census_acs5_data_year, LAST_VALUE(census_acs5_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS census_acs5_data_year,
-    COALESCE(
-        cook_board_of_review_district_data_year,
-        LAST_VALUE(cook_board_of_review_district_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS cook_board_of_review_district_data_year,
-    COALESCE(
-        cook_commissioner_district_data_year,
-        LAST_VALUE(cook_commissioner_district_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS cook_commissioner_district_data_year,
-    COALESCE(
-        cook_judicial_district_data_year,
-        LAST_VALUE(cook_judicial_district_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS cook_judicial_district_data_year,
-    COALESCE(
-        ward_chicago_data_year, LAST_VALUE(ward_chicago_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS ward_chicago_data_year,
-    COALESCE(
-        ward_evanston_data_year, LAST_VALUE(ward_evanston_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS ward_evanston_data_year,
-    COALESCE(
-        chicago_community_area_data_year,
-        LAST_VALUE(chicago_community_area_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS chicago_community_area_data_year,
-    COALESCE(
-        chicago_industrial_corridor_data_year,
-        LAST_VALUE(chicago_industrial_corridor_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS chicago_industrial_corridor_data_year,
-    COALESCE(
-        chicago_police_district_data_year,
-        LAST_VALUE(chicago_police_district_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS chicago_police_district_data_year,
-    COALESCE(
-        econ_coordinated_care_area_data_year,
-        LAST_VALUE(econ_coordinated_care_area_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS econ_coordinated_care_area_data_year,
-    COALESCE(
-        econ_enterprise_zone_data_year,
-        LAST_VALUE(econ_enterprise_zone_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS econ_enterprise_zone_data_year,
-    COALESCE(
-        econ_industrial_growth_zone_data_year,
-        LAST_VALUE(econ_industrial_growth_zone_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS econ_industrial_growth_zone_data_year,
-    COALESCE(
-        econ_qualified_opportunity_zone_data_year,
-        LAST_VALUE(econ_qualified_opportunity_zone_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS econ_qualified_opportunity_zone_data_year,
-    COALESCE(
-        econ_central_business_district_data_year,
-        LAST_VALUE(econ_central_business_district_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS econ_central_business_district_data_year,
-    COALESCE(
-        env_flood_fema_data_year, LAST_VALUE(env_flood_fema_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS env_flood_fema_data_year,
-    COALESCE(
-        env_flood_fs_data_year, LAST_VALUE(env_flood_fs_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS env_flood_fs_data_year,
-    COALESCE(
-        env_ohare_noise_contour_data_year,
-        LAST_VALUE(env_ohare_noise_contour_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS env_ohare_noise_contour_data_year,
-    COALESCE(
-        env_airport_noise_data_year,
-        LAST_VALUE(env_airport_noise_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS env_airport_noise_data_year,
-    COALESCE(
-        school_data_year, LAST_VALUE(school_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS school_data_year,
-    COALESCE(
-        tax_data_year, LAST_VALUE(tax_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS tax_data_year,
-    COALESCE(
-        access_cmap_walk_data_year,
-        LAST_VALUE(access_cmap_walk_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS access_cmap_walk_data_year,
-    COALESCE(
-        misc_subdivision_data_year,
-        LAST_VALUE(misc_subdivision_data_year)
-            IGNORE NULLS
-            OVER (ORDER BY unfilled.year DESC)
-    ) AS misc_subdivision_data_year
+    {% for tablename, fieldnames in fields.items() %}
+        {%- set outer_loop_last = loop.last %}
+        {% for fieldname in fieldnames %}
+            {%- set inner_loop_last = loop.last %}
+            COALESCE(
+                {{ fieldname }}_fill_year,
+                {#-
+                    Use a window function to fill nulls with the first year of
+                    available data for this data source
+                -#}
+                LAST_VALUE({{ fieldname }}_fill_year)
+                    IGNORE NULLS
+                    OVER (ORDER BY unfilled.year DESC)
+            ) AS {{ fieldname }}_fill_year,
+            COALESCE(
+                {{ fieldname }}_data_year,
+                LAST_VALUE({{ fieldname }}_data_year)
+                    IGNORE NULLS
+                    OVER (ORDER BY unfilled.year DESC)
+            ) AS {{ fieldname }}_data_year
+            {%- if not outer_loop_last or not inner_loop_last -%}
+                ,
+            {%- endif -%}
+        {% endfor %}
+    {% endfor %}
 FROM unfilled
 ORDER BY unfilled.year

--- a/dbt/models/location/location.tax.sql
+++ b/dbt/models/location/location.tax.sql
@@ -230,3 +230,4 @@ LEFT JOIN wide
             ELSE pcl.year
         END = wide.year
     )
+WHERE pcl.year >= (SELECT MIN(year) FROM wide)

--- a/dbt/models/location/schema.yml
+++ b/dbt/models/location/schema.yml
@@ -265,8 +265,116 @@ models:
     description: '{{ doc("view_vw_pin10_location_fill") }}'
     columns: *vw_location_columns
 
-
 unit_tests:
+  - name: location_crosswalk_year_fill_should_create_proper_fill_and_data_years
+    description: view should define correct fill and data years
+    model: location.crosswalk_year_fill
+    given:
+      - input: source("spatial", "parcel")
+        rows: &crosswalk-location-fill-unit-test-pin-and-year
+          # Two PINs, one for each year from 2019-2021
+          - {pin10: "0123456789", year: "2019"}
+          - {pin10: "1234567890", year: "2019"}
+          - {pin10: "0123456789", year: "2020"}
+          - {pin10: "1234567890", year: "2020"}
+          - {pin10: "0123456789", year: "2021"}
+          - {pin10: "1234567890", year: "2021"}
+      # Test `census` table as an example of a table with only one variable
+      - input: ref("location.census")
+        rows:
+          # Make sure that the data start in 2020, one year after the first
+          # parcel year (2019), so that we can test that the year will still
+          # get a representation in the output using the earliest year of data
+          - {pin10: "0123456789", year: "2020", census_data_year: "2020"}
+          # Add missing data for 2020 to test that we properly remove nulls
+          # when pulling the full set of years
+          - {pin10: "1234567890", year: "2020", census_data_year: null}
+          # Add a row for 2021 with data that comes from 2020 to test that
+          # the output will have a fill_year of 2021 in spite of the earlier
+          # data year
+          - {pin10: "0123456789", year: "2021", census_data_year: "2020"}
+          - {pin10: "1234567890", year: "2021", census_data_year: null}
+      # Test `chicago` table as an example of a table with multiple variables.
+      # The different types of rows are the same as we configured for the
+      # single-variable case above, we just need multiple columns in each case
+      # to account for the multiple variables
+      - input: ref("location.chicago")
+        rows:
+          - pin10: "0123456789"
+            year: "2019"
+            chicago_community_area_data_year: "2019"
+            chicago_industrial_corridor_data_year: null
+            chicago_police_district_data_year: null
+          - pin10: "1234567890"
+            year: "2019"
+            chicago_community_area_data_year: null
+            chicago_industrial_corridor_data_year: null
+            chicago_police_district_data_year: null
+          - pin10: "0123456789"
+            year: "2020"
+            chicago_community_area_data_year: "2019"
+            chicago_industrial_corridor_data_year: "2020"
+            chicago_police_district_data_year: null
+          - pin10: "1234567890"
+            year: "2020"
+            chicago_community_area_data_year: null
+            chicago_industrial_corridor_data_year: null
+            chicago_police_district_data_year: null
+          - pin10: "0123456789"
+            year: "2021"
+            chicago_community_area_data_year: "2019"
+            chicago_industrial_corridor_data_year: "2020"
+            chicago_police_district_data_year: "2021"
+          - pin10: "1234567890"
+            year: "2021"
+            chicago_community_area_data_year: null
+            chicago_industrial_corridor_data_year: null
+            chicago_police_district_data_year: null
+      - input: ref("location.census_acs5")
+        rows: *crosswalk-location-fill-unit-test-pin-and-year
+      - input: ref("location.political")
+        rows: *crosswalk-location-fill-unit-test-pin-and-year
+      - input: ref("location.economy")
+        rows: *crosswalk-location-fill-unit-test-pin-and-year
+      - input: ref("location.environment")
+        rows: *crosswalk-location-fill-unit-test-pin-and-year
+      - input: ref("location.school")
+        rows: *crosswalk-location-fill-unit-test-pin-and-year
+      - input: ref("location.tax")
+        rows: *crosswalk-location-fill-unit-test-pin-and-year
+      - input: ref("location.access")
+        rows: *crosswalk-location-fill-unit-test-pin-and-year
+      - input: ref("location.other")
+        rows: *crosswalk-location-fill-unit-test-pin-and-year
+    expect:
+      rows:
+        - year: "2019"
+          census_fill_year: "2020"
+          census_data_year: "2020"
+          chicago_community_area_fill_year: "2019"
+          chicago_community_area_data_year: "2019"
+          chicago_industrial_corridor_fill_year: "2020"
+          chicago_industrial_corridor_data_year: "2020"
+          chicago_police_district_fill_year: "2021"
+          chicago_police_district_data_year: "2021"
+        - year: "2020"
+          census_fill_year: "2020"
+          census_data_year: "2020"
+          chicago_community_area_fill_year: "2020"
+          chicago_community_area_data_year: "2019"
+          chicago_industrial_corridor_fill_year: "2020"
+          chicago_industrial_corridor_data_year: "2020"
+          chicago_police_district_fill_year: "2021"
+          chicago_police_district_data_year: "2021"
+        - year: "2021"
+          census_fill_year: "2021"
+          census_data_year: "2020"
+          chicago_community_area_fill_year: "2021"
+          chicago_community_area_data_year: "2019"
+          chicago_industrial_corridor_fill_year: "2021"
+          chicago_industrial_corridor_data_year: "2020"
+          chicago_police_district_fill_year: "2021"
+          chicago_police_district_data_year: "2021"
   - name: location_vw_pin10_location_fill_should_fill_missing_years
     description: view should fill missing years of data with nearest year
     model: location.vw_pin10_location_fill

--- a/dbt/models/location/schema.yml
+++ b/dbt/models/location/schema.yml
@@ -330,6 +330,9 @@ unit_tests:
             chicago_community_area_data_year: null
             chicago_industrial_corridor_data_year: null
             chicago_police_district_data_year: null
+      # All of the input tables from here on down are just boilerplate to get
+      # the joins to work in the model. The values for these input tables don't
+      # really matter because we don't need any of the data in the tables
       - input: ref("location.census_acs5")
         rows: *crosswalk-location-fill-unit-test-pin-and-year
       - input: ref("location.political")
@@ -375,6 +378,7 @@ unit_tests:
           chicago_industrial_corridor_data_year: "2020"
           chicago_police_district_fill_year: "2021"
           chicago_police_district_data_year: "2021"
+
   - name: location_vw_pin10_location_fill_should_fill_missing_years
     description: view should fill missing years of data with nearest year
     model: location.vw_pin10_location_fill
@@ -395,9 +399,9 @@ unit_tests:
             year: "2015"
             access_cmap_walk_data_year: "2017"
             access_cmap_walk_total_score: 100
-      # Everything below is just boilerplate to get the joins to work in the
-      # view. The table values don't really matter because we don't need any
-      # of the data from these tables
+      # All of the input tables from here on down are just boilerplate to get
+      # the joins to work in the model. The values for these input tables don't
+      # really matter because we don't need any of the data in the tables
       - input: ref("location.census")
         rows: *unit-test-pin-and-year
       - input: ref("location.census_acs5")

--- a/dbt/models/location/schema.yml
+++ b/dbt/models/location/schema.yml
@@ -264,3 +264,50 @@ models:
   - name: location.vw_pin10_location_fill
     description: '{{ doc("view_vw_pin10_location_fill") }}'
     columns: *vw_location_columns
+
+
+unit_tests:
+  - name: location_vw_pin10_location_fill_should_fill_missing_years
+    description: view should fill missing years of data with nearest year
+    model: location.vw_pin10_location_fill
+    given:
+      - input: source("spatial", "parcel")
+        rows: &unit-test-pin-and-year
+          - {pin10: "0123456789", year: "2015"}
+      - input: ref("location.crosswalk_year_fill")
+        rows:
+          - year: "2015"
+            access_cmap_walk_data_year: "2017"
+            access_cmap_walk_fill_year: "2015"
+      # It doesn't matter which table we use here, we just need a fixture for
+      # one of the tables that we merge together in the fill view
+      - input: ref("location.access")
+        rows:
+          - pin10: "0123456789"
+            year: "2015"
+            access_cmap_walk_data_year: "2017"
+            access_cmap_walk_total_score: 100
+      # Everything below is just boilerplate to get the joins to work in the
+      # view. The table values don't really matter because we don't need any
+      # of the data from these tables
+      - input: ref("location.census")
+        rows: *unit-test-pin-and-year
+      - input: ref("location.census_acs5")
+        rows: *unit-test-pin-and-year
+      - input: ref("location.political")
+        rows: *unit-test-pin-and-year
+      - input: ref("location.chicago")
+        rows: *unit-test-pin-and-year
+      - input: ref("location.economy")
+        rows: *unit-test-pin-and-year
+      - input: ref("location.environment")
+        rows: *unit-test-pin-and-year
+      - input: ref("location.school")
+        rows: *unit-test-pin-and-year
+      - input: ref("location.tax")
+        rows: *unit-test-pin-and-year
+      - input: ref("location.other")
+        rows: *unit-test-pin-and-year
+    expect:
+      rows:
+        - {pin10: "0123456789", year: "2015", access_cmap_walk_total_score: 100}


### PR DESCRIPTION
During model QC, we realized that a number of location features have unusual patterns of missingness over time (https://github.com/ccao-data/model-res-avm/issues/336).

I tested this PR with two new unit tests, one for `location.vw_pin10_location_fill` and one for `location.crosswalk_year_fill`, along with thorough QC of the two tables. In particular, I checked two things:

* The `year`, `{feature_name}_fill_year`, and `{feature_name}_data_year` columns in `location.crosswalk_year_fill` make sense for each feature
* The counts of missing values for each feature in `location.vw_pin10_location_fill` look reasonable when grouped by year
    * By "reasonable", I mean to say that the number of missing records corresponds to the number of parcels that do not have a shape for the fill year

Note that this PR only fixes the problem for `location` features; `proximity` features are filled in a similar way, but in a distinct set of queries. I'm planning to put up a fast-follow to this PR that makes the same change for the `proximity` queries.