### PR TITLE
Disable open data asset tests for private assets until they are public

### DIFF
--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -114,7 +114,8 @@ exposures:
     owner:
       name: Data Department
     meta:
-      test_row_count: true
+      # Disabled until the asset is public
+      test_row_count: false
       asset_id: uuu4-fqy8
       primary_key:
         - pin
@@ -133,7 +134,8 @@ exposures:
     owner:
       name: Data Department
     meta:
-      test_row_count: true
+      # Disabled until the asset is public
+      test_row_count: false
       asset_id: pabr-t5kh
       primary_key:
         - pin
@@ -175,7 +177,8 @@ exposures:
     owner:
       name: Data Department
     meta:
-      test_row_count: true
+      # Disabled until the asset is public
+      test_row_count: false
       year_field: assessment_year
       asset_id: 6yjf-dfxs
       primary_key:


### PR DESCRIPTION
https://github.com/ccao-data/data-architecture/pull/718 fixed one problem with our open data asset tests, but tests [are still failing](https://github.com/ccao-data/data-architecture/actions/runs/13139044701/job/36661398317#step:5:37) because we're trying to test new assets that are not yet public so our script gets a 403 when querying them. This PR disables tests for those assets to resolve the failures. We can re-enable these tests once the assets are public.

The workflow is still failing due to new parcel shapes, but you can confirm that it's not erroring out anymore: https://github.com/ccao-data/data-architecture/actions/runs/13139890483/job/36664237973