### PR TITLE
Modify School districts to fill with unified if NA

### DIFF
--- a/dbt/models/model/model.vw_pin_shared_input.sql
+++ b/dbt/models/model/model.vw_pin_shared_input.sql
@@ -236,9 +236,14 @@ SELECT
     vwlf.chicago_community_area_name AS loc_chicago_community_area_name,
 
     -- Location data used for spatial fixed effects
-    vwlf.school_elementary_district_geoid
+    COALESCE(
+        vwlf.school_elementary_district_geoid,
+        vwlf.school_unified_district_geoid
+    )
         AS loc_school_elementary_district_geoid,
-    vwlf.school_secondary_district_geoid
+    COALESCE(
+        vwlf.school_secondary_district_geoid, vwlf.school_unified_district_geoid
+    )
         AS loc_school_secondary_district_geoid,
     vwlf.school_unified_district_geoid AS loc_school_unified_district_geoid,
     vwlf.tax_special_service_area_num AS loc_tax_special_service_area_num,

--- a/dbt/models/model/model.vw_pin_shared_input.sql
+++ b/dbt/models/model/model.vw_pin_shared_input.sql
@@ -242,7 +242,8 @@ SELECT
     )
         AS loc_school_elementary_district_geoid,
     COALESCE(
-        vwlf.school_secondary_district_geoid, vwlf.school_unified_district_geoid
+        vwlf.school_secondary_district_geoid,
+        vwlf.school_unified_district_geoid
     )
         AS loc_school_secondary_district_geoid,
     vwlf.school_unified_district_geoid AS loc_school_unified_district_geoid,


### PR DESCRIPTION
This fixes an issue discovered in [336](https://github.com/ccao-data/model-res-avm/issues/336), where school districts were NA in elementary or secondary and had a valid unified school district. This simply coalesces the values during the shared input step.