### PR TITLE
Fix foreclosure script to work with values of 0

### DIFF
--- a/dbt/models/proximity/proximity.cnt_pin_num_foreclosure.sql
+++ b/dbt/models/proximity/proximity.cnt_pin_num_foreclosure.sql
@@ -67,11 +67,16 @@ SELECT
         0
     ) AS num_foreclosure_in_half_mile_past_5_years,
     COALESCE(pc.num_pin_in_half_mile, 1) AS num_pin_in_half_mile,
-    ROUND(
-        CAST(pib.num_foreclosure_in_half_mile_past_5_years AS DOUBLE) / (
-            CAST(pc.num_pin_in_half_mile AS DOUBLE) / 1000
-        ), 2
-    ) AS num_foreclosure_per_1000_pin_past_5_years,
+    CASE
+        WHEN
+            COALESCE(pib.num_foreclosure_in_half_mile_past_5_years, 0) = 0
+            THEN 0
+        ELSE ROUND(
+                CAST(pib.num_foreclosure_in_half_mile_past_5_years AS DOUBLE)
+                / (CAST(COALESCE(pc.num_pin_in_half_mile, 1) AS DOUBLE) / 1000),
+                2
+            )
+    END AS num_foreclosure_per_1000_pin_past_5_years,
     CONCAT(
         CAST(CAST(pl.year AS INT) - 5 AS VARCHAR),
         ' - ',

--- a/dbt/models/proximity/proximity.cnt_pin_num_foreclosure.sql
+++ b/dbt/models/proximity/proximity.cnt_pin_num_foreclosure.sql
@@ -67,16 +67,11 @@ SELECT
         0
     ) AS num_foreclosure_in_half_mile_past_5_years,
     COALESCE(pc.num_pin_in_half_mile, 1) AS num_pin_in_half_mile,
-    CASE
-        WHEN
-            COALESCE(pib.num_foreclosure_in_half_mile_past_5_years, 0) = 0
-            THEN 0
-        ELSE ROUND(
-                CAST(pib.num_foreclosure_in_half_mile_past_5_years AS DOUBLE)
-                / (CAST(COALESCE(pc.num_pin_in_half_mile, 1) AS DOUBLE) / 1000),
-                2
-            )
-    END AS num_foreclosure_per_1000_pin_past_5_years,
+    ROUND(
+        CAST(COALESCE(pib.num_foreclosure_in_half_mile_past_5_years, 0) AS DOUBLE)
+        / (CAST(pc.num_pin_in_half_mile AS DOUBLE) / 1000),
+        2
+    ) AS num_foreclosure_per_1000_pin_past_5_years,
     CONCAT(
         CAST(CAST(pl.year AS INT) - 5 AS VARCHAR),
         ' - ',

--- a/dbt/models/proximity/proximity.cnt_pin_num_foreclosure.sql
+++ b/dbt/models/proximity/proximity.cnt_pin_num_foreclosure.sql
@@ -68,7 +68,9 @@ SELECT
     ) AS num_foreclosure_in_half_mile_past_5_years,
     COALESCE(pc.num_pin_in_half_mile, 1) AS num_pin_in_half_mile,
     ROUND(
-        CAST(COALESCE(pib.num_foreclosure_in_half_mile_past_5_years, 0) AS DOUBLE)
+        CAST(
+            COALESCE(pib.num_foreclosure_in_half_mile_past_5_years, 0) AS DOUBLE
+        )
         / (CAST(pc.num_pin_in_half_mile AS DOUBLE) / 1000),
         2
     ) AS num_foreclosure_per_1000_pin_past_5_years,


### PR DESCRIPTION
This fixes an issue discovered in [336](https://github.com/ccao-data/model-res-avm/issues/336), where PINs with 0 foreclosures within 1/2 a mile returned values of NA. This coalesces the result to 0 if there are 0 pins in that radius.