### PR TITLE
Tag `model.vw_pin_shared_input` for daily materialization

### DIFF
--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -217,6 +217,9 @@ models:
 
   - name: model.vw_pin_shared_input
     description: '{{ doc("view_vw_pin_shared_input") }}'
+    config:
+      tags:
+        - daily
     columns:
       - &acs5_count_sex_total
         name: acs5_count_sex_total


### PR DESCRIPTION
In https://github.com/ccao-data/data-architecture/pull/669 we changed `model.vw_pin_shared_input` to materialize as a table, but we neglected to tag it with the `daily` tag so that it would get rebuilt every day by the [`build-daily-dbt-models` workflow](https://github.com/ccao-data/data-architecture/actions/workflows/build_daily_dbt_models.yaml). This PR adds that missing tag.

Proof that the tag works:

```
(dbt) ~/data-architecture/dbt$ dbt list --select tag:daily
22:43:32  Running with dbt=1.9.1
22:43:33  Registered adapter: athena=1.8.4
ccao_data_athena.model.model.vw_card_res_input
ccao_data_athena.model.model.vw_pin_condo_input
ccao_data_athena.model.model.vw_pin_shared_input
...
```