### PR TITLE
Loosen PRB test threshold for `pre-mailed` assessment stage

### DIFF
--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -37,7 +37,10 @@ models:
           expression: |
             cod >= 0
             AND prd >= 0
-            AND prb BETWEEN -1 AND 1
+            AND (
+            (prb BETWEEN -1 AND 1 AND assessment_stage != 'pre-mailed') OR
+            (prb BETWEEN -1.5 AND 1.5 AND assessment_stage = 'pre-mailed')
+            )
             AND mki >= 0
             AND triad IS NOT NULL
             AND geography_type IS NOT NULL

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -34,7 +34,7 @@ models:
     data_tests:
       - expression_is_true:
           name: reporting_ratio_stats_metrics_are_sensible
-          # pre-mailed values exhibit variance that makes applying the same
+          # pre-mailed values exhibit variance that makes applying the same prb
           # constraints as other assessment stages trigger a test failure too
           # often to be helpful
           expression: |

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -34,12 +34,15 @@ models:
     data_tests:
       - expression_is_true:
           name: reporting_ratio_stats_metrics_are_sensible
+          # pre-mailed values exhibit variance that makes applying the same
+          # constraints as other assessment stages trigger a test failure too
+          # often to be helpful
           expression: |
             cod >= 0
             AND prd >= 0
             AND (
-            (prb BETWEEN -1 AND 1 AND assessment_stage != 'pre-mailed') OR
-            (prb BETWEEN -1.5 AND 1.5 AND assessment_stage = 'pre-mailed')
+              (prb BETWEEN -1 AND 1 AND assessment_stage != 'pre-mailed')
+              OR (prb BETWEEN -1.5 AND 1.5 AND assessment_stage = 'pre-mailed')
             )
             AND mki >= 0
             AND triad IS NOT NULL


### PR DESCRIPTION
Quick PR to suppress PRB test failures in `reporting.ratio_stats` for the pre-mailed stage. We've been getting a test failure for Cicero this year and after inspection the sales data looks fine - there's nothing to be corrected. Pre-mailed is a bit of an odd stage so for now we'll loosen the PRB test threshold for that stage to avoid constant failure alerts while maintaining the stricter alerts for other stages.

[Here's our quick and dirty sales investigation.](https://github.com/user-attachments/files/18734929/prb.zip)
