### PR TITLE
Add new parking space CDU code to nonlivable construction

### DIFF
--- a/dbt/models/default/default.vw_pin_condo_char.sql
+++ b/dbt/models/default/default.vw_pin_condo_char.sql
@@ -254,7 +254,7 @@ SELECT DISTINCT
     -- Count of non-unit PINs by pin10
     SUM(CASE
         WHEN (
-            filled.cdu = 'GR'
+            filled.cdu IN ('GR', 'PS')
             OR (
                 SUBSTR(filled.unitno, 1, 1) = 'P'
                 AND SUBSTR(filled.unitno, 1, 2) != 'PH'
@@ -286,7 +286,7 @@ SELECT DISTINCT
     filled.bldg_is_mixed_use,
     vph.oneyr_pri_board_tot,
     COALESCE((
-        filled.cdu = 'GR'
+        filled.cdu IN ('GR', 'PS')
         OR (
             SUBSTR(filled.unitno, 1, 1) = 'P'
             AND SUBSTR(filled.unitno, 1, 2) != 'PH'
@@ -313,7 +313,7 @@ SELECT DISTINCT
         WHEN filled.note = 'PARKING/STORAGE/COMMON UNIT'
             OR filled.parking_pin = TRUE
             THEN 'identified by valuations as non-unit'
-        WHEN filled.cdu = 'GR' THEN 'cdu'
+        WHEN filled.cdu IN ('GR', 'PS') THEN 'cdu'
         WHEN (
             SUBSTR(filled.unitno, 1, 1) = 'P'
             AND SUBSTR(filled.unitno, 1, 2) != 'PH'


### PR DESCRIPTION
Since we don't have any 'PS' CDUs yet, this code shouldn't result in any changes to our data, and doesn't:

```
select
	count(*)
from iasworld.oby
where user16 = 'PS'
```

yields 0, as does

```
select
	count(*)
from iasworld.comdat
where user16 = 'PS'
```

```
select
  is_parking_space,
  parking_space_flag_reason,
  is_question_garage_unit,
  is_common_area,
  'old' as source
from default.vw_pin_condo_char

union all

select
  is_parking_space,
  parking_space_flag_reason,
  is_question_garage_unit,
  is_common_area,
  'new' as source
from z_ci_add_new_parking_space_code_to_nonlivable_construction_default.vw_pin_condo_char
```

|skim_variable          |source|n_missing|logical.mean|logical.count             |
|-----------------------|------|---------|------------|--------------------------|
|is_parking_space       |new   |0        |0.1685960190|FAL: 9128045, TRU: 1851028|
|is_parking_space       |old   |0        |0.1685960190|FAL: 9128045, TRU: 1851028|
|is_question_garage_unit|new   |0        |0.0001717814|FAL: 10977187, TRU: 1886  |
|is_question_garage_unit|old   |0        |0.0001717814|FAL: 10977187, TRU: 1886  |
|is_common_area         |new   |0        |0.0026499505|FAL: 10949979, TRU: 29094 |
|is_common_area         |old   |0        |0.0026499505|FAL: 10949979, TRU: 29094 |

```
> table(check$parking_space_flag_reason, check$source)
                                      
                                           new     old
  cdu                                  1593762 1593762
  declaration percent                     4012    4012
  identified by valuations as non-unit  206278  206278
  model predicted negative value          2914    2914
  prior value                             3997    3997
  unit number                            40065   40065
```