### PR TITLE
Add assessable permits flag to `vw_pin_status` view

### DIFF
--- a/dbt/models/default/default.vw_pin_status.sql
+++ b/dbt/models/default/default.vw_pin_status.sql
@@ -142,7 +142,7 @@ SELECT
     pdat.note2 AS pardat_note,
     pdat.class = '999' AS is_filler_class,
     pdat.parid LIKE '%999%' AS is_filler_pin,
-    permit.num_assessable_permits > 0 AS has_assessable_permit_past_3_years
+    permit.num_assessable_permits > 0 AS has_recent_assessable_permit
 FROM {{ source('iasworld', 'pardat') }} AS pdat
 LEFT JOIN {{ source('spatial', 'corner') }} AS colo
     ON SUBSTR(pdat.parid, 1, 10) = colo.pin10

--- a/dbt/models/default/default.vw_pin_status.sql
+++ b/dbt/models/default/default.vw_pin_status.sql
@@ -87,6 +87,29 @@ WITH ahsap AS (
     WHERE par.cur = 'Y'
         AND par.deactivat IS NULL
     GROUP BY par.parid, par.taxyr
+),
+
+assessable_permits_past_3_years AS (
+    SELECT
+        pardat.parid AS pin,
+        pardat.taxyr AS year,
+        SUM(
+            CASE WHEN permit.year IS NULL THEN 0 ELSE 1 END
+        ) AS num_assessable_permits
+    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    LEFT JOIN (
+        SELECT
+            pin,
+            SUBSTR(date_issued, 1, 4) AS year
+        FROM {{ ref('default.vw_pin_permit') }}
+        WHERE assessable = 'A'
+            AND date_issued IS NOT NULL
+        GROUP BY pin, SUBSTR(date_issued, 1, 4)
+    ) AS permit
+        ON pardat.parid = permit.pin
+        AND CAST(permit.year AS INT)
+        BETWEEN CAST(pardat.taxyr AS INT) - 2 AND CAST(pardat.taxyr AS INT)
+    GROUP BY pardat.parid, pardat.taxyr
 )
 
 SELECT
@@ -118,7 +141,8 @@ SELECT
     ddat.cdu_description AS dweldat_cdu_description,
     pdat.note2 AS pardat_note,
     pdat.class = '999' AS is_filler_class,
-    pdat.parid LIKE '%999%' AS is_filler_pin
+    pdat.parid LIKE '%999%' AS is_filler_pin,
+    permit.num_assessable_permits > 0 AS has_assessable_permit_past_3_years
 FROM {{ source('iasworld', 'pardat') }} AS pdat
 LEFT JOIN {{ source('spatial', 'corner') }} AS colo
     ON SUBSTR(pdat.parid, 1, 10) = colo.pin10
@@ -169,5 +193,8 @@ LEFT JOIN ({{ aggregate_cdu(
 LEFT JOIN {{ ref('ccao.pin_test') }} AS ptst
     ON pdat.parid = ptst.pin
     AND pdat.taxyr = ptst.year
+LEFT JOIN assessable_permits_past_3_years AS permit
+    ON pdat.parid = permit.pin
+    AND pdat.taxyr = permit.year
 WHERE pdat.cur = 'Y'
     AND pdat.deactivat IS NULL

--- a/dbt/models/default/schema/default.vw_pin_status.yml
+++ b/dbt/models/default/schema/default.vw_pin_status.yml
@@ -22,6 +22,9 @@ models:
           on December 31st of the parcel year. For example, for a parcel
           with year 2024, this column will count all assessable permits
           issued between January 1st, 2022, and December 31st, 2024.
+        data_tests:
+          - not_null:
+              name: default_vw_pin_status_has_recent_assessable_permit_not_null
       - name: is_ahsap
         description: '{{ doc("shared_column_is_ahsap") }}'
       - name: is_common_area

--- a/dbt/models/default/schema/default.vw_pin_status.yml
+++ b/dbt/models/default/schema/default.vw_pin_status.yml
@@ -13,6 +13,15 @@ models:
         description: CDU from `iasworld.dweldat` table
       - name: dweldat_cdu_description
         description: CDU code description for `dweldat_cdu_description`
+      - name: has_recent_assessable_permit
+        description: |
+          Parcel has at least one assessable permit in the prior 3 years.
+
+          The date range that defines "the prior 3 years" starts on
+          January 1st of the year 2 years before the parcel year, and ends
+          on December 31st of the parcel year. For example, for a parcel
+          with year 2024, this column will count all assessable permits
+          issued between January 1st, 2022, and December 31st, 2024.
       - name: is_ahsap
         description: '{{ doc("shared_column_is_ahsap") }}'
       - name: is_common_area


### PR DESCRIPTION
This PR adds a new column `has_recent_assessable_permit` to the `default.vw_pin_status` view. This column looks for assessable permits issued between January 1st of the year two years prior to the parcel year and December 31st of the parcel year, returning `TRUE` if any such permits exist and `FALSE` otherwise.

This PR doesn't yet add the new column to the `open_data.vw_parcel_status` view. Do we want to do that now, or wait till later @wrridgeway?

Connects https://github.com/ccao-data/model-res-avm/issues/340.