### PR TITLE
Remove township as a choice for socrata chunking

### DIFF
--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -29,7 +29,7 @@ on:
       years:
         # Comma separated list of years
         type: string
-        description: Years to update or overwrite
+        description: Years to update or overwrite (comma separated)
         default: 'all'
         required: false
 

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -32,10 +32,7 @@ on:
         description: Years to update or overwrite
         default: 'all'
         required: false
-      by_township:
-        type: boolean
-        description: Chunk Socrata upload by township
-        required: false
+
 
 env:
   UV_SYSTEM_PYTHON: 1
@@ -95,5 +92,4 @@ jobs:
           SOCRATA_ASSET: ${{ inputs.socrata_asset }}
           OVERWRITE: ${{ inputs.overwrite }}
           YEARS: ${{ inputs.years }}
-          BY_TOWNSHIP: ${{ inputs.by_township }}
         run: python ./socrata/socrata_upload.py

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -29,7 +29,7 @@ on:
       years:
         # Comma separated list of years
         type: string
-        description: Years to update or overwrite (comma separated)
+        description: Years to update or overwrite (comma-separated)
         default: 'all'
         required: false
 

--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -199,7 +199,7 @@ exposures:
       name: Data Department
     meta:
       test_row_count: true
-      asset_id: vgzx-68gb
+      asset_id: a8dq-ppc7
       primary_key:
         - pin
         - year

--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -199,7 +199,7 @@ exposures:
       name: Data Department
     meta:
       test_row_count: true
-      asset_id: a8dq-ppc7
+      asset_id: vgzx-68gb
       primary_key:
         - pin
         - year

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -42,6 +42,21 @@ def parse_years(years):
     return years
 
 
+def check_overwrite(overwrite):
+    """
+    Make sure overwrite environmental variable is typed correctly.
+    """
+
+    if not overwrite:
+        overwrite = False
+
+    # Github inputs are passed as strings rather than booleans
+    if isinstance(overwrite, str):
+        overwrite = overwrite == "true"
+
+    return overwrite
+
+
 def get_asset_info(socrata_asset):
     """
     Simple helper function to retrieve asset-specific information from dbt.
@@ -241,10 +256,6 @@ def socrata_upload(socrata_asset, overwrite=False, years=None):
     (update rather than overwrite).
     """
 
-    # Github inputs are passed as strings rather than booleans
-    if isinstance(overwrite, str):
-        overwrite = overwrite == "true"
-
     athena_asset, asset_id = get_asset_info(socrata_asset)
 
     groups = generate_groups(years=years, athena_asset=athena_asset)
@@ -296,6 +307,6 @@ def socrata_upload(socrata_asset, overwrite=False, years=None):
 
 socrata_upload(
     socrata_asset=os.getenv("SOCRATA_ASSET"),
-    overwrite=os.getenv("OVERWRITE"),
+    overwrite=check_overwrite(os.getenv("OVERWRITE")),
     years=parse_years(os.getenv("YEARS")),
 )

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -294,7 +294,7 @@ def socrata_upload(socrata_asset, overwrite=False, years=None):
                 "sql_query": sql_query,
                 "overwrite": overwrite,
                 "count": count,
-                "year": item[0],
+                "year": item,
             }
             if count == 0 and overwrite:
                 upload("put", **upload_args)

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -300,6 +300,7 @@ def socrata_upload(socrata_asset, overwrite=False, years=None):
                 upload("put", **upload_args)
             else:
                 upload("post", **upload_args)
+            count += 1
 
     toc = time.perf_counter()
     print(f"Total upload in {toc - tic:0.4f} seconds")

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -42,6 +42,32 @@ def parse_years(years):
     return years
 
 
+def parse_years_list(athena_asset, years=None):
+    """
+    Helper function to determine what years need to be iterated over for
+    upload.
+    """
+
+    if years is not None:
+        if years == ["all"]:
+            years_list = (
+                cursor.execute(
+                    "SELECT DISTINCT year FROM "
+                    + athena_asset
+                    + " ORDER BY year"
+                )
+                .as_pandas()["year"]
+                .to_list()
+            )
+        else:
+            years_list = years
+
+    else:
+        years_list = None
+
+    return years_list
+
+
 def check_overwrite(overwrite):
     """
     Make sure overwrite environmental variable is typed correctly.
@@ -222,32 +248,6 @@ def upload(method, asset_id, sql_query, overwrite, count, year=None):
     # Return the updated count so that if this function is called in a loop
     # the updated count persists.
     return count
-
-
-def parse_years_list(athena_asset, years=None):
-    """
-    Helper function to determine what years need to be iterated over for
-    upload.
-    """
-
-    if years is not None:
-        if years == ["all"]:
-            years_list = (
-                cursor.execute(
-                    "SELECT DISTINCT year FROM "
-                    + athena_asset
-                    + " ORDER BY year"
-                )
-                .as_pandas()["year"]
-                .to_list()
-            )
-        else:
-            years_list = years
-
-    else:
-        years_list = None
-
-    return years_list
 
 
 def socrata_upload(socrata_asset, overwrite=False, years=None):


### PR DESCRIPTION
This PR removes chunking by township as an option for socrata uploads. Now that the script automatically chunks any group larger than 10,000 rows being able to dictate which years we'd like to upload is more than enough user choice.

I'm going to have to add functionality for handling multiple assets in one go in order to automate socrata uploads in a future PR, and simplifying this script as much as possible in preparation for that will save some time and energy.

I tested all the possible configurations of overwriting and year values, and all of the jobs ran as expected:

![image](https://github.com/user-attachments/assets/2d6ad98b-35f5-40c6-87fc-9a90b1edb097)
https://github.com/ccao-data/data-architecture/actions/runs/13421072113/job/37493591749

![image](https://github.com/user-attachments/assets/d14f14cd-8a90-4789-9493-4a98c8558ed4)
https://github.com/ccao-data/data-architecture/actions/runs/13421200605/job/37494008961

![image](https://github.com/user-attachments/assets/3b24ebc7-405c-4812-9788-9f577045ec07)
https://github.com/ccao-data/data-architecture/actions/runs/13421301622/job/37494345438

![image](https://github.com/user-attachments/assets/ac8a7897-5327-41e9-8708-595770f83817)
https://github.com/ccao-data/data-architecture/actions/runs/13422411118/job/37497958718

![image](https://github.com/user-attachments/assets/6bdf8f51-15e2-42ef-8960-638a43575661)
https://github.com/ccao-data/data-architecture/actions/runs/13422509341/job/37498265818

![image](https://github.com/user-attachments/assets/31d74c1d-b982-42b6-8df7-d7a4c74e013b)
https://github.com/ccao-data/data-architecture/actions/runs/13423091271/job/37500179006