### PR TITLE
Align open data db transformations with socrata

### DIFF
--- a/dbt/models/open_data/open_data.vw_sf_mf_improvement_char.sql
+++ b/dbt/models/open_data/open_data.vw_sf_mf_improvement_char.sql
@@ -50,17 +50,17 @@ SELECT
         WHEN char_apts = '6' THEN 'None'
     END AS char_apts,
     CASE
-        WHEN char_attic_fnsh = "1" THEN "Living Area"
-        WHEN char_attic_fnsh = "2" THEN "Partial"
-        WHEN char_attic_fnsh = "3" THEN "None"
+        WHEN char_attic_fnsh = '1' THEN 'Living Area'
+        WHEN char_attic_fnsh = '2' THEN 'Partial'
+        WHEN char_attic_fnsh = '3' THEN 'None'
     END AS char_attic_fnsh,
     CASE
         WHEN char_gar1_att = '1' THEN 'Yes'
         WHEN char_gar1_att = '2' THEN 'No'
     END AS char_gar1_att,
     CASE
-        WHEN char_gar1_area = "1" THEN "Yes"
-        WHEN char_gar1_area = "2" THEN "No"
+        WHEN char_gar1_area = '1' THEN 'Yes'
+        WHEN char_gar1_area = '2' THEN 'No'
     END AS char_gar1_area,
     CASE
         WHEN char_gar1_size = '1' THEN '1 cars'

--- a/dbt/models/open_data/open_data.vw_sf_mf_improvement_char.sql
+++ b/dbt/models/open_data/open_data.vw_sf_mf_improvement_char.sql
@@ -49,12 +49,19 @@ SELECT
         WHEN char_apts = '5' THEN 'Six'
         WHEN char_apts = '6' THEN 'None'
     END AS char_apts,
-    char_attic_fnsh,
+    CASE
+        WHEN char_attic_fnsh = "1" THEN "Living Area"
+        WHEN char_attic_fnsh = "2" THEN "Partial"
+        WHEN char_attic_fnsh = "3" THEN "None"
+    END AS char_attic_fnsh,
     CASE
         WHEN char_gar1_att = '1' THEN 'Yes'
         WHEN char_gar1_att = '2' THEN 'No'
     END AS char_gar1_att,
-    char_gar1_area,
+    CASE
+        WHEN char_gar1_area = "1" THEN "Yes"
+        WHEN char_gar1_area = "2" THEN "No"
+    END AS char_gar1_area,
     CASE
         WHEN char_gar1_size = '1' THEN '1 cars'
         WHEN char_gar1_size = '2' THEN '1.5 cars'
@@ -122,11 +129,6 @@ SELECT
         WHEN char_site = '3' THEN 'Detracts From Value'
     END AS char_site,
     char_ncu,
-    CASE
-        WHEN char_renovation = '1' THEN 'Yes'
-        WHEN char_renovation = '2' THEN 'No'
-    END AS char_renovation,
-    char_recent_renovation AS recent_renovation,
     CASE
         WHEN char_porch = '0' THEN 'None'
         WHEN char_porch = '1' THEN 'Frame Enclosed'


### PR DESCRIPTION
While investigating every open data asset for parity with the open data db, I came upon two columns that need to be but are not currently being transformed. These were the only two I could find.

```
select char_attic_fnsh, char_gar1_area, count(*) as count
from z_ci_align_open_data_db_columns_with_socrata_open_data.vw_sf_mf_improvement_char
group by char_attic_fnsh, char_gar1_area
```

char_attic_fnsh | char_gar1_area | count
-- | -- | --
Living Area | No | 3134847
  | No | 3472
Living Area | Yes | 179158
Partial | Yes | 1387
Partial | No | 181195
Partial |   | 99
  | Yes | 1609
Living Area | | 954
None |   | 4910
None | Yes | 2048661
  |   | 64803
None | No | 23931299