### PR TITLE
Remove class 999 from universe

### DIFF
--- a/dbt/models/default/default.vw_pin_address.sql
+++ b/dbt/models/default/default.vw_pin_address.sql
@@ -65,4 +65,5 @@ WHERE par.cur = 'Y'
     -- or that are not 14 characters long
     AND REGEXP_COUNT(par.parid, '[a-zA-Z]') = 0
     AND LENGTH(par.parid) = 14
+    -- Class 999 are test pins
     AND par.class NOT IN ('999')

--- a/dbt/models/default/default.vw_pin_address.sql
+++ b/dbt/models/default/default.vw_pin_address.sql
@@ -65,3 +65,4 @@ WHERE par.cur = 'Y'
     -- or that are not 14 characters long
     AND REGEXP_COUNT(par.parid, '[a-zA-Z]') = 0
     AND LENGTH(par.parid) = 14
+    AND par.class NOT IN ('999')

--- a/dbt/models/default/default.vw_pin_exempt.sql
+++ b/dbt/models/default/default.vw_pin_exempt.sql
@@ -49,3 +49,4 @@ WHERE
     -- or that are not 14 characters long
     AND REGEXP_COUNT(par.parid, '[a-zA-Z]') = 0
     AND LENGTH(par.parid) = 14
+    AND par.class NOT IN ('999')

--- a/dbt/models/default/default.vw_pin_exempt.sql
+++ b/dbt/models/default/default.vw_pin_exempt.sql
@@ -49,4 +49,5 @@ WHERE
     -- or that are not 14 characters long
     AND REGEXP_COUNT(par.parid, '[a-zA-Z]') = 0
     AND LENGTH(par.parid) = 14
+    -- Class 999 are test pins
     AND par.class NOT IN ('999')

--- a/dbt/models/default/default.vw_pin_universe.sql
+++ b/dbt/models/default/default.vw_pin_universe.sql
@@ -181,4 +181,5 @@ WHERE par.cur = 'Y'
     -- or that are not 14 characters long
     AND REGEXP_COUNT(par.parid, '[a-zA-Z]') = 0
     AND LENGTH(par.parid) = 14
+    -- Class 999 are test pins
     AND par.class NOT IN ('999')

--- a/dbt/models/default/default.vw_pin_universe.sql
+++ b/dbt/models/default/default.vw_pin_universe.sql
@@ -181,3 +181,4 @@ WHERE par.cur = 'Y'
     -- or that are not 14 characters long
     AND REGEXP_COUNT(par.parid, '[a-zA-Z]') = 0
     AND LENGTH(par.parid) = 14
+    AND par.class NOT IN ('999')

--- a/dbt/models/default/default.vw_pin_value.sql
+++ b/dbt/models/default/default.vw_pin_value.sql
@@ -37,6 +37,7 @@ WITH stages AS (
     WHERE rolltype != 'RR'
         AND deactivat IS NULL
         AND valclass IS NULL
+        -- Class 999 are test pins
         AND class NOT IN ('999')
     GROUP BY parid, taxyr
 ),
@@ -427,6 +428,7 @@ stage_values AS (
     AND asmt.rolltype != 'RR'
     AND asmt.deactivat IS NULL
     AND asmt.valclass IS NULL
+    -- Class 999 are test pins
     AND asmt.class NOT IN ('999')
     GROUP BY asmt.parid, asmt.taxyr
 ),

--- a/dbt/models/default/default.vw_pin_value.sql
+++ b/dbt/models/default/default.vw_pin_value.sql
@@ -37,6 +37,7 @@ WITH stages AS (
     WHERE rolltype != 'RR'
         AND deactivat IS NULL
         AND valclass IS NULL
+        AND class NOT IN ('999')
     GROUP BY parid, taxyr
 ),
 

--- a/dbt/models/default/default.vw_pin_value.sql
+++ b/dbt/models/default/default.vw_pin_value.sql
@@ -426,6 +426,7 @@ stage_values AS (
     AND asmt.rolltype != 'RR'
     AND asmt.deactivat IS NULL
     AND asmt.valclass IS NULL
+    AND asmt.class NOT IN ('999')
     GROUP BY asmt.parid, asmt.taxyr
 ),
 

--- a/dbt/models/default/schema/default.vw_pin_address.yml
+++ b/dbt/models/default/schema/default.vw_pin_address.yml
@@ -64,14 +64,17 @@ unit_tests:
     model: default.vw_pin_address
     given:
       - input: source("iasworld", "pardat")
-        rows: &invalid-pin-rows
+        rows:
           # `parid` is the important column here, and all other columns are
           # only set to ensure proper joins when creating the dummy tables
           - {parid: "00000000000000", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
           - {parid: "0", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
           - {parid: "A", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
       - input: source("iasworld", "legdat")
-        rows: *invalid-pin-rows
+        rows: &invalid-pin-rows
+          - {parid: "00000000000000", taxyr: "2024", cur: "Y", deactivat: null}
+          - {parid: "0", taxyr: "2024", cur: "Y", deactivat: null}
+          - {parid: "A", taxyr: "2024", cur: "Y", deactivat: null}
       - input: source("iasworld", "owndat")
         rows: *invalid-pin-rows
     expect:

--- a/dbt/models/default/schema/default.vw_pin_address.yml
+++ b/dbt/models/default/schema/default.vw_pin_address.yml
@@ -67,9 +67,9 @@ unit_tests:
         rows: &invalid-pin-rows
           # `parid` is the important column here, and all other columns are
           # only set to ensure proper joins when creating the dummy tables
-          - {parid: "00000000000000", taxyr: "2024", cur: "Y", deactivat: null}
-          - {parid: "0", taxyr: "2024", cur: "Y", deactivat: null}
-          - {parid: "A", taxyr: "2024", cur: "Y", deactivat: null}
+          - {parid: "00000000000000", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
+          - {parid: "0", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
+          - {parid: "A", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
       - input: source("iasworld", "legdat")
         rows: *invalid-pin-rows
       - input: source("iasworld", "owndat")

--- a/dbt/models/default/schema/default.vw_pin_address.yml
+++ b/dbt/models/default/schema/default.vw_pin_address.yml
@@ -67,9 +67,9 @@ unit_tests:
         rows:
           # `parid` is the important column here, and all other columns are
           # only set to ensure proper joins when creating the dummy tables
-          - {parid: "00000000000000", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
-          - {parid: "0", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
-          - {parid: "A", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
+          - {parid: "00000000000000", taxyr: "2024", class: "200", cur: "Y", deactivat: null}
+          - {parid: "0", taxyr: "2024", class: "200", cur: "Y", deactivat: null}
+          - {parid: "A", taxyr: "2024", class: "200", cur: "Y", deactivat: null}
       - input: source("iasworld", "legdat")
         rows: &invalid-pin-rows
           - {parid: "00000000000000", taxyr: "2024", cur: "Y", deactivat: null}

--- a/dbt/models/default/schema/default.vw_pin_exempt.yml
+++ b/dbt/models/default/schema/default.vw_pin_exempt.yml
@@ -68,9 +68,9 @@ unit_tests:
         rows:
           # `class` is the important column here, and all other columns are
           # only set to ensure proper joins when creating the dummy tables
-          - {parid: "00000000000000", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
-          - {parid: "0", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
-          - {parid: "A", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
+          - {parid: "00000000000000", taxyr: "2024", class: "200", cur: "Y", deactivat: null}
+          - {parid: "0", taxyr: "2024", class: "200", cur: "Y", deactivat: null}
+          - {parid: "A", taxyr: "2024", class: "200", cur: "Y", deactivat: null}
       - input: source("iasworld", "owndat")
         rows:
           - {parid: "00000000000000", taxyr: "2024", cur: "Y", deactivat: null, ownnum: "1"}

--- a/dbt/models/default/schema/default.vw_pin_exempt.yml
+++ b/dbt/models/default/schema/default.vw_pin_exempt.yml
@@ -68,9 +68,9 @@ unit_tests:
         rows:
           # `class` is the important column here, and all other columns are
           # only set to ensure proper joins when creating the dummy tables
-          - {parid: "00000000000000", taxyr: "2024", cur: "Y", deactivat: null}
-          - {parid: "0", taxyr: "2024", cur: "Y", deactivat: null}
-          - {parid: "A", taxyr: "2024", cur: "Y", deactivat: null}
+          - {parid: "00000000000000", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
+          - {parid: "0", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
+          - {parid: "A", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
       - input: source("iasworld", "owndat")
         rows:
           - {parid: "00000000000000", taxyr: "2024", cur: "Y", deactivat: null, ownnum: "1"}

--- a/dbt/models/default/schema/default.vw_pin_universe.yml
+++ b/dbt/models/default/schema/default.vw_pin_universe.yml
@@ -286,7 +286,7 @@ unit_tests:
         rows:
           # `class` is the important column here, and all other columns are
           # only set to ensure proper joins when creating the dummy tables
-          - {parid: "00000000000000", taxyr: "2024", cur: "Y", deactivat: null}
+          - {parid: "00000000000000", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
           - {parid: "0", taxyr: "2024", cur: "Y", deactivat: null}
           - {parid: "A", taxyr: "2024", cur: "Y", deactivat: null}
       - input: source("iasworld", "legdat")

--- a/dbt/models/default/schema/default.vw_pin_universe.yml
+++ b/dbt/models/default/schema/default.vw_pin_universe.yml
@@ -261,7 +261,7 @@ unit_tests:
         rows:
           # `class` is the important column here, and all other columns are
           # only set to ensure proper joins when creating the dummy tables
-          - {parid: "00000000000000", taxyr: "2024", cur: "Y", deactivat: null, class: "2.1-1)A"}
+          - {parid: "00000000000000", taxyr: "2024", class: '200', cur: "Y", deactivat: null, class: "2.1-1)A"}
       - input: source("iasworld", "legdat")
         rows:
           - {parid: "00000000000000", taxyr: "2024", cur: "Y", deactivat: null, user1: "70"}

--- a/dbt/models/default/schema/default.vw_pin_universe.yml
+++ b/dbt/models/default/schema/default.vw_pin_universe.yml
@@ -261,7 +261,7 @@ unit_tests:
         rows:
           # `class` is the important column here, and all other columns are
           # only set to ensure proper joins when creating the dummy tables
-          - {parid: "00000000000000", taxyr: "2024", class: '200', cur: "Y", deactivat: null, class: "2.1-1)A"}
+          - {parid: "00000000000000", taxyr: "2024", class: "200", cur: "Y", deactivat: null, class: "2.1-1)A"}
       - input: source("iasworld", "legdat")
         rows:
           - {parid: "00000000000000", taxyr: "2024", cur: "Y", deactivat: null, user1: "70"}
@@ -286,7 +286,7 @@ unit_tests:
         rows:
           # `class` is the important column here, and all other columns are
           # only set to ensure proper joins when creating the dummy tables
-          - {parid: "00000000000000", taxyr: "2024", class: '200', cur: "Y", deactivat: null}
+          - {parid: "00000000000000", taxyr: "2024", class: "200", cur: "Y", deactivat: null}
           - {parid: "0", taxyr: "2024", cur: "Y", deactivat: null}
           - {parid: "A", taxyr: "2024", cur: "Y", deactivat: null}
       - input: source("iasworld", "legdat")

--- a/dbt/models/default/schema/default.vw_pin_value.yml
+++ b/dbt/models/default/schema/default.vw_pin_value.yml
@@ -252,13 +252,13 @@ unit_tests:
           # `cur` and `procname` are the important fields that determine the
           # stage, everything else in these inputs is just for joins
           - {parid: "pre-mailed", taxyr: "2024", class: '200', cur: "Y", procname: null, rolltype: "RP", valasm3: 10}
-          - {parid: "mailed", taxyr: "2024", procname: "CCAOVALUE", rolltype: "RP", valasm3: 10}
+          - {parid: "mailed", taxyr: "2024", class: '200', procname: "CCAOVALUE", rolltype: "RP", valasm3: 10}
           # Pre-certified needs an extra row so that the history filter can see
           # that there has already been a mailed value
-          - {parid: "pre-certified", taxyr: "2024", procname: "CCAOVALUE", rolltype: "RP", valasm3: 10}
-          - {parid: "pre-certified", taxyr: "2024", cur: "Y", procname: null, rolltype: "RP", valasm3: 10}
-          - {parid: "ccao-certified", taxyr: "2024", procname: "CCAOFINAL", rolltype: "RP", valasm3: 10}
-          - {parid: "bor-certified", taxyr: "2024", procname: "BORVALUE", rolltype: "RP", valasm3: 10}
+          - {parid: "pre-certified", taxyr: "2024", class: '200', procname: "CCAOVALUE", rolltype: "RP", valasm3: 10}
+          - {parid: "pre-certified", taxyr: "2024", class: '200', cur: "Y", procname: null, rolltype: "RP", valasm3: 10}
+          - {parid: "ccao-certified", taxyr: "2024", class: '200', procname: "CCAOFINAL", rolltype: "RP", valasm3: 10}
+          - {parid: "bor-certified", taxyr: "2024", class: '200', procname: "BORVALUE", rolltype: "RP", valasm3: 10}
       # Reason codes are not important, and we only include them to complete
       # the joins that are required to construct the view
       - input: source("iasworld", "aprval")

--- a/dbt/models/default/schema/default.vw_pin_value.yml
+++ b/dbt/models/default/schema/default.vw_pin_value.yml
@@ -228,7 +228,7 @@ unit_tests:
         # `class` is the important column here, and all other columns are only
         # provided to ensure proper joins when creating the dummy table
         rows:
-          - {parid: "123", taxyr: "2024", procname: "CCAOVALUE", rolltype: "RP", valasm3: 10, class: "2.1-1)A"}
+          - {parid: "123", taxyr: "2024", class: '200', procname: "CCAOVALUE", rolltype: "RP", valasm3: 10, class: "2.1-1)A"}
       # The input tables below are not important, and are only included for the
       # sake of completing the joins that construct the view
       - input: source("iasworld", "aprval")
@@ -251,7 +251,7 @@ unit_tests:
         rows:
           # `cur` and `procname` are the important fields that determine the
           # stage, everything else in these inputs is just for joins
-          - {parid: "pre-mailed", taxyr: "2024", cur: "Y", procname: null, rolltype: "RP", valasm3: 10}
+          - {parid: "pre-mailed", taxyr: "2024", class: '200', cur: "Y", procname: null, rolltype: "RP", valasm3: 10}
           - {parid: "mailed", taxyr: "2024", procname: "CCAOVALUE", rolltype: "RP", valasm3: 10}
           # Pre-certified needs an extra row so that the history filter can see
           # that there has already been a mailed value

--- a/dbt/models/default/schema/default.vw_pin_value.yml
+++ b/dbt/models/default/schema/default.vw_pin_value.yml
@@ -228,7 +228,7 @@ unit_tests:
         # `class` is the important column here, and all other columns are only
         # provided to ensure proper joins when creating the dummy table
         rows:
-          - {parid: "123", taxyr: "2024", class: '200', procname: "CCAOVALUE", rolltype: "RP", valasm3: 10, class: "2.1-1)A"}
+          - {parid: "123", taxyr: "2024", class: "200", procname: "CCAOVALUE", rolltype: "RP", valasm3: 10, class: "2.1-1)A"}
       # The input tables below are not important, and are only included for the
       # sake of completing the joins that construct the view
       - input: source("iasworld", "aprval")
@@ -251,14 +251,14 @@ unit_tests:
         rows:
           # `cur` and `procname` are the important fields that determine the
           # stage, everything else in these inputs is just for joins
-          - {parid: "pre-mailed", taxyr: "2024", class: '200', cur: "Y", procname: null, rolltype: "RP", valasm3: 10}
-          - {parid: "mailed", taxyr: "2024", class: '200', procname: "CCAOVALUE", rolltype: "RP", valasm3: 10}
+          - {parid: "pre-mailed", taxyr: "2024", class: "200", cur: "Y", procname: null, rolltype: "RP", valasm3: 10}
+          - {parid: "mailed", taxyr: "2024", class: "200", procname: "CCAOVALUE", rolltype: "RP", valasm3: 10}
           # Pre-certified needs an extra row so that the history filter can see
           # that there has already been a mailed value
-          - {parid: "pre-certified", taxyr: "2024", class: '200', procname: "CCAOVALUE", rolltype: "RP", valasm3: 10}
-          - {parid: "pre-certified", taxyr: "2024", class: '200', cur: "Y", procname: null, rolltype: "RP", valasm3: 10}
-          - {parid: "ccao-certified", taxyr: "2024", class: '200', procname: "CCAOFINAL", rolltype: "RP", valasm3: 10}
-          - {parid: "bor-certified", taxyr: "2024", class: '200', procname: "BORVALUE", rolltype: "RP", valasm3: 10}
+          - {parid: "pre-certified", taxyr: "2024", class: "200", procname: "CCAOVALUE", rolltype: "RP", valasm3: 10}
+          - {parid: "pre-certified", taxyr: "2024", class: "200", cur: "Y", procname: null, rolltype: "RP", valasm3: 10}
+          - {parid: "ccao-certified", taxyr: "2024", class: "200", procname: "CCAOFINAL", rolltype: "RP", valasm3: 10}
+          - {parid: "bor-certified", taxyr: "2024", class: "200", procname: "BORVALUE", rolltype: "RP", valasm3: 10}
       # Reason codes are not important, and we only include them to complete
       # the joins that are required to construct the view
       - input: source("iasworld", "aprval")

--- a/dbt/models/default/schema/default.vw_pin_value.yml
+++ b/dbt/models/default/schema/default.vw_pin_value.yml
@@ -198,7 +198,7 @@ models:
         column_name: mailed_class
         config:
           where: CAST(year AS int) < {{ var('data_test_iasworld_year_start') }}
-          error_if: ">289"
+          error_if: ">310"
     - not_null:
         name: default_vw_pin_value_mailed_tot_mv_not_null
         column_name: mailed_tot_mv

--- a/dbt/models/model/model.vw_pin_shared_input.sql
+++ b/dbt/models/model/model.vw_pin_shared_input.sql
@@ -65,6 +65,8 @@ WITH uni AS (
         ON leg.user1 = CAST(twn.township_code AS VARCHAR)
     WHERE par.cur = 'Y'
         AND par.deactivat IS NULL
+        -- Class 999 are test pins
+        AND par.class NOT IN ('999')
 ),
 
 acs5 AS (
@@ -148,6 +150,8 @@ tax_bill_amount AS (
     WHERE pin.pin IS NOT NULL
         AND pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
+        -- Class 999 are test pins
+        AND pardat.class NOT IN ('999')
 ),
 
 school_district_ratings AS (

--- a/dbt/models/reporting/reporting.vw_pin_most_recent_sale.sql
+++ b/dbt/models/reporting/reporting.vw_pin_most_recent_sale.sql
@@ -6,6 +6,8 @@ WITH all_pins AS (
     FROM {{ source('iasworld', 'pardat') }}
     WHERE cur = 'Y'
         AND deactivat IS NULL
+        -- Class 999 are test pins
+        AND class NOT IN ('999')
         -- noqa: disable=RF02
         AND taxyr = (
             SELECT MAX(taxyr)

--- a/dbt/models/reporting/reporting.vw_pin_township_class.sql
+++ b/dbt/models/reporting/reporting.vw_pin_township_class.sql
@@ -67,3 +67,5 @@ LEFT JOIN {{ ref('location.tax') }} AS tax
     END = tax.year
 WHERE correct.cur = 'Y'
     AND correct.deactivat IS NULL
+    -- Class 999 are test pins
+    AND correct.class NOT IN ('999')

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -263,6 +263,7 @@ models:
             where: >
               CAST(year AS int) BETWEEN {{ var('data_test_iasworld_year_start') }}
               AND {{ var('data_test_iasworld_year_end') }}
+            error_if: ">5"
       - unique_combination_of_columns:
           name: reporting_vw_pin_township_class_unique_by_14_digit_pin_year_stage
           combination_of_columns:


### PR DESCRIPTION
Class `999` are test parcels and don't serve any purpose being in our athena databases. We can leave them in `default.vw_pin_status` since that view explicitly tracks them. I only applied these changes to views that use `pardat` or `asmt_all` as a base and join other sources onto those tables. Views that join `pardat` or `asmt_all` onto other sources as a base shouldn't have any class `999` parcels to worry about; they only seem to exist in `pardat` and `asmt_all` and I checked every view in the `default` db that wasn't built on one them to confirm this (included appeals, sales, etc.). The reporting view that was updated doesn't have any differences in row count because we're already inner joining on `ccao.class_dict` which doesn't contain class `999`.

```
select 'pardat' as "table", count(*) as count from iasworld.pardat
where class = '999'
and deactivat is null
and cur = 'Y'

union all

select 'asmt_all' as "table", count(*) as count from iasworld.asmt_all
where class = '999'
and deactivat is null
and cur = 'Y'

union all

select 'comdat' as "table", count(*) as count from iasworld.comdat
where class = '999'
and deactivat is null
and cur = 'Y'

union all

select 'dweldat' as "table", count(*) as count from iasworld.dweldat
where class = '999'
and deactivat is null
and cur = 'Y'

union all

select 'oby' as "table", count(*) as count from iasworld.oby
where class = '999'
and deactivat is null
and cur = 'Y'
```

table | count
-- | --
dweldat | 0
asmt_all | 87
comdat | 0
pardat | 104
oby | 0

## default.vw_pin_address
```
with old as (
	select year,
		count(*) as old,
		sum(
			case
				when class = '999' then 1 else 0
			end
		) as class_999_count
	from default.vw_pin_address as vpa
		left join iasworld.pardat on vpa.pin = pardat.parid
		and vpa.year = pardat.taxyr
		and pardat.cur = 'Y'
		and pardat.deactivat is null
	group by year
),
new as (
	select year,
		count(*) as new
	from z_ci_remove_class_999_from_universe_default.vw_pin_address
	group by year
)
select old.year,
	old.old,
	new.new,
	old - new as diff,
	class_999_count
from old
	left join new on old.year = new.year
order by year desc
```

year | old | new | diff | class_999_count
-- | -- | -- | -- | --
2025 | 1864055 | 1863954 | 101 | 101
2024 | 1864107 | 1864107 | 0 | 0
2023 | 1864161 | 1864161 | 0 | 0
2022 | 1865018 | 1865016 | 2 | 2
2021 | 1864589 | 1864589 | 0 | 0
2020 | 1864035 | 1864035 | 0 | 0
2019 | 1864102 | 1864102 | 0 | 0
2018 | 1864590 | 1864590 | 0 | 0
2017 | 1864621 | 1864621 | 0 | 0
2016 | 1863996 | 1863996 | 0 | 0
2015 | 1862756 | 1862756 | 0 | 0
2014 | 1862170 | 1862170 | 0 | 0
2013 | 1861935 | 1861935 | 0 | 0
2012 | 1862181 | 1862181 | 0 | 0
2011 | 1861008 | 1861008 | 0 | 0
2010 | 1859244 | 1859244 | 0 | 0
2009 | 1849650 | 1849650 | 0 | 0
2008 | 1832618 | 1832618 | 0 | 0
2007 | 1804219 | 1804219 | 0 | 0
2006 | 1771314 | 1771314 | 0 | 0
2005 | 1740965 | 1740965 | 0 | 0
2004 | 1716218 | 1716218 | 0 | 0
2003 | 1693153 | 1693153 | 0 | 0
2002 | 1673735 | 1673735 | 0 | 0
2001 | 1655398 | 1655398 | 0 | 0
2000 | 1637269 | 1637269 | 0 | 0
1999 | 1620990 | 1620990 | 0 | 0

## default.vw_pin_exempt
```
with old as (
	select year,
		count(*) as old,
		sum(
			case
				when class = '999' then 1 else 0
			end
		) as class_999_count
	from default.vw_pin_exempt
	group by year
),
new as (
	select year,
		count(*) as new
	from z_ci_remove_class_999_from_universe_default.vw_pin_exempt
	group by year
)
select old.year,
	old.old,
	new.new,
	old - new as diff,
	class_999_count
from old
	left join new on old.year = new.year
order by year desc
```

year | old | new | diff | class_999_count
-- | -- | -- | -- | --
2025 | 93501 | ### | 0 | 0
2024 | 93509 | ### | 0 | 0
2023 | 92481 | ### | 0 | 0
2022 | 92416 | ### | 0 | 0

## default.vw_pin_universe
```
with old as (
	select year,
		count(*) as old,
		sum(
			case
				when class = '999' then 1 else 0
			end
		) as class_999_count
	from default.vw_pin_universe
	group by year
),
new as (
	select year,
		count(*) as new
	from z_ci_remove_class_999_from_universe_default.vw_pin_universe
	group by year
)
select old.year,
	old.old,
	new.new,
	old - new as diff,
	class_999_count
from old
	left join new on old.year = new.year
order by year desc
```

year | old | new | diff | class_999_count
-- | -- | -- | -- | --
2025 | 1864055 | 1863954 | 101 | 101
2024 | 1864107 | 1864107 | 0 | 0
2023 | 1864161 | 1864161 | 0 | 0
2022 | 1865018 | 1865016 | 2 | 2
2021 | 1864589 | 1864589 | 0 | 0
2020 | 1864035 | 1864035 | 0 | 0
2019 | 1864102 | 1864102 | 0 | 0
2018 | 1864590 | 1864590 | 0 | 0
2017 | 1864621 | 1864621 | 0 | 0
2016 | 1863996 | 1863996 | 0 | 0
2015 | 1862756 | 1862756 | 0 | 0
2014 | 1862170 | 1862170 | 0 | 0
2013 | 1861935 | 1861935 | 0 | 0
2012 | 1862181 | 1862181 | 0 | 0
2011 | 1861008 | 1861008 | 0 | 0
2010 | 1859244 | 1859244 | 0 | 0
2009 | 1849650 | 1849650 | 0 | 0
2008 | 1832618 | 1832618 | 0 | 0
2007 | 1804219 | 1804219 | 0 | 0
2006 | 1771314 | 1771314 | 0 | 0
2005 | 1740965 | 1740965 | 0 | 0
2004 | 1716218 | 1716218 | 0 | 0
2003 | 1693153 | 1693153 | 0 | 0
2002 | 1673735 | 1673735 | 0 | 0
2001 | 1655398 | 1655398 | 0 | 0
2000 | 1637269 | 1637269 | 0 | 0
1999 | 1620990 | 1620990 | 0 | 0

## default.vw_pin_value

```
select old.pin,
	old.year,
	old.pre_mailed_class,
	new.pre_mailed_tot,
	old.mailed_class,
	new.mailed_tot,
	old.pre_certified_class,
	new.pre_certified_tot,
	old.certified_class,
	new.certified_tot,
	old.board_class,
	new.board_tot
from default.vw_pin_value old
	left join z_ci_remove_class_999_from_universe_default.vw_pin_value new
	on old.pin = new.pin
	and old.year = new.year
where new.pin is null
    OR (new.pre_mailed_class IS NULL AND old.pre_mailed_class IS NOT NULL)
	OR (new.mailed_class IS NULL AND old.mailed_class IS NOT NULL)
	OR (new.pre_certified_class IS NULL AND old.pre_certified_class IS NOT NULL)
	OR (new.certified_class IS NULL AND old.certified_class IS NOT NULL)
	OR (new.board_class IS NULL AND old.board_class IS NOT NULL)
```

The output for this query is too large to share here, but it yields 95 rows that are either missing entirely since they were `999` parcels with pre-mailed values only, or they were parcels with class 999 for mailed values in 2021 which are now null (those rows retain there values for other stages).

## model.vw_pin_shared_input

```
with old as (
	select meta_year,
		count(*) as old,
		sum(
			case
				when meta_class = '999' then 1 else 0
			end
		) as class_999_count
	from model.vw_pin_shared_input
	group by meta_year
),
new as (
	select meta_year,
		count(*) as new
	from z_ci_remove_class_999_from_universe_model.vw_pin_shared_input
	group by meta_year
)
select old.meta_year,
	old.old,
	new.new,
	old - new as diff,
	class_999_count
from old
	left join new on old.meta_year = new.meta_year
order by meta_year desc
```

meta_year | old | new | diff | class_999_count
-- | -- | -- | -- | --
2025 | 1864055 | 1863954 | 101 | 101
2024 | 1864107 | 1864107 | 0 | 0
2023 | 1864162 | 1864161 | 1 | 1
2022 | 1865018 | 1865016 | 2 | 2
2021 | 1864589 | 1864589 | 0 | 0
2020 | 1864035 | 1864035 | 0 | 0
2019 | 1864102 | 1864102 | 0 | 0
2018 | 1864590 | 1864590 | 0 | 0
2017 | 1864621 | 1864621 | 0 | 0
2016 | 1863996 | 1863996 | 0 | 0
2015 | 1862756 | 1862756 | 0 | 0
2014 | 1862170 | 1862170 | 0 | 0
2013 | 1861935 | 1861935 | 0 | 0
2012 | 1862181 | 1862181 | 0 | 0
2011 | 1861008 | 1861008 | 0 | 0
2010 | 1859244 | 1859244 | 0 | 0
2009 | 1849650 | 1849650 | 0 | 0
2008 | 1832618 | 1832618 | 0 | 0
2007 | 1804219 | 1804219 | 0 | 0
2006 | 1771314 | 1771314 | 0 | 0
2005 | 1740965 | 1740965 | 0 | 0
2004 | 1716218 | 1716218 | 0 | 0
2003 | 1693153 | 1693153 | 0 | 0
2002 | 1673735 | 1673735 | 0 | 0
2001 | 1655398 | 1655398 | 0 | 0
2000 | 1637269 | 1637269 | 0 | 0
1999 | 1620990 | 1620990 | 0 | 0