### PR TITLE
Pull prior year AVs to match prior year MVs in prior year val IC QC view

### DIFF
--- a/dbt/models/qc/qc.vw_ic_reference_all_non_res_pin_level_prior_year_vals.sql
+++ b/dbt/models/qc/qc.vw_ic_reference_all_non_res_pin_level_prior_year_vals.sql
@@ -40,8 +40,8 @@ LEFT JOIN (
     EXCEPT
     SELECT asmt_hist.* FROM {{ source('iasworld', 'asmt_hist') }} AS asmt_hist
 ) AS asmt
-    ON pardat.parid = asmt.parid
-    AND pardat.taxyr = asmt.taxyr
+    ON aprval.parid = asmt.parid
+    AND aprval.taxyr = asmt.taxyr
     AND asmt.cur = 'Y'
     AND asmt.deactivat IS NULL
     AND asmt.valclass IS NULL


### PR DESCRIPTION
This PR fixes a small bug that Valuations noticed in the QC view that IC uses for comparing prior year values. The view should return prior year AVs and MVs for all parcels in the current year, but it's returning current year AVs instead. The source of the bug is that the query currently joins `pardat` to `aprval` on `aprval.taxyr + 1 = pardat.taxyr` in order to get prior year MVs for parcels in the current year, but then it joins `asmt_all` to `pardat` using `taxyr`, which returns current year AVs. By joining `asmt_all` to `aprval` using `taxyr` instead, we return prior year AVs to match the prior year MVs.

Valuations has confirmed that this fix works on their end.