### PR TITLE
Simplify Socrata API script and allow multiple assets to be updated

### DIFF
--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -6,19 +6,9 @@ on:
       socrata_asset:
         type: string
         description: >
-          Comma-separated Socrata assets to update. Options are:
-          Appeals |
-          Assessed Values |
-          Parcel Addresses |
-          Parcel Proximity |
-          Parcel Sales |
-          Parcel Status |
-          Permits |
-          Property Tax-Exempt Parcels |
-          Parcel Universe (Historic) |
-          Parcel Universe (Current Year) |
-          Residential Condominium Unit Characteristics |
-          Single and Multi-Family Improvement Characteristics
+          Comma-separated Socrata assets to update. Run
+          `dbt list --resource-types exposure --output json --output-keys label`
+          to see options.
         required: true
       years:
         # Comma separated list of years

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -25,8 +25,8 @@ on:
         type: string
         description: >
           Years to update or overwrite (comma-separated). Leaving this field
-          blank will upload an entire asset in one piece. Enter 'all' to upload
-          all years individually.
+          blank will upload an entire asset in one piece. Enter 'all' to chunk
+          the upload by year for all years.
         required: false
       overwrite:
         # True for overwrite, False for update

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -6,19 +6,19 @@ on:
       socrata_asset:
         type: string
         description: |
-          Target Socrata asset. Options are:
-          - Appeals
-          - Assessed Values
-          - Parcel Addresses
-          - Parcel Proximity
-          - Parcel Sales
-          - Parcel Status
-          - Permits
-          - Property Tax-Exempt Parcels
-          - Parcel Universe (Historic)
-          - Parcel Universe (Current Year)
-          - Residential Condominium Unit Characteristics
-          - Single and Multi-Family Improvement Characteristics
+          Target Socrata asset. Options are:\n
+          * Appeals\n
+          * Assessed Values\n
+          * Parcel Addresses\n
+          * Parcel Proximity\n
+          * Parcel Sales\n
+          * Parcel Status\n
+          * Permits\n
+          * Property Tax-Exempt Parcels\n
+          * Parcel Universe (Historic)\n
+          * Parcel Universe (Current Year)\n
+          * Residential Condominium Unit Characteristics\n
+          * Single and Multi-Family Improvement Characteristics
         required: true
       overwrite:
         # True for overwrite, False for update

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -5,19 +5,19 @@ on:
     inputs:
       socrata_asset:
         type: string
-        description: |
-          Target Socrata asset. Options are:
-          Appeals
-          Assessed Values
-          Parcel Addresses
-          Parcel Proximity
-          Parcel Sales
-          Parcel Status
-          Permits
-          Property Tax-Exempt Parcels
-          Parcel Universe (Historic)
-          Parcel Universe (Current Year)
-          Residential Condominium Unit Characteristics
+        description: >
+          Comma-separated Socrata assets to update. Options are:
+          Appeals |
+          Assessed Values |
+          Parcel Addresses |
+          Parcel Proximity |
+          Parcel Sales |
+          Parcel Status |
+          Permits |
+          Property Tax-Exempt Parcels |
+          Parcel Universe (Historic) |
+          Parcel Universe (Current Year) |
+          Residential Condominium Unit Characteristics |
           Single and Multi-Family Improvement Characteristics
         required: true
       overwrite:

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -6,9 +6,9 @@ on:
       socrata_asset:
         type: string
         description: >
-          Comma-separated Socrata assets to update. Run
-          `dbt list --resource-types exposure --output json --output-keys label`
-          to see options.
+          Comma-separated list of names of Socrata assets to update.
+          Asset names are the same as the asset title in Socrata (or dbt
+          exposure labels), minus the "Assessor - " prefix.
         required: true
       years:
         # Comma separated list of years

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -4,22 +4,21 @@ on:
   workflow_dispatch:
     inputs:
       socrata_asset:
-        type: choice
-        description: Target Socrata asset
-        options:
-        - Appeals
-        - Assessed Values
-        - Parcel Addresses
-        - Parcel Proximity
-        - Parcel Sales
-        - Parcel Status
-        - Permits
-        - Property Tax-Exempt Parcels
-        - Parcel Universe (Historic)
-        - Parcel Universe (Current Year)
-        - Residential Condominium Unit Characteristics
-        - Single and Multi-Family Improvement Characteristics
-        default: Parcel Universe (Current Year)
+        type: string
+        description: |
+          Target Socrata asset. Options are:
+          - Appeals
+          - Assessed Values
+          - Parcel Addresses
+          - Parcel Proximity
+          - Parcel Sales
+          - Parcel Status
+          - Permits
+          - Property Tax-Exempt Parcels
+          - Parcel Universe (Historic)
+          - Parcel Universe (Current Year)
+          - Residential Condominium Unit Characteristics
+          - Single and Multi-Family Improvement Characteristics
         required: true
       overwrite:
         # True for overwrite, False for update

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -6,19 +6,19 @@ on:
       socrata_asset:
         type: string
         description: |
-          Target Socrata asset. Options are:\n
-          * Appeals\n
-          * Assessed Values\n
-          * Parcel Addresses\n
-          * Parcel Proximity\n
-          * Parcel Sales\n
-          * Parcel Status\n
-          * Permits\n
-          * Property Tax-Exempt Parcels\n
-          * Parcel Universe (Historic)\n
-          * Parcel Universe (Current Year)\n
-          * Residential Condominium Unit Characteristics\n
-          * Single and Multi-Family Improvement Characteristics
+          Target Socrata asset. Options are:
+          Appeals
+          Assessed Values
+          Parcel Addresses
+          Parcel Proximity
+          Parcel Sales
+          Parcel Status
+          Permits
+          Property Tax-Exempt Parcels
+          Parcel Universe (Historic)
+          Parcel Universe (Current Year)
+          Residential Condominium Unit Characteristics
+          Single and Multi-Family Improvement Characteristics
         required: true
       overwrite:
         # True for overwrite, False for update

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -10,7 +10,7 @@ on:
           Appeals |
           Assessed Values |
           Parcel Addresses |
-          Parcel Proximity<br>
+          Parcel Proximity |
           Parcel Sales |
           Parcel Status |
           Permits |

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -10,7 +10,7 @@ on:
           Appeals |
           Assessed Values |
           Parcel Addresses |
-          Parcel Proximity |
+          Parcel Proximity<br>
           Parcel Sales |
           Parcel Status |
           Permits |

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -20,16 +20,19 @@ on:
           Residential Condominium Unit Characteristics |
           Single and Multi-Family Improvement Characteristics
         required: true
+      years:
+        # Comma separated list of years
+        type: string
+        description: >
+          Years to update or overwrite (comma-separated). Leaving this field
+          blank will upload an entire asset in one piece. Enter 'all' to upload
+          all years individually.
+        required: false
       overwrite:
         # True for overwrite, False for update
         type: boolean
         description: Overwrite socrata asset
         required: true
-      years:
-        # Comma separated list of years
-        type: string
-        description: Years to update or overwrite (comma-separated). Enter 'all' to upload all years individually.
-        required: false
 
 
 env:

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -28,8 +28,7 @@ on:
       years:
         # Comma separated list of years
         type: string
-        description: Years to update or overwrite (comma-separated)
-        default: 'all'
+        description: Years to update or overwrite (comma-separated). Enter 'all' to upload all years individually.
         required: false
 
 

--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -199,7 +199,7 @@ exposures:
       name: Data Department
     meta:
       test_row_count: true
-      asset_id: vgzx-68gb
+      asset_id: 3sp4-s4qg
       primary_key:
         - pin
         - year

--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -180,7 +180,7 @@ exposures:
       # Disabled until the asset is public
       test_row_count: false
       year_field: assessment_year
-      asset_id: tqd2-4zjs
+      asset_id: 6yjf-dfxs
       primary_key:
         - pin
         - permit_number
@@ -199,7 +199,7 @@ exposures:
       name: Data Department
     meta:
       test_row_count: true
-      asset_id: 3sp4-s4qg
+      asset_id: vgzx-68gb
       primary_key:
         - pin
         - year

--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -180,7 +180,7 @@ exposures:
       # Disabled until the asset is public
       test_row_count: false
       year_field: assessment_year
-      asset_id: 6yjf-dfxs
+      asset_id: tqd2-4zjs
       primary_key:
         - pin
         - permit_number

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -276,6 +276,3 @@ socrata_upload(
     overwrite=check_overwrite(os.getenv("OVERWRITE")),
     years=parse_years(os.getenv("YEARS")),
 )
-
-
-# %%

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -144,8 +144,9 @@ def get_asset_info(socrata_asset):
 
 def build_query(athena_asset, asset_id, years=None):
     """
-    Build a dictionary of Athena compatible SQL queries and their associated years. Many of the CCAO's open data assets are
-    too large to pass to Socrata without chunking.
+    Build a dictionary of Athena compatible SQL queries and their associated
+    years. Many of the CCAO's open data assets are too large to pass to Socrata
+    without chunking.
     """
 
     # Retrieve column names and types from Athena

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -281,13 +281,13 @@ def socrata_upload(socrata_asset, overwrite=False, years=None):
     print(f"Total upload in {toc - tic:0.4f} seconds")
 
 
-# Retrieve asset(s)
-all_assets = parse_assets(os.getenv("SOCRATA_ASSET"))
+if __name__ == "__main__":
+    # Retrieve asset(s)
+    all_assets = parse_assets(os.getenv("SOCRATA_ASSET"))
 
-
-for asset in all_assets:
-    socrata_upload(
-        socrata_asset=asset,
-        overwrite=check_overwrite(os.getenv("OVERWRITE")),
-        years=parse_years(os.getenv("YEARS")),
-    )
+    for asset in all_assets:
+        socrata_upload(
+            socrata_asset=asset,
+            overwrite=check_overwrite(os.getenv("OVERWRITE")),
+            years=parse_years(os.getenv("YEARS")),
+        )

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -42,7 +42,7 @@ def parse_assets(assets):
     return assets
 
 
-def parse_years(years):
+def parse_years(years=None):
     """
     Make sure the years environmental variable is formatted correctly.
     """
@@ -81,7 +81,7 @@ def parse_years_list(athena_asset, years=None):
     return years_list
 
 
-def check_overwrite(overwrite):
+def check_overwrite(overwrite=False):
     """
     Make sure overwrite environmental variable is typed correctly.
     """

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -215,8 +215,6 @@ def build_query_dict(athena_asset, asset_id, years=None):
     return query_dict
 
 
-# %%
-# %%
 def upload(asset_id, sql_query, overwrite):
     """
     Function to perform the upload to Socrata. `puts` or `posts` depending on

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -187,6 +187,7 @@ def build_query(athena_asset, asset_id, years=None):
 
     query = f"SELECT {', '.join(columns['column'])} FROM {athena_asset}"
 
+    # Build a dictionary with queries for each year requested, or no years
     if not years:
         query = {None: query}
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -36,10 +36,7 @@ def parse_assets(assets):
     Make sure the asset environmental variable is formatted correctly.
     """
 
-    assets = str(assets).split(",")
-    assets = [i.strip() for i in assets]
-
-    return assets
+    return [asset.strip() for asset in str(assets).split(",")]
 
 
 def parse_years(years=None):

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -100,9 +100,6 @@ def get_asset_info(socrata_asset):
     Simple helper function to retrieve asset-specific information from dbt.
     """
 
-    if not os.path.isdir("./dbt"):
-        os.chdir("..")
-
     os.chdir("./dbt")
 
     DBT = dbtRunner()

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 import os
+import re
 import time
 
 import pandas as pd
@@ -48,6 +49,13 @@ def parse_years(years=None):
         years = None
     if years is not None:
         years = str(years).replace(" ", "").split(",")
+
+        # Only allow anticipated values
+        years = [
+            re.sub("[^0-9]", "", year)
+            for year in years
+            if re.sub("[^0-9]", "", year)
+        ]
 
     return years
 
@@ -207,6 +215,8 @@ def build_query_dict(athena_asset, asset_id, years=None):
     return query_dict
 
 
+# %%
+# %%
 def upload(asset_id, sql_query, overwrite):
     """
     Function to perform the upload to Socrata. `puts` or `posts` depending on

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -82,7 +82,7 @@ def parse_years_list(athena_asset, years=None):
     return years_list
 
 
-def check_overwrite(overwrite=False):
+def check_overwrite(overwrite):
     """
     Make sure overwrite environmental variable is typed correctly.
     """
@@ -285,10 +285,12 @@ def socrata_upload(socrata_asset, overwrite=False, years=None):
 
 # Retrieve asset(s)
 all_assets = parse_assets(os.getenv("SOCRATA_ASSET"))
+overwrite = check_overwrite(os.getenv("OVERWRITE"))
+years = parse_years(os.getenv("YEARS"))
 
 for asset in all_assets:
     socrata_upload(
         socrata_asset=asset,
-        overwrite=check_overwrite(os.getenv("OVERWRITE")),
-        years=parse_years(os.getenv("YEARS")),
+        overwrite=overwrite,
+        years=years,
     )

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -60,7 +60,7 @@ def parse_years_list(athena_asset, years=None):
     Helper function to determine what years need to be iterated over for
     upload.
     """
-
+    print(years)
     if years is not None:
         if years == ["all"]:
             years_list = (
@@ -78,6 +78,7 @@ def parse_years_list(athena_asset, years=None):
     else:
         years_list = None
 
+    print(years_list)
     return years_list
 
 
@@ -197,7 +198,7 @@ def build_query(athena_asset, asset_id, years=None):
     print(columns)
 
     query = f"SELECT {', '.join(columns['column'])} FROM {athena_asset}"
-    print(years)
+
     # Build a dictionary with queries for each year requested, or no years
     if not years:
         query = {None: query}

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -289,6 +289,7 @@ overwrite = check_overwrite(os.getenv("OVERWRITE"))
 years = parse_years(os.getenv("YEARS"))
 
 for asset in all_assets:
+    print(years)
     socrata_upload(
         socrata_asset=asset,
         overwrite=overwrite,

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -280,6 +280,7 @@ def socrata_upload(socrata_asset, overwrite=False, years=None):
     print(f"Total upload in {toc - tic:0.4f} seconds")
 
 
+# Retrieve asset(s)
 all_assets = parse_assets(os.getenv("SOCRATA_ASSET"))
 
 for asset in all_assets:
@@ -288,4 +289,3 @@ for asset in all_assets:
         overwrite=check_overwrite(os.getenv("OVERWRITE")),
         years=parse_years(os.getenv("YEARS")),
     )
-# %%

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -31,6 +31,16 @@ cursor = connect(
 ).cursor(unload=True)
 
 
+def parse_assets(assets):
+    """
+    Make sure the asset environmental variable is formatted correctly.
+    """
+
+    assets = str(assets).replace(" ", "").split(",")
+
+    return assets
+
+
 def parse_years(years):
     """
     Make sure the years environmental variable is formatted correctly.
@@ -270,8 +280,12 @@ def socrata_upload(socrata_asset, overwrite=False, years=None):
     print(f"Total upload in {toc - tic:0.4f} seconds")
 
 
-socrata_upload(
-    socrata_asset=os.getenv("SOCRATA_ASSET"),
-    overwrite=check_overwrite(os.getenv("OVERWRITE")),
-    years=parse_years(os.getenv("YEARS")),
-)
+all_assets = parse_assets(os.getenv("SOCRATA_ASSET"))
+
+for asset in all_assets:
+    socrata_upload(
+        socrata_asset=asset,
+        overwrite=check_overwrite(os.getenv("OVERWRITE")),
+        years=parse_years(os.getenv("YEARS")),
+    )
+# %%

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -199,13 +199,12 @@ def build_query_dict(athena_asset, asset_id, years=None):
 
     # Build a dictionary with queries for each year requested, or no years
     if not years:
-        query = {None: query}
+        query_dict = {None: query}
 
     else:
-        query = [query + " WHERE year = '" + year + "'" for year in years]
-        query = dict([(k, v) for k, v in zip(years, query)])
+        query_dict = {year: f"{query} WHERE year = '{year}'" for year in years}
 
-    return query
+    return query_dict
 
 
 def upload(asset_id, sql_query, overwrite):

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -60,7 +60,7 @@ def parse_years_list(athena_asset, years=None):
     Helper function to determine what years need to be iterated over for
     upload.
     """
-    print(years)
+
     if years is not None:
         if years == ["all"]:
             years_list = (
@@ -78,7 +78,6 @@ def parse_years_list(athena_asset, years=None):
     else:
         years_list = None
 
-    print(years_list)
     return years_list
 
 
@@ -285,13 +284,11 @@ def socrata_upload(socrata_asset, overwrite=False, years=None):
 
 # Retrieve asset(s)
 all_assets = parse_assets(os.getenv("SOCRATA_ASSET"))
-overwrite = check_overwrite(os.getenv("OVERWRITE"))
-years = parse_years(os.getenv("YEARS"))
+
 
 for asset in all_assets:
-    print(years)
     socrata_upload(
         socrata_asset=asset,
-        overwrite=overwrite,
-        years=years,
+        overwrite=check_overwrite(os.getenv("OVERWRITE")),
+        years=parse_years(os.getenv("YEARS")),
     )

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -141,7 +141,7 @@ def get_asset_info(socrata_asset):
     return athena_asset, asset_id
 
 
-def build_query(athena_asset, asset_id, years=None):
+def build_query_dict(athena_asset, asset_id, years=None):
     """
     Build a dictionary of Athena compatible SQL queries and their associated
     years. Many of the CCAO's open data assets are too large to pass to Socrata
@@ -268,7 +268,7 @@ def socrata_upload(socrata_asset, overwrite=False, years=None):
 
     years_list = parse_years_list(years=years, athena_asset=athena_asset)
 
-    sql_query = build_query(
+    sql_query = build_query_dict(
         athena_asset=athena_asset,
         asset_id=asset_id,
         years=years_list,

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -221,15 +221,6 @@ def upload(method, asset_id, sql_query, overwrite, count, year=None):
         input_data[i] = input_data[i].fillna("").dt.strftime("%Y-%m-%dT%X")
 
     # Raise URL status if it's bad
-    session.get(
-        (
-            "https://datacatalog.cookcountyil.gov/resource/"
-            + asset_id
-            + ".json?$limit=1"
-        ),
-        headers={"X-App-Token": app_token},
-    ).raise_for_status()
-
     session.get(url=url, headers={"X-App-Token": app_token}).raise_for_status()
 
     for i in range(0, input_data.shape[0], 10000):

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -197,7 +197,7 @@ def build_query(athena_asset, asset_id, years=None):
     print(columns)
 
     query = f"SELECT {', '.join(columns['column'])} FROM {athena_asset}"
-
+    print(years)
     # Build a dictionary with queries for each year requested, or no years
     if not years:
         query = {None: query}

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -133,8 +133,7 @@ def get_asset_info(socrata_asset):
 
 def build_query(athena_asset, asset_id, years=None):
     """
-    Build an Athena compatible SQL query. Function will append a year
-    conditional if `years` is non-empty. Many of the CCAO's open data assets are
+    Build a dictionary of Athena compatible SQL queries and their associated years. Many of the CCAO's open data assets are
     too large to pass to Socrata without chunking.
     """
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -222,8 +222,7 @@ def upload(asset_id, sql_query, overwrite):
             print_message = (
                 print_message + " year: " + year + " for asset " + asset_id
             )
-        print(year)
-        print(query)
+
         input_data = cursor.execute(query).as_pandas()
         date_columns = input_data.select_dtypes(include="datetime").columns
         for i in date_columns:

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -48,18 +48,18 @@ def parse_years(years=None):
     if years == "":
         years = None
     if years is not None:
-        years = str(years).replace(" ", "").split(",")
-
         # Only allow anticipated values
         years = [
             re.sub("[^0-9]", "", year)
-            for year in years
+            for year in str(years).split(",")
             if re.sub("[^0-9]", "", year)
         ]
 
     return years
 
 
+# %%
+# %%
 def parse_years_list(athena_asset, years=None):
     """
     Helper function to determine what years need to be iterated over for

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -36,7 +36,8 @@ def parse_assets(assets):
     Make sure the asset environmental variable is formatted correctly.
     """
 
-    assets = str(assets).replace(" ", "").split(",")
+    assets = str(assets).split(",")
+    assets = [i.strip() for i in assets]
 
     return assets
 
@@ -99,6 +100,9 @@ def get_asset_info(socrata_asset):
     """
     Simple helper function to retrieve asset-specific information from dbt.
     """
+
+    if not os.path.isdir("./dbt"):
+        os.chdir("..")
 
     os.chdir("./dbt")
 
@@ -188,7 +192,7 @@ def build_query(athena_asset, asset_id, years=None):
     # Limit pull to columns present in open data asset
     columns = columns[columns["column"].isin(asset_columns)]
 
-    print("The following columns will be updated:")
+    print(f"The following columns will be updated for {athena_asset}:")
     print(columns)
 
     query = f"SELECT {', '.join(columns['column'])} FROM {athena_asset}"

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -58,8 +58,6 @@ def parse_years(years=None):
     return years
 
 
-# %%
-# %%
 def parse_years_list(athena_asset, years=None):
     """
     Helper function to determine what years need to be iterated over for

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -101,6 +101,8 @@ def get_asset_info(socrata_asset):
     Simple helper function to retrieve asset-specific information from dbt.
     """
 
+    # When running locally, we will probably be inside the socrata/ dir, so
+    # switch back out to find the dbt/ dir
     if not os.path.isdir("./dbt"):
         os.chdir("..")
 


### PR DESCRIPTION
This started as trying to allow this script to accept multiple assets, but working with it was a chore and it was clear it could be simplified and improved.

This PR really just shifts a lot of the looping and year handling to the query building and upload functions and removes a lot of `overwrite` parameter handling involving a `count` variable by only allowing `overwrite` to be true the first time it's handled.