### PR TITLE
Add year column to permit views

### DIFF
--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -25,7 +25,7 @@ permit_addresses AS (
 
 SELECT
     permit.parid AS pin,
-    YEAR(CAST(permit.permdt AS TIMESTAMP)) AS year,
+    SUBSTR(permit.permdt, 1, 4) AS year,
     permit.num AS permit_number,
     permit.user28 AS local_permit_number,
     permit.permdt AS date_issued,

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -25,6 +25,7 @@ permit_addresses AS (
 
 SELECT
     permit.parid AS pin,
+    YEAR(CAST(permit.permdt AS TIMESTAMP)) AS year,
     permit.num AS permit_number,
     permit.user28 AS local_permit_number,
     permit.permdt AS date_issued,

--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -59,6 +59,8 @@ models:
         description: '{{ doc("column_permit_status") }}'
       - name: work_description
         description: '{{ doc("column_permit_work_description") }}'
+      - name: year
+        description: Year permit was issued. Derived from `date_issued`.
     data_tests:
       - unique_combination_of_columns:
           name: default_vw_pin_permit_unique_by_pin_and_permit_number

--- a/dbt/models/open_data/open_data.vw_permit.sql
+++ b/dbt/models/open_data/open_data.vw_permit.sql
@@ -6,6 +6,7 @@ SELECT
         pin, COALESCE(permit_number, ''), COALESCE(date_issued, '')
     ) AS row_id,
     pin,
+    year,
     permit_number,
     local_permit_number,
     CAST(date_issued AS TIMESTAMP) AS date_issued,


### PR DESCRIPTION
This new column allows the the socrata api script to treat the permit view the same as every other view. There are unfortunately three null values in the `year` column, which we can usually assume is complete. This feels like something we should ask the permit team to address rather than scripting out a workaround.