### PR TITLE
Add not-null test to `default.vw_pin_permit.date_issued`

### DIFF
--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -25,6 +25,11 @@ models:
       - name: date_issued
         description: >
           Date that the municipality issued the permit to the applicant
+        data_tests:
+          - not_null:
+              name: default_vw_pin_permit_date_issued_not_null
+              config:
+                error_if: ">3"
       - name: date_submitted
         description: '{{ doc("column_permit_date_submitted") }}'
       - name: date_updated


### PR DESCRIPTION
This PR adds a data test to `default.vw_pin_permit` to confirm that the `date_issued` column is not null.