### PR TITLE
Move permit `date_issued` not-null test to data integrity test

### DIFF
--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -25,6 +25,11 @@ models:
       - name: date_issued
         description: >
           Date that the municipality issued the permit to the applicant
+        data_tests:
+          - not_null:
+              name: default_vw_pin_permit_date_issued_not_null
+              config:
+                error_if: ">3"
       - name: date_submitted
         description: '{{ doc("column_permit_date_submitted") }}'
       - name: date_updated

--- a/dbt/models/iasworld/schema/iasworld.permit.yml
+++ b/dbt/models/iasworld/schema/iasworld.permit.yml
@@ -61,11 +61,6 @@ sources:
             description: '{{ doc("shared_column_pin") }}'
           - name: permdt
             description: Permit date
-            data_tests:
-              - not_null:
-                  name: iasworld_permit_date_issued_not_null
-                  config:
-                    error_if: ">3"
           - name: seq
             description: '{{ doc("shared_column_seq") }}'
           - name: trans_id


### PR DESCRIPTION
There was a small mistake in https://github.com/ccao-data/data-architecture/pull/747: By defining the test on `iasworld.permit`, it inherited the `data_test_iasworld` tag, and so got included in our [nightly iasworld tests](https://github.com/ccao-data/data-architecture/actions/runs/13582846933/job/37971819096#step:7:499) rather than our weekly data integrity tests. This PR moves it to `default.vw_pin_permit`, which will move it to our weekly data integrity tests and better reflect the purpose of the test.

Proof that this works:

```console
$ dbt list --selector select_data_test_non_iasworld | grep date_issued_not_null
ccao_data_athena.default.schema.default_vw_pin_permit_date_issued_not_null
$ dbt list --selector select_data_test_iasworld | grep date_issued_not_null
$
```