### PR TITLE
Fix export problem in IC reference file for COMDAT details

### DIFF
--- a/dbt/models/qc/schema.yml
+++ b/dbt/models/qc/schema.yml
@@ -389,7 +389,7 @@ models:
             data_type: int
           - name: Gross Building Area
             index: Z
-            data_type: int
+            data_type: float
           - name: Net Rentable Area
             index: AC
             data_type: decimal

--- a/dbt/scripts/utils/export.py
+++ b/dbt/scripts/utils/export.py
@@ -20,6 +20,15 @@ from openpyxl.worksheet.table import Table, TableStyleInfo
 # Shared object for running dbt CLI commands
 DBT = dbtRunner()
 
+# Config object that maps string data type keys to callables that we can use to
+# format output cells of a given data type
+DATA_TYPE_FUNC_MAP: dict[str, typing.Callable] = {
+    "int": int,
+    "float": float,
+    "decimal": decimal.Decimal,
+    "str": str,
+}
+
 
 def export_models(
     target: str = "dev",
@@ -365,20 +374,12 @@ def save_model_to_workbook(
                             horizontal=horiz_align_dir
                         )
                     if data_type := column_config.get("data_type"):
-                        type_func: typing.Callable
-                        if data_type == "int":
-                            type_func = int
-                        elif data_type == "float":
-                            type_func = float
-                        elif data_type == "decimal":
-                            type_func = decimal.Decimal
-                        elif data_type == "str":
-                            type_func = str
-                        else:
+                        type_func = DATA_TYPE_FUNC_MAP.get(data_type)
+                        if type_func is None:
                             raise ValueError(
                                 f"data_type '{data_type}' in export_format "
                                 f"for model {model.name} is not recognized, "
-                                "must be one of 'int', 'float', or 'str'"
+                                f"must be one of: {DATA_TYPE_FUNC_MAP.keys()}"
                             )
                         column_format_by_index[idx]["data_type"] = type_func
 

--- a/dbt/scripts/utils/export.py
+++ b/dbt/scripts/utils/export.py
@@ -379,7 +379,8 @@ def save_model_to_workbook(
                             raise ValueError(
                                 f"data_type '{data_type}' in export_format "
                                 f"for model {model.name} is not recognized, "
-                                f"must be one of: {DATA_TYPE_FUNC_MAP.keys()}"
+                                "must be one of: "
+                                f"{', '.join(DATA_TYPE_FUNC_MAP.keys())}"
                             )
                         column_format_by_index[idx]["data_type"] = type_func
 


### PR DESCRIPTION
The COMDAT details view that we export daily for IC contains a data type mismatch that is currently causing the workbook to fail to export: A column is configured as an integer, but contains float values. This PR changes that column config to a float instead of an int.

We also make an unrelated quality-of-life tweak to the portion of the code that parses data types in order to make it more maintainable in the long run.