### PR TITLE
Update socrata api cron schedule

### DIFF
--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -26,8 +26,8 @@ on:
   schedule:
   # First of every month at 5am UTC (12am UTC-5)
   # '0 5 1 * *'
-  # Temporarily set to UTC 2:55pm, 9:55pm CDT
-  - cron: '05 15 12 3 *'
+  # Temporarily set to UTC 2:30pm, 10:30pm CDT
+  - cron: '30 14 12 3 *'
 
 
 env:


### PR DESCRIPTION
I think I did the cron math wrong. Looking at this job that ran at [9am](https://github.com/ccao-data/data-architecture/actions/runs/13812389329) we can see the [schedule](https://github.com/ccao-data/data-architecture/actions/runs/13812389329/workflow) was for `0 13 * * *` which was 4 hours ahead. Or we can wait till 11:05.