### PR TITLE
Remove unecessary aws credentials step and fix buffered workflow logs

### DIFF
--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -31,6 +31,7 @@ on:
 
 
 env:
+  PYTHONUNBUFFERED: "1"
   UV_SYSTEM_PYTHON: 1
 
 jobs:

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -71,12 +71,6 @@ jobs:
         shell: bash
         run: uv pip install .
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-east-1
-          role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
-
       - name: Upload to Socrata
         env:
           AWS_IAM_ROLE_TO_ASSUME_ARN: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -26,8 +26,8 @@ on:
   schedule:
   # First of every month at 5am UTC (12am UTC-5)
   # '0 5 1 * *'
-  # Temporarily set to UTC 5:30pm, 12:30pm CDT
-  - cron: '30 17 12 3 *'
+  # Temporarily set to UTC 4:30pm, 11:30pm CDT
+  - cron: '30 16 13 3 *'
 
 
 env:

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -11,7 +11,6 @@ import requests
 from dbt.cli.main import dbtRunner
 from pyathena import connect
 from pyathena.pandas.cursor import PandasCursor
-from pyathena.util import RetryConfig
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +29,6 @@ cursor = connect(
     s3_staging_dir="s3://ccao-athena-results-us-east-1/",
     region_name="us-east-1",
     cursor_class=PandasCursor,
-    retry_config=RetryConfig(attempt=1),
 ).cursor(unload=True)
 
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -11,6 +11,7 @@ import requests
 from dbt.cli.main import dbtRunner
 from pyathena import connect
 from pyathena.pandas.cursor import PandasCursor
+from pyathena.util import RetryConfig
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ cursor = connect(
     s3_staging_dir="s3://ccao-athena-results-us-east-1/",
     region_name="us-east-1",
     cursor_class=PandasCursor,
+    retry_config=RetryConfig(attempt=1),
 ).cursor(unload=True)
 
 


### PR DESCRIPTION
This PR should address [two issues](https://github.com/ccao-data/data-architecture/actions/runs/13817905136) that surfaced during our first test of running the socrata api script on a scheduled workflow:

- After one hour the runner's AWS token expired and it could no longer query Athena. This was because I added an unnecessary `Configure AWS credentials` step to the workflow what reduced how long the aws token is valid from 4 to 1 hours.
- The workflow logs are not necessarily printed in order which makes debugging difficult
---
Putting this here since it's [poorly documented](https://github.com/laughingman7743/PyAthena/blob/2787190871d6be6f18f7ff1fa61c8e570cd2d7e4/pyathena/util.py#L41) and was hard to find despite us not needing it for this PR:

```
from pyathena.util import RetryConfig

# Connect to Athena
cursor = connect(
    s3_staging_dir="s3://ccao-athena-results-us-east-1/",
    region_name="us-east-1",
    cursor_class=PandasCursor,
    # Limit cursor retry attempts
    retry_config=RetryConfig(attempt=1),
).cursor(unload=True)
```