### PR TITLE
Tweak some dbt docs for uniqueness based on a review of our models

### DIFF
--- a/dbt/models/ccao/docs.md
+++ b/dbt/models/ccao/docs.md
@@ -66,7 +66,7 @@ These rates are applied during the modeling process in order to disaggregate
 the value of land from the total PIN value. They are provided yearly prior
 to modeling.
 
-**Primary Key**: `town_nbhd`, `year`
+**Primary Key**: `town_nbhd`, `year`, `class`
 {% enddocs %}
 
 # land_site_rate

--- a/dbt/models/default/docs.md
+++ b/dbt/models/default/docs.md
@@ -96,6 +96,8 @@ institutions, or local governments.
 - Mailing addresses and owner names have not been regularly updated since 2017.
 - Newer properties may be missing a mailing or property address, as they
   need to be assigned one by the postal service.
+
+**Primary Key**: `year`, `pin`
 {% enddocs %}
 
 # vw_pin_history
@@ -141,9 +143,8 @@ Sourced from `iasworld.sales`, which is sourced from
 
 ### Assumptions
 
-- `deactivat` properly indicates sales that should and shouldn't be included.
-- For sales not unique by pin and sale date, the most expensive sale for a
-  given day/PIN is used.
+- `iasworld.sale.deactivat` properly indicates sales that should and shouldn't
+  be included.
 - Some parcels are sold for the exact same price soon after an initial sale -
   we ignore duplicate prices for PINs if they've sold in the last 12 months.
 
@@ -154,11 +155,17 @@ Sourced from `iasworld.sales`, which is sourced from
 - `sale.mydec` data is given precedence over `iasworld.sales` prior to 2021
 - Multicard sales are excluded from `mydec` data because they can't be joined
   to `iasworld.sales` (which is only parcel-level) without creating duplicates
-- Sales are unique by `doc_no` if multisales are excluded. When multisales are
-  _not_ excluded, sales are unique by `doc_no` and `pin`.
-- We include iasworld sales and mydec sales only if the mydec sale isn't already
-  present in iasworld (calculated by doc_no). This allows us to use mydec sales
-  for analysis or modeling if the iasworld sales ingest is lags behind mydec.
+- Row uniqueness is complicated, and depends on the type of data you are
+  interested in:
+    - If you exclude sales of multiple PINs ("multisales") by filtering where
+      `not is_multisale`, sales are unique by `doc_no`
+    - If you include multisales but filter where
+      `not sale_filter_same_sale_within_365`, sales are unique by `pin`,
+      `doc_no`, and `sale_price`
+        - The reason `sale_price` is necessary here is to handle some known
+          duplicates in the source data. To remove these duplicates and make
+          multisales unique by `pin` and `doc_no`, group your query by `pin`
+          and `doc_no` and select `MAX(sale_price)`
 
 ### Lineage
 
@@ -170,7 +177,7 @@ process. The full data lineage looks something like:
 
 ![Data Flow Diagram](./assets/sales-lineage.svg)
 
-**Primary Key**: `doc_no`, `pin`
+**Primary Key**: `doc_no`, `pin`, `sale_price`
 {% enddocs %}
 
 # vw_pin_sale_combined

--- a/dbt/models/default/docs.md
+++ b/dbt/models/default/docs.md
@@ -165,7 +165,10 @@ Sourced from `iasworld.sales`, which is sourced from
         - The reason `sale_price` is necessary here is to handle some known
           duplicates in the source data. To remove these duplicates and make
           multisales unique by `pin` and `doc_no`, group your query by `pin`
-          and `doc_no` and select `MAX(sale_price)`
+          and `doc_no` and select either the maximum or minimum sale price.
+          We tend to prefer the maximum, but there is no inherent correctness
+          to this choice, and the correct sale price to choose will depend
+          on how you want to use the sales
 
 ### Lineage
 

--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -110,10 +110,16 @@ models:
           name: default_vw_pin_sale_sale_filter_less_than_10k
           expression: NOT sale_filter_less_than_10k OR sale_price <= 10000
       - unique_combination_of_columns:
-          name: default_vw_pin_sale_unique_price_pin_and_year
+          name: default_vw_pin_sale_unique_doc_no
+          combination_of_columns:
+            - doc_no
+          config:
+            where: NOT is_multisale
+      - unique_combination_of_columns:
+          name: default_vw_pin_sale_unique_price_pin_and_doc_no
           combination_of_columns:
             - pin
-            - year
+            - doc_no
             - sale_price
           config:
-            where: NOT sale_filter_same_sale_within_365 AND NOT sale_filter_deed_type
+            where: NOT sale_filter_same_sale_within_365


### PR DESCRIPTION
I did a quick review of our docs while fleshing out https://github.com/ccao-data/data-architecture/issues/770 and discovered a couple spots where our docs are not exactly correct about row uniqueness. This PR fixes those spots and also tweaks a couple of tests for `default.vw_pin_sale` to better reflect the two different uniqueness conditions.