### PR TITLE
Add municipality to permit views

### DIFF
--- a/dbt/models/default/columns.md
+++ b/dbt/models/default/columns.md
@@ -5,9 +5,7 @@ Address where permitted work will take place.
 
 This field usually includes the municipality name for municipalities
 outside Chicago. If the municipality name is missing, the address
-is either in Chicago, or we generated it based on the concatenation
-of the address component fields, which do not include municipality
-name.
+is in Chicago.
 
 Municipalities are responsible for filling out this field when submitting a
 permit.

--- a/dbt/models/default/columns.md
+++ b/dbt/models/default/columns.md
@@ -3,12 +3,6 @@
 {% docs column_permit_address_full %}
 Address where permitted work will take place.
 
-This field combines the "mailing address" field in the source data
-with the concatenated output of the address component fields like
-`address_street_dir`, `address_street_name`, etc. We prefer the
-mailing address if it exists, and otherwise we substitute the
-concatenated address components.
-
 This field usually includes the municipality name for municipalities
 outside Chicago. If the municipality name is missing, the address
 is either in Chicago, or we generated it based on the concatenation

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -47,12 +47,12 @@ SELECT
         address.address_street_name,
         address.address_suffix_1,
         address.address_suffix_2
-    ) AS location_address_full,
-    address.address_street_dir AS location_address_street_dir,
-    address.address_street_number AS location_address_street_number,
-    address.address_street_name AS location_address_street_name,
-    address.address_suffix_1 AS location_address_suffix_1,
-    address.address_suffix_2 AS location_address_suffix_2,
+    ) AS prop_address_full,
+    address.address_street_dir AS prop_address_street_dir,
+    address.address_street_number AS prop_address_street_number,
+    address.address_street_name AS prop_address_street_name,
+    address.address_suffix_1 AS prop_address_suffix_1,
+    address.address_suffix_2 AS prop_address_suffix_2,
     -- Replace double commas that are present in the note2 field. We need
     -- to get rid of two types of double commas: trailing double commas,
     -- which need to be removed, and double commas inside an address

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -61,7 +61,7 @@ SELECT
         REGEXP_REPLACE(permit.note2, ',,$'),
         ',,',
         ', '
-    ) AS mailing_address,
+    ) AS mail_address,
     permit.user21 AS applicant_name,
     permit.why AS job_code_primary,
     permit.user42 AS job_code_secondary,

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -38,7 +38,7 @@ SELECT
     permit.flag AS status,
     permit.user18 AS assessable,
     permit.amount,
-    vpu.township,
+    vpu.township_name AS township,
     NULLIF(ARRAY_JOIN(vpu.tax_municipality_name, ', '), '') AS municipality,
     -- When note2 is filled out and present, it represents the full
     -- concatenated street address. When not present, we need to

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -41,13 +41,16 @@ SELECT
     vpu.township_name,
     NULLIF(ARRAY_JOIN(vpu.tax_municipality_name, ', '), '')
         AS tax_municipality_name,
-    CONCAT_WS(
-        ' ',
-        CAST(address.address_street_number AS VARCHAR),
-        address.address_street_dir,
-        address.address_street_name,
-        address.address_suffix_1,
-        address.address_suffix_2
+    NULLIF(
+        CONCAT_WS(
+            ' ',
+            CAST(address.address_street_number AS VARCHAR),
+            address.address_street_dir,
+            address.address_street_name,
+            address.address_suffix_1,
+            address.address_suffix_2
+        ),
+        ''
     ) AS prop_address_full,
     address.address_street_dir AS prop_address_street_dir,
     address.address_street_number AS prop_address_street_number,

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -38,7 +38,7 @@ SELECT
     permit.flag AS status,
     permit.user18 AS assessable,
     permit.amount,
-    vpu.township_name AS township,
+    vpu.township_name AS township_name,
     NULLIF(ARRAY_JOIN(vpu.tax_municipality_name, ', '), '') AS municipality,
     CONCAT_WS(
         ' ',

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -38,6 +38,7 @@ SELECT
     permit.flag AS status,
     permit.user18 AS assessable,
     permit.amount,
+    vpu.township,
     NULLIF(ARRAY_JOIN(vpu.tax_municipality_name, ', '), '') AS municipality,
     -- When note2 is filled out and present, it represents the full
     -- concatenated street address. When not present, we need to

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -39,7 +39,7 @@ SELECT
     permit.user18 AS assessable,
     permit.amount,
     vpu.township_name AS township_name,
-    NULLIF(ARRAY_JOIN(vpu.tax_municipality_name, ', '), '') AS municipality,
+    NULLIF(ARRAY_JOIN(vpu.tax_municipality_name, ', '), '') AS tax_municipality_name,
     CONCAT_WS(
         ' ',
         CAST(address.address_street_number AS VARCHAR),

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -38,6 +38,7 @@ SELECT
     permit.flag AS status,
     permit.user18 AS assessable,
     permit.amount,
+    NULLIF(ARRAY_JOIN(vpu.tax_municipality_name, ', '), '') AS municipality,
     -- When note2 is filled out and present, it represents the full
     -- concatenated street address. When not present, we need to
     -- reconstruct it from the detailed address fields
@@ -80,3 +81,6 @@ FROM active_permits AS permit
 -- so we can use it as a basis for joining permits to themselves
 INNER JOIN permit_addresses AS address
     ON permit.iasw_id = address.iasw_id
+LEFT JOIN {{ ref('default.vw_pin_universe') }} AS vpu
+    ON permit.parid = vpu.pin
+    AND SUBSTR(permit.permdt, 1, 4) = vpu.year

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -40,33 +40,28 @@ SELECT
     permit.amount,
     vpu.township_name AS township,
     NULLIF(ARRAY_JOIN(vpu.tax_municipality_name, ', '), '') AS municipality,
-    -- When note2 is filled out and present, it represents the full
-    -- concatenated street address. When not present, we need to
-    -- reconstruct it from the detailed address fields
-    COALESCE(
-        -- Replace double commas that are present in the note2 field. We need
-        -- to get rid of two types of double commas: trailing double commas,
-        -- which need to be removed, and double commas inside an address
-        -- string, which should be replaced with a single comma
-        REPLACE(
-            REGEXP_REPLACE(permit.note2, ',,$'),
-            ',,',
-            ', '
-        ),
-        CONCAT_WS(
-            ' ',
-            CAST(address.address_street_number AS VARCHAR),
-            address.address_street_dir,
-            address.address_street_name,
-            address.address_suffix_1,
-            address.address_suffix_2
-        )
-    ) AS address_full,
-    address.address_street_dir,
-    address.address_street_number,
-    address.address_street_name,
-    address.address_suffix_1,
-    address.address_suffix_2,
+    CONCAT_WS(
+        ' ',
+        CAST(address.address_street_number AS VARCHAR),
+        address.address_street_dir,
+        address.address_street_name,
+        address.address_suffix_1,
+        address.address_suffix_2
+    ) AS location_address_full,
+    address.address_street_dir AS location_address_street_dir,
+    address.address_street_number AS location_address_street_number,
+    address.address_street_name AS location_address_street_name,
+    address.address_suffix_1 AS location_address_suffix_1,
+    address.address_suffix_2 AS location_address_suffix_2,
+    -- Replace double commas that are present in the note2 field. We need
+    -- to get rid of two types of double commas: trailing double commas,
+    -- which need to be removed, and double commas inside an address
+    -- string, which should be replaced with a single comma
+    REPLACE(
+        REGEXP_REPLACE(permit.note2, ',,$'),
+        ',,',
+        ', '
+    ) AS mailing_address,
     permit.user21 AS applicant_name,
     permit.why AS job_code_primary,
     permit.user42 AS job_code_secondary,

--- a/dbt/models/default/default.vw_pin_permit.sql
+++ b/dbt/models/default/default.vw_pin_permit.sql
@@ -38,8 +38,9 @@ SELECT
     permit.flag AS status,
     permit.user18 AS assessable,
     permit.amount,
-    vpu.township_name AS township_name,
-    NULLIF(ARRAY_JOIN(vpu.tax_municipality_name, ', '), '') AS tax_municipality_name,
+    vpu.township_name,
+    NULLIF(ARRAY_JOIN(vpu.tax_municipality_name, ', '), '')
+        AS tax_municipality_name,
     CONCAT_WS(
         ' ',
         CAST(address.address_street_number AS VARCHAR),

--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -52,6 +52,8 @@ models:
         description: '{{ doc("column_permit_job_code_secondary") }}'
       - name: local_permit_number
         description: Permit number as recorded by the municipality
+      - name: municipality
+        description: '{{ doc("column_tax_district_name") }}'
       - name: notes
         description: Notes on this field recorded by the reviewer in iasWorld
       - name: permit_number

--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -40,18 +40,6 @@ models:
         description: '{{ doc("column_permit_job_code_secondary") }}'
       - name: local_permit_number
         description: Permit number as recorded by the municipality
-      - name: location_address_full
-        description: '{{ doc("column_permit_address_full") }}'
-      - name: location_address_street_dir
-        description: '{{ doc("shared_column_prop_address_street_dir") }}'
-      - name: location_address_street_name
-        description: '{{ doc("shared_column_prop_address_street_name") }}'
-      - name: location_address_street_number
-        description: '{{ doc("shared_column_prop_address_street_number") }}'
-      - name: location_address_suffix_1
-        description: '{{ doc("shared_column_prop_address_suffix_1") }}'
-      - name: location_address_suffix_2
-        description: '{{ doc("shared_column_prop_address_suffix_2") }}'
       - name: mailing_address
         description: '{{ doc("docs shared_column_mail_address_full") }}'
       - name: municipality
@@ -62,6 +50,18 @@ models:
         description: '{{ doc("column_permit_number") }}'
       - name: pin
         description: '{{ doc("shared_column_pin") }}'
+      - name: prop_address_full
+        description: '{{ doc("column_permit_address_full") }}'
+      - name: prop_address_street_dir
+        description: '{{ doc("shared_column_prop_address_street_dir") }}'
+      - name: prop_address_street_name
+        description: '{{ doc("shared_column_prop_address_street_name") }}'
+      - name: prop_address_street_number
+        description: '{{ doc("shared_column_prop_address_street_number") }}'
+      - name: prop_address_suffix_1
+        description: '{{ doc("shared_column_prop_address_suffix_1") }}'
+      - name: prop_address_suffix_2
+        description: '{{ doc("shared_column_prop_address_suffix_2") }}'
       - name: recheck_year
         description: '{{ doc("column_permit_recheck_year") }}'
       - name: status

--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -40,7 +40,7 @@ models:
         description: '{{ doc("column_permit_job_code_secondary") }}'
       - name: local_permit_number
         description: Permit number as recorded by the municipality
-      - name: mailing_address
+      - name: mail_address
         description: '{{ doc("shared_column_mail_address_full") }}'
       - name: municipality
         description: '{{ doc("column_tax_district_name") }}'

--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -41,7 +41,7 @@ models:
       - name: local_permit_number
         description: Permit number as recorded by the municipality
       - name: mailing_address
-        description: '{{ doc("docs shared_column_mail_address_full") }}'
+        description: '{{ doc("shared_column_mail_address_full") }}'
       - name: municipality
         description: '{{ doc("column_tax_district_name") }}'
       - name: notes

--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -2,18 +2,6 @@ models:
   - name: default.vw_pin_permit
     description: '{{ doc("view_vw_pin_permit") }}'
     columns:
-      - name: address_full
-        description: '{{ doc("column_permit_address_full") }}'
-      - name: address_street_dir
-        description: '{{ doc("shared_column_prop_address_street_dir") }}'
-      - name: address_street_name
-        description: '{{ doc("shared_column_prop_address_street_name") }}'
-      - name: address_street_number
-        description: '{{ doc("shared_column_prop_address_street_number") }}'
-      - name: address_suffix_1
-        description: '{{ doc("shared_column_prop_address_suffix_1") }}'
-      - name: address_suffix_2
-        description: '{{ doc("shared_column_prop_address_suffix_2") }}'
       - name: amount
         description: '{{ doc("column_permit_amount") }}'
       - name: applicant_name
@@ -52,6 +40,20 @@ models:
         description: '{{ doc("column_permit_job_code_secondary") }}'
       - name: local_permit_number
         description: Permit number as recorded by the municipality
+      - name: location_address_full
+        description: '{{ doc("column_permit_address_full") }}'
+      - name: location_address_street_dir
+        description: '{{ doc("shared_column_prop_address_street_dir") }}'
+      - name: location_address_street_name
+        description: '{{ doc("shared_column_prop_address_street_name") }}'
+      - name: location_address_street_number
+        description: '{{ doc("shared_column_prop_address_street_number") }}'
+      - name: location_address_suffix_1
+        description: '{{ doc("shared_column_prop_address_suffix_1") }}'
+      - name: location_address_suffix_2
+        description: '{{ doc("shared_column_prop_address_suffix_2") }}'
+      - name: mailing_address
+        description: '{{ doc("docs shared_column_mail_address_full") }}'
       - name: municipality
         description: '{{ doc("column_tax_district_name") }}'
       - name: notes

--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -42,7 +42,7 @@ models:
         description: Permit number as recorded by the municipality
       - name: mail_address
         description: '{{ doc("shared_column_mail_address_full") }}'
-      - name: municipality
+      - name: tax_municipality_name
         description: '{{ doc("column_tax_district_name") }}'
       - name: notes
         description: Notes on this field recorded by the reviewer in iasWorld

--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -42,8 +42,6 @@ models:
         description: Permit number as recorded by the municipality
       - name: mail_address
         description: '{{ doc("shared_column_mail_address_full") }}'
-      - name: tax_municipality_name
-        description: '{{ doc("column_tax_district_name") }}'
       - name: notes
         description: Notes on this field recorded by the reviewer in iasWorld
       - name: permit_number
@@ -66,7 +64,9 @@ models:
         description: '{{ doc("column_permit_recheck_year") }}'
       - name: status
         description: '{{ doc("column_permit_status") }}'
-      - name: township
+      - name: tax_municipality_name
+        description: '{{ doc("column_tax_district_name") }}'
+      - name: township_name
         description: '{{ doc("shared_column_township_name") }}'
       - name: work_description
         description: '{{ doc("column_permit_work_description") }}'

--- a/dbt/models/default/schema/default.vw_pin_permit.yml
+++ b/dbt/models/default/schema/default.vw_pin_permit.yml
@@ -66,6 +66,8 @@ models:
         description: '{{ doc("column_permit_recheck_year") }}'
       - name: status
         description: '{{ doc("column_permit_status") }}'
+      - name: township
+        description: '{{ doc("shared_column_township_name") }}'
       - name: work_description
         description: '{{ doc("column_permit_work_description") }}'
       - name: year

--- a/dbt/models/open_data/open_data.vw_permit.sql
+++ b/dbt/models/open_data/open_data.vw_permit.sql
@@ -28,7 +28,9 @@ SELECT
     END AS assessable,
     amount,
     municipality,
-    address_full AS address,
+    township,
+    prop_address_full AS property_address,
+    mail_address AS mailing_address,
     applicant_name,
     CASE
         WHEN job_code_primary = '1' THEN 'RESIDENTIAL PERMIT'

--- a/dbt/models/open_data/open_data.vw_permit.sql
+++ b/dbt/models/open_data/open_data.vw_permit.sql
@@ -27,6 +27,7 @@ SELECT
         WHEN assessable = 'N' THEN 'Non-Assessable'
     END AS assessable,
     amount,
+    municipality,
     address_full AS address,
     applicant_name,
     CASE

--- a/dbt/models/open_data/open_data.vw_permit.sql
+++ b/dbt/models/open_data/open_data.vw_permit.sql
@@ -27,8 +27,8 @@ SELECT
         WHEN assessable = 'N' THEN 'Non-Assessable'
     END AS assessable,
     amount,
-    municipality,
-    township,
+    tax_municipality_name AS municipality,
+    township_name AS township,
     prop_address_full AS property_address,
     mail_address AS mailing_address,
     applicant_name,


### PR DESCRIPTION
Quick PR to add a municipality column to our permits views for easy filtering/aggregation. No rush to review this, just figured we'd have it ready to go if we decide we want to move forward with adding the column to the open data asset.

```
select
  count(*) as count,
  'new' as new
from z_ci_add_municipalities_to_permits_view_default.vw_pin_permit
union all
select
  count(*) as count,
  'old' as new
from default.vw_pin_permit
```

count | new
-- | --
554250 | old
554250 | new

```
select
  year,
  sum(cast(municipality is null as int)) as null_muni,
  sum(cast(municipality is not null as int)) as non_null_muni
from z_ci_add_municipalities_to_permits_view_default.vw_pin_permit
where year between '1999' and '2025'
group by year
order by year desc
```

year | null_muni | non_null_muni
-- | -- | --
2025 | 297 | 3379
2024 | 5046 | 93977
2023 | 4624 | 99013
2022 | 3807 | 96151
2021 | 5016 | 112950
2020 | 4573 | 103904
2019 | 448 | 15166
2018 | 9 | 3000
2017 | 0 | 109
2016 | 0 | 4
2015 | 0 | 1
2014 | 0 | 3
2013 | 0 | 2
2012 | 1 | 6
2011 | 1 | 6
2010 | 0 | 7
2009 | 0 | 2
2008 | 0 | 2
2007 | 0 | 6
2006 | 1 | 7
2005 | 1 | 0
2004 | 1 | 0
2002 | 16 | 0
2001 | 7 | 0
2000 | 20 | 0
1999 | 1 | 0

I don't think there are any new tests that need to be added here? We could do something with `iasworld.permit.permdt` since it's part of the municipality join and is kind of dirty, but I'm not entirely sure what.