### PR TITLE
Remove `assessment_year` column from `open_data.vw_permit`

### DIFF
--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -177,7 +177,7 @@ exposures:
       name: Data Department
     meta:
       test_row_count: true
-      year_field: assessment_year
+      year_field: year
       asset_id: 6yjf-dfxs
       primary_key:
         - pin

--- a/dbt/models/open_data/open_data.vw_permit.sql
+++ b/dbt/models/open_data/open_data.vw_permit.sql
@@ -12,7 +12,6 @@ SELECT
     CAST(date_issued AS TIMESTAMP) AS date_issued,
     CAST(date_submitted AS TIMESTAMP) AS date_submitted,
     estimated_date_of_completion,
-    assessment_year,
     recheck_year,
     CASE
         WHEN status = 'C' THEN 'CLOSED'


### PR DESCRIPTION
This column is difficult to understand and rather dirty, it seems more confusing than helpful to include on the open data portal. Part of https://github.com/ccao-data/data-architecture/issues/776.

@ccao-jardine Jean and I feel it's best to just remove this column rather than try to explain it to the public since we're not entirely sure ourselves how it works, even after reaching out to field.