### PR TITLE
Fix dependency version for `assesspy` in `ratio_stats`

### DIFF
--- a/.github/scripts/deploy_dbt_model_dependencies.sh
+++ b/.github/scripts/deploy_dbt_model_dependencies.sh
@@ -16,7 +16,7 @@
 # into a Python model script with a set of import calls like so:
 #
 #   sc.addPyFile(f"{s3_dependency_dir}/attrs==23.2.0.zip")
-#   sc.addPyFile(f"{s3_dependency_dir}/assesspy==2.0.1.zip")
+#   sc.addPyFile(f"{s3_dependency_dir}/assesspy==2.0.2.zip")
 #   import attrs
 #   import assesspy
 #

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -30,7 +30,7 @@ models:
       tags:
         - daily
       packages:
-        - "assesspy==2.0.1"
+        - "assesspy==2.0.2"
     data_tests:
       - expression_is_true:
           name: reporting_ratio_stats_metrics_are_sensible


### PR DESCRIPTION
We upgraded the version of `assesspy` that we use when building `reporting.ratio_stats` in https://github.com/ccao-data/data-architecture/pull/740, but we neglected to update the dependency configuration in `models/reporting/schema.yml` that the `build-daily-dbt-models` workflow uses to determine which versions of Python dependencies to deploy. This is causing `build-daily-dbt-models` [to fail consistently](https://github.com/ccao-data/data-architecture/actions/runs/14195532197/job/39769687992). This PR fixes the failing workflow by updating the dependency configuration to point to the correct version of `assesspy`.

See [here](https://github.com/ccao-data/data-architecture/actions/runs/14200537049/job/39786149060?pr=779#step:7:1) for evidence that the new version of `assesspy` deploys correctly.

Note that it took about a month to surface this bug because we uploaded the new version of `assesspy` to the dependency bucket manually while testing #740, but the dependency bucket has a 30-day object expiration timeout, so it took 30 days to reveal that we hadn't configured the dependency version properly.