### PR TITLE
Decrease data pushed to socrata through api

### DIFF
--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -108,6 +108,8 @@ exposures:
   - name: parcel_status
     label: Parcel Status
     type: dashboard
+    tags:
+      - inactive
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Parcel-Status/uuu4-fqy8
     depends_on:
       - ref('open_data.vw_parcel_status')

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -56,6 +56,8 @@ def parse_assets(assets=None):
         "open_data.*",
         "--resource-types",
         "exposure",
+        "--exclude",
+        "tag:inactive",
         "--output",
         "json",
         "--output-keys",

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -146,7 +146,7 @@ def parse_years_list(athena_asset, years=None):
     elif not years and os.getenv("WORKFLOW_EVENT_NAME") == "schedule":
         # Update most recent year only on scheduled workflow
         years_list = (
-            cursor.execute("SELECT MAX(year) FROM " + athena_asset)
+            cursor.execute("SELECT MAX(year) AS year FROM " + athena_asset)
             .as_pandas()["year"]
             .to_list()
         )

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -156,7 +156,7 @@ def parse_years_list(athena_asset, years=None):
             .to_list()
         )
         years_list.append(str(datetime.now().year))
-        years_list = min(years_list)
+        years_list = [min(years_list)]
 
     else:
         years_list = None

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 import time
-from datetime import datetime
 
 import pandas as pd
 import requests
@@ -145,11 +144,12 @@ def parse_years_list(athena_asset, years=None):
             years_list = years
 
     elif not years and os.getenv("WORKFLOW_EVENT_NAME") == "schedule":
-        # Update current and prior year only on scheduled workflow
-        years_list = [
-            str(year)
-            for year in [datetime.now().year - 1, datetime.now().year]
-        ]
+        # Update most recent year only on scheduled workflow
+        years_list = (
+            cursor.execute("SELECT MAX(year) FROM " + athena_asset)
+            .as_pandas()["year"]
+            .to_list()
+        )
 
     else:
         years_list = None

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import time
+from datetime import datetime
 
 import pandas as pd
 import requests
@@ -146,12 +147,16 @@ def parse_years_list(athena_asset, years=None):
             years_list = years
 
     elif not years and os.getenv("WORKFLOW_EVENT_NAME") == "schedule":
-        # Update most recent year only on scheduled workflow
+        # Update most recent year only on scheduled workflow. In some
+        # cases the max year is incorrectly in the future, so we
+        # append the current year to the list and take the minimum.
         years_list = (
             cursor.execute("SELECT MAX(year) AS year FROM " + athena_asset)
             .as_pandas()["year"]
             .to_list()
         )
+        years_list.append(str(datetime.now().year))
+        years_list = min(years_list)
 
     else:
         years_list = None


### PR DESCRIPTION
This won't fix randomly getting denied by Socrata's API, but it will make what we upload smaller so we're less likely to run up against tokens expiring, runners timing out, etc.

- Only upload most recent year for each asset. Permits asset has a row from 2032, so if most recent year is > whatever the current year is, script will default to current year. Previously we were uploading current year and/or current year - 1 for every asset, depending on which years are available in the asset.
- Added dbt tag for parcel status asset so it won't get updated since it's private.

I ran the script with these updates in an environment that simulates the scheduled github action and it worked as intended.