### PR TITLE
Fix permit year field in open data asset tests

### DIFF
--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -94,12 +94,12 @@ def main() -> None:
         # numbers. It's unclear why this is the case, but it seems to be a quirk
         # of the API. We need to convert them to int so that we can compare them
         # to Athena data.
-        asset_row_counts_by_year = [
-            int(year_count[asset_year_field])
-            if year_count[asset_year_field] is not None
-            else None
-            for year_count in asset_row_counts_by_year
-        ]
+
+        for year_count in asset_row_counts_by_year:
+            if year_count[asset_year_field] is not None:
+                year_count[asset_year_field] = int(
+                    year_count[asset_year_field]
+                )
 
         dbt_output = io.StringIO()
         with contextlib.redirect_stdout(dbt_output):

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -85,9 +85,9 @@ def main() -> None:
 
         # Socrata won't return a year column for rows with no year, so we need to add a None year value to the list of rows with no year. This is a bit of a hack, but it works for now.
         [
-            year.update({"year": None})
+            year.update({asset_year_field: None})
             for year in asset_row_counts_by_year
-            if "year" not in year
+            if asset_year_field not in year
         ]
 
         dbt_output = io.StringIO()

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -93,7 +93,7 @@ def main() -> None:
                 **year_count,
                 asset_year_field: int(year_count[asset_year_field])
                 if year_count.get(asset_year_field) is not None
-                else None
+                else None,
             }
             for year_count in asset_row_counts_by_year
         ]

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -191,8 +191,9 @@ def diff_row_counts(
     open_data_asset_row_counts = sorted(
         open_data_asset_row_counts,
         key=lambda x: (
-            [open_data_asset_year_field] == [None],
-            [open_data_asset_year_field],
+            x[open_data_asset_year_field]
+            if x[open_data_asset_year_field] is not None
+            else 0
         ),
     )
 

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -83,7 +83,8 @@ def main() -> None:
 
         asset_row_counts_by_year = response.json()
 
-        # Socrata won't return a year column for rows with no year, so we need to add a None year value to the list of rows with no year. This is a bit of a hack, but it works for now.
+        # Socrata won't return a year column for rows with no year, so we need
+        # to add None as the year value to the dict with no year.
         [
             year.update({asset_year_field: None})
             for year in asset_row_counts_by_year

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -90,6 +90,12 @@ def main() -> None:
             if asset_year_field not in year
         ]
 
+        for index, value in enumerate(asset_row_counts_by_year):
+            if value[asset_year_field] is not None:
+                asset_row_counts_by_year[index][asset_year_field] = int(
+                    value[asset_year_field]
+                )
+
         dbt_output = io.StringIO()
         with contextlib.redirect_stdout(dbt_output):
             dbt_result = DBT.invoke(
@@ -202,13 +208,7 @@ def diff_row_counts(
 
         asset_count: int = 0
         for asset_row_count_dict in open_data_asset_row_counts:
-            if (
-                asset_row_count_dict[open_data_asset_year_field]
-                == str(model_year)
-            ) or (
-                asset_row_count_dict[open_data_asset_year_field] is None
-                and model_year is None
-            ):
+            if asset_row_count_dict[open_data_asset_year_field] == model_year:
                 asset_count = int(asset_row_count_dict["COUNT"])
                 break
         else:
@@ -243,13 +243,7 @@ def diff_row_counts(
         base_formatted_row = {}
 
         for model_row_count_dict in athena_model_row_counts:
-            if (
-                str(model_row_count_dict[athena_model_year_field])
-                == asset_year
-            ) or (
-                model_row_count_dict[athena_model_year_field] is None
-                and asset_year is None
-            ):
+            if model_row_count_dict[athena_model_year_field] == asset_year:
                 break
         else:
             # No matching year found, so these two datasets must be different

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -183,9 +183,10 @@ def diff_row_counts(
     athena_model_row_counts = sorted(
         athena_model_row_counts,
         key=lambda x: (
-            [athena_model_year_field] == [None],
-            [athena_model_year_field],
-        ),
+            x[athena_model_year_field]
+            if x[athena_model_year_field] is not None
+            else 0
+    ),
     )
     open_data_asset_row_counts = sorted(
         open_data_asset_row_counts,

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -83,6 +83,13 @@ def main() -> None:
 
         asset_row_counts_by_year = response.json()
 
+        # Socrata won't return a year column for rows with no year, so we need to add a None year value to the list of rows with no year. This is a bit of a hack, but it works for now.
+        [
+            year.update({"year": None})
+            for year in asset_row_counts_by_year
+            if "year" not in year
+        ]
+
         dbt_output = io.StringIO()
         with contextlib.redirect_stdout(dbt_output):
             dbt_result = DBT.invoke(
@@ -163,10 +170,18 @@ def diff_row_counts(
     """
     # We expect these lists to already be sorted, but double-check anyway
     athena_model_row_counts = sorted(
-        athena_model_row_counts, key=lambda x: x[athena_model_year_field]
+        athena_model_row_counts,
+        key=lambda x: (
+            [athena_model_year_field] == None,  # noqa: E711
+            [athena_model_year_field],
+        ),
     )
     open_data_asset_row_counts = sorted(
-        open_data_asset_row_counts, key=lambda x: x[open_data_asset_year_field]
+        open_data_asset_row_counts,
+        key=lambda x: (
+            [open_data_asset_year_field] == None,  # noqa: E711)
+            [open_data_asset_year_field],
+        ),
     )
 
     # Extract the current and last year since we want to apply different

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -202,7 +202,13 @@ def diff_row_counts(
 
         asset_count: int = 0
         for asset_row_count_dict in open_data_asset_row_counts:
-            if asset_row_count_dict[open_data_asset_year_field] == model_year:
+            if (
+                asset_row_count_dict[open_data_asset_year_field]
+                == str(model_year)
+            ) or (
+                asset_row_count_dict[open_data_asset_year_field] is None
+                and model_year is None
+            ):
                 asset_count = int(asset_row_count_dict["COUNT"])
                 break
         else:
@@ -237,7 +243,13 @@ def diff_row_counts(
         base_formatted_row = {}
 
         for model_row_count_dict in athena_model_row_counts:
-            if model_row_count_dict[athena_model_year_field] == asset_year:
+            if (
+                str(model_row_count_dict[athena_model_year_field])
+                == asset_year
+            ) or (
+                model_row_count_dict[athena_model_year_field] is None
+                and asset_year is None
+            ):
                 break
         else:
             # No matching year found, so these two datasets must be different

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -186,7 +186,7 @@ def diff_row_counts(
             x[athena_model_year_field]
             if x[athena_model_year_field] is not None
             else 0
-    ),
+        ),
     )
     open_data_asset_row_counts = sorted(
         open_data_asset_row_counts,

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -172,14 +172,14 @@ def diff_row_counts(
     athena_model_row_counts = sorted(
         athena_model_row_counts,
         key=lambda x: (
-            [athena_model_year_field] == None,  # noqa: E711
+            [athena_model_year_field] == [None],
             [athena_model_year_field],
         ),
     )
     open_data_asset_row_counts = sorted(
         open_data_asset_row_counts,
         key=lambda x: (
-            [open_data_asset_year_field] == None,  # noqa: E711)
+            [open_data_asset_year_field] == [None],
             [open_data_asset_year_field],
         ),
     )

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -84,22 +84,22 @@ def main() -> None:
         asset_row_counts_by_year = response.json()
 
         # Socrata won't return a year column for rows with no year, so we need
-        # to add None as the year value to the dict with no year.
-        [
-            year.update({asset_year_field: None})
-            for year in asset_row_counts_by_year
-            if asset_year_field not in year
+        # to add None as the year value to any rows with no year.
+        asset_row_counts_by_year = [
+            {asset_year_field: None, **year_count}
+            for year_count in asset_row_counts_by_year
         ]
 
         # Socrata returns year columns as strings even though they're typed as
-        # numbers. It's unlcear why this is the case, but it seems to be a quirk
+        # numbers. It's unclear why this is the case, but it seems to be a quirk
         # of the API. We need to convert them to int so that we can compare them
         # to Athena data.
-        for index, value in enumerate(asset_row_counts_by_year):
-            if value[asset_year_field] is not None:
-                asset_row_counts_by_year[index][asset_year_field] = int(
-                    value[asset_year_field]
-                )
+        asset_row_counts_by_year = [
+            int(year_count[asset_year_field])
+            if year_count[asset_year_field] is not None
+            else None
+            for year_count in asset_row_counts_by_year
+        ]
 
         dbt_output = io.StringIO()
         with contextlib.redirect_stdout(dbt_output):

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -90,6 +90,10 @@ def main() -> None:
             if asset_year_field not in year
         ]
 
+        # Socrata returns year columns as strings even though they're typed as
+        # numbers. It's unlcear why this is the case, but it seems to be a quirk
+        # of the API. We need to convert them to int so that we can compare them
+        # to Athena data.
         for index, value in enumerate(asset_row_counts_by_year):
             if value[asset_year_field] is not None:
                 asset_row_counts_by_year[index][asset_year_field] = int(


### PR DESCRIPTION
This PR addresses an issue with the permits view in Athena/asset on the open data portal. Because this dataset is the first we've had that can have `NULL`  year values, handling its year field can lead to difficulties we haven't encountered in the past. Specifically, the Socrata API won't return a year field at all for grouped queries where the group is `year = NULL`, and python's `sort` function cannot handle `NULL` values.

Additionally, this PR makes sure that the test script successfully links years from our Athena db that are typed as `int` to year fields from Socrata, which its API delivers as `string` regardless of being numbers.