### PR TITLE
Change open data year columns type to INT

### DIFF
--- a/dbt/models/open_data/open_data.vw_appeal.sql
+++ b/dbt/models/open_data/open_data.vw_appeal.sql
@@ -6,7 +6,7 @@ SELECT
     pin,
     class,
     township_code,
-    year,
+    CAST(year AS INT) AS year,
     mailed_bldg,
     mailed_land,
     mailed_tot,

--- a/dbt/models/open_data/open_data.vw_assessed_value.sql
+++ b/dbt/models/open_data/open_data.vw_assessed_value.sql
@@ -5,7 +5,7 @@
 SELECT
     CONCAT(pin, year) AS row_id,
     pin,
-    year,
+    CAST(year AS INT) AS year,
     class,
     township_code,
     township_name,

--- a/dbt/models/open_data/open_data.vw_parcel_address.sql
+++ b/dbt/models/open_data/open_data.vw_parcel_address.sql
@@ -6,7 +6,7 @@ SELECT
     CONCAT(pin, year) AS row_id,
     pin,
     pin10,
-    year,
+    CAST(year AS INT) AS year,
     prop_address_full,
     prop_address_city_name,
     prop_address_state,

--- a/dbt/models/open_data/open_data.vw_parcel_proximity.sql
+++ b/dbt/models/open_data/open_data.vw_parcel_proximity.sql
@@ -5,7 +5,7 @@
 SELECT
     CONCAT(pin10, year) AS row_id,
     pin10,
-    year,
+    CAST(year AS INT) AS year,
     num_pin_in_half_mile,
     num_bus_stop_in_half_mile,
     num_bus_stop_data_year,

--- a/dbt/models/open_data/open_data.vw_parcel_sale.sql
+++ b/dbt/models/open_data/open_data.vw_parcel_sale.sql
@@ -4,7 +4,7 @@
 SELECT
     CAST(sale_key AS VARCHAR) AS row_id,
     pin,
-    year,
+    CAST(year AS INT) AS year,
     township_code,
     nbhd,
     class,

--- a/dbt/models/open_data/open_data.vw_parcel_status.sql
+++ b/dbt/models/open_data/open_data.vw_parcel_status.sql
@@ -4,7 +4,7 @@
 SELECT
     CONCAT(pin, year) AS row_id,
     pin,
-    year,
+    CAST(year AS INT) AS year,
     class,
     is_corner_lot,
     is_ahsap,

--- a/dbt/models/open_data/open_data.vw_parcel_universe_current.sql
+++ b/dbt/models/open_data/open_data.vw_parcel_universe_current.sql
@@ -6,7 +6,7 @@ SELECT
     CONCAT(pin, year) AS row_id,
     pin,
     pin10,
-    year,
+    CAST(year AS INT) AS year,
     class,
     triad_name,
     triad_code,

--- a/dbt/models/open_data/open_data.vw_parcel_universe_historical.sql
+++ b/dbt/models/open_data/open_data.vw_parcel_universe_historical.sql
@@ -6,7 +6,7 @@ SELECT
     CONCAT(pin, year) AS row_id,
     pin,
     pin10,
-    year,
+    CAST(year AS INT) AS year,
     class,
     triad_name,
     triad_code,

--- a/dbt/models/open_data/open_data.vw_permit.sql
+++ b/dbt/models/open_data/open_data.vw_permit.sql
@@ -6,7 +6,7 @@ SELECT
         pin, COALESCE(permit_number, ''), COALESCE(date_issued, '')
     ) AS row_id,
     pin,
-    year,
+    CAST(year AS INT) AS year,
     permit_number,
     local_permit_number,
     CAST(date_issued AS TIMESTAMP) AS date_issued,

--- a/dbt/models/open_data/open_data.vw_property_tax_exempt_parcel.sql
+++ b/dbt/models/open_data/open_data.vw_property_tax_exempt_parcel.sql
@@ -5,7 +5,7 @@
 SELECT
     CONCAT(pin, year) AS row_id,
     pin,
-    year,
+    CAST(year AS INT) AS year,
     township_name,
     township_code,
     owner_name,

--- a/dbt/models/open_data/open_data.vw_res_condo_unit_char.sql
+++ b/dbt/models/open_data/open_data.vw_res_condo_unit_char.sql
@@ -7,7 +7,7 @@ SELECT
     pin,
     pin10,
     card,
-    year,
+    CAST(year AS INT) AS year,
     class,
     township_code,
     tieback_key_pin,

--- a/dbt/models/open_data/open_data.vw_sf_mf_improvement_char.sql
+++ b/dbt/models/open_data/open_data.vw_sf_mf_improvement_char.sql
@@ -5,7 +5,7 @@
 SELECT
     pin || CAST(card AS VARCHAR) || year AS row_id,
     pin,
-    year,
+    CAST(year AS INT) AS year,
     card,
     class,
     township_code,


### PR DESCRIPTION
We transform year columns from strings to numbers for each of the assets on the open data portal. Part of having the `open_data` Athena db is to have those views represent what's on the open data portal without any transformations being done there (Socrata). It stands to reason year fields in the Athena db should also be numbers.

Having year columns as strings in our Athena dbs is an artifact of partitioning by year, rather than any design choice on our part - I shouldn't have continued this practice in the `open_data` db when it isn't necessary there.