### PR TITLE
Disable PRB test for pre-mailed values

### DIFF
--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -40,10 +40,7 @@ models:
           expression: |
             cod >= 0
             AND prd >= 0
-            AND (
-              (prb BETWEEN -1 AND 1 AND assessment_stage != 'pre-mailed')
-              OR (prb BETWEEN -1.5 AND 1.5 AND assessment_stage = 'pre-mailed')
-            )
+            AND (prb BETWEEN -1 AND 1 OR assessment_stage = 'pre-mailed')
             AND mki >= 0
             AND triad IS NOT NULL
             AND geography_type IS NOT NULL


### PR DESCRIPTION
We've decided that this test is too sensitive to outliers due to the variance in pre-mailed values that are under active review. This PR disables the PRB bounds test for pre-mailed values, since we are putting together a provisional value dashboard that will expose stats like PRB to teams that are accountable to them in a more accessible way.