### PR TITLE
Address `year` field to `int` in `open_data` db

### DIFF
--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -155,7 +155,7 @@ def parse_years_list(athena_asset, years=None):
             .as_pandas()["year"]
             .to_list()
         )
-        years_list.append(str(datetime.now().year))
+        years_list.append(datetime.now().year)
         years_list = [min(years_list)]
 
     else:
@@ -240,7 +240,7 @@ def build_query_dict(athena_asset, asset_id, years=None):
         query_dict = {None: query}
 
     else:
-        query_dict = {year: f"{query} WHERE year = '{year}'" for year in years}
+        query_dict = {year: f"{query} WHERE year = {year}" for year in years}
 
     return query_dict
 
@@ -268,7 +268,7 @@ def upload(asset_id, sql_query, overwrite):
             print_message = print_message + " all years for asset " + asset_id
         else:
             print_message = (
-                print_message + " year: " + year + " for asset " + asset_id
+                f"{print_message} year: {year} for asset {asset_id}"
             )
 
         input_data = cursor.execute(query).as_pandas()

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -116,12 +116,15 @@ def parse_years(years=None):
     if years == "":
         years = None
     if years is not None:
-        # Only allow anticipated values
-        years = [
-            re.sub("[^0-9]", "", year)
-            for year in str(years).split(",")
-            if re.sub("[^0-9]", "", year)
-        ]
+        if years == "all":
+            years = ["all"]
+        else:
+            # Only allow anticipated values
+            years = [
+                re.sub("[^0-9]", "", year)
+                for year in str(years).split(",")
+                if re.sub("[^0-9]", "", year)
+            ]
 
     return years
 


### PR DESCRIPTION
This PR addresses two issues:

- In https://github.com/ccao-data/data-architecture/pull/788 I changed all of the open data views' `year` fields to `int` from `string` without anticipating how it would affect this script. It did, and it [caused our monthly upload to fail](https://github.com/ccao-data/data-architecture/actions/runs/14770244541/job/41469029211).
- The 'all' option for the `years` input was essentially being ignore by the script and is now properly handled

Successful run with `all` option invoked and handling `year` fields as `int` [here](https://github.com/ccao-data/data-architecture/actions/runs/14782947275/job/41505671868).