### PR TITLE
Remove deprecated columns from permits open data view

### DIFF
--- a/dbt/models/open_data/open_data.vw_permit.sql
+++ b/dbt/models/open_data/open_data.vw_permit.sql
@@ -10,9 +10,7 @@ SELECT
     permit_number,
     local_permit_number,
     CAST(date_issued AS TIMESTAMP) AS date_issued,
-    CAST(date_submitted AS TIMESTAMP) AS date_submitted,
     estimated_date_of_completion,
-    recheck_year,
     CASE
         WHEN status = 'C' THEN 'CLOSED'
         WHEN status = 'L' THEN 'LEGACY'


### PR DESCRIPTION
Two columns that were removed from the Permits open data asset are still in the athena view that feeds it. There should be 22 columns in the view (21 that will show up on the open data portal + a row_id columns). This PR leaves us with 22 columns rather than 24. Output from an API update performing as expected can be found here.