### PR TITLE
Fix PINVAL table configs

### DIFF
--- a/dbt/models/pinval/docs.md
+++ b/dbt/models/pinval/docs.md
@@ -1,7 +1,6 @@
 # vw_assessment_card
 
-{% docs view_vw_assessment_card %}
-
+{% docs view_pinval_vw_assessment_card %}
 Table that holds card level data for subject PINs for PINVAL.
 
 **Primary Key**: `run_id`, `pin`, `meta_card_num`
@@ -9,7 +8,7 @@ Table that holds card level data for subject PINs for PINVAL.
 
 # vw_comp
 
-{% docs view_vw_comp %}
+{% docs view_pinval_vw_comp %}
 Table that holds card level data for comparables for PINVAL.
 
 **Primary Key**: `run_id`, `pin`, `meta_card_num`, `comp_num`

--- a/dbt/models/pinval/schema.yml
+++ b/dbt/models/pinval/schema.yml
@@ -1,6 +1,6 @@
 models:
-  - name: pinval.vw_pinval_comp
-    description: '{{ doc("vw_pinval_comp") }}'
+  - name: pinval.vw_comp
+    description: '{{ doc("view_pinval_vw_comp") }}'
     data_tests:
       - unique_combination_of_columns:
           name: pinval_comp_unique_run_id_pin_card_comp_num
@@ -10,8 +10,8 @@ models:
             - card
             - comp_num
 
-  - name: pinval.vw_pinval_assessment_card
-    description: '{{ doc("vw_pinval_assessment_card") }}'
+  - name: pinval.vw_assessment_card
+    description: '{{ doc("view_pinval_vw_assessment_card") }}'
     data_tests:
       - unique_combination_of_columns:
           name: pinval_assessment_card_unique_run_id_pin_card


### PR DESCRIPTION
I noticed while looking at our source freshness tests today that [dbt is throwing some warnings related to PINVAL tables](https://github.com/ccao-data/data-architecture/actions/runs/14837513125/job/41652085074#step:4:26). It looks like when we added these tables in https://github.com/ccao-data/data-architecture/pull/793, we used the incorrect table names and docs blocks names in the `schema.yml` configuration, which was causing dbt to not know about the tables. This PR fixes those errors to resolve the warnings and correct the DAG.

See [this workflow](https://github.com/ccao-data/data-architecture/actions/runs/14841942935/job/41666771867?pr=808#step:9:43) for evidence that the DAG builds correctly, with no warnings.