### PR TITLE
Use comp run with fixed small multicards in `pinval.vw_comp` view

### DIFF
--- a/dbt/models/pinval/pinval.vw_comp.sql
+++ b/dbt/models/pinval/pinval.vw_comp.sql
@@ -5,7 +5,7 @@ WITH runs_to_include AS (
     FROM {{ source('model', 'metadata') }}
     -- This will eventually grab all run_ids where
     -- run_type == comps
-    WHERE run_id = '2025-02-11-charming-eric'
+    WHERE run_id = '2025-04-25-fancy-free-billy'
 ),
 
 raw_comp AS (


### PR DESCRIPTION
In https://github.com/ccao-data/model-res-avm/pull/360 we made some changes to the comps pipeline so that comps for 2-3 card parcels better reflect the way that we value these parcels as of https://github.com/ccao-data/model-res-avm/pull/328. This PR updates the `pinval.vw_comp` view to use the comp run from this PR as the basis for comps, so that we can start using fixed comps in PINVAL development.

Connects https://github.com/ccao-data/pinval/issues/41.