### PR TITLE
Tweak `default_vw_card_res_char_row_count` test to exclude class 999

### DIFF
--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -98,7 +98,7 @@ jobs:
               dbt test -t "$TARGET" -s ${{ inputs.models }} --exclude "tag:data_test_iasworld" --indirect-selection cautious --defer --state "$STATE_DIR"
             else
               echo "Running tests on modified/new resources only"
-              dbt test -t "$TARGET" -s state:modified state:new --exclude "tag:data_test_iasworld" --indirect-selection cautious --defer --state "$STATE_DIR"
+              dbt test -t "$TARGET" --selector select_data_test_new_or_modified_non_iasworld --defer --state "$STATE_DIR"
             fi
           else
             echo "Running tests on all resources"

--- a/dbt/models/default/schema/default.vw_card_res_char.yml
+++ b/dbt/models/default/schema/default.vw_card_res_char.yml
@@ -115,9 +115,15 @@ models:
           equals: >
             (
               SELECT COUNT(*)
-              FROM {{ source('iasworld', 'dweldat') }}
-              WHERE cur = 'Y'
-                AND deactivat IS NULL
+              FROM {{ source('iasworld', 'dweldat') }} AS dwel
+              LEFT JOIN {{ source('iasworld', 'pardat') }} AS par
+                ON dwel.parid = par.parid
+                AND dwel.taxyr = par.taxyr
+                AND par.cur = 'Y'
+                AND par.deactivat IS NULL
+              WHERE dwel.cur = 'Y'
+                AND dwel.deactivat IS NULL
+                AND par.class != '999'
             )
       - unique_combination_of_columns:
           name: default_vw_card_res_char_unique_by_pin_card_and_year

--- a/dbt/selectors.yml
+++ b/dbt/selectors.yml
@@ -29,3 +29,21 @@ selectors:
           - method: tag
             value: data_test_iasworld
             indirect_selection: cautious
+
+  - name: select_data_test_new_or_modified_non_iasworld
+    description: >
+      Selector for running new or modified tests, while excluding iasWorld data
+      tests
+    definition:
+      intersection:
+        - method: resource_type
+          value: test
+        - union:
+            - method: state
+              value: new
+            - method: state
+              value: modified
+        - exclude:
+            - method: tag
+              value: data_test_iasworld
+              indirect_selection: cautious


### PR DESCRIPTION
In https://github.com/ccao-data/data-architecture/pull/807 we updated the `default.vw_card_res_char` view to remove PINs with class 999, which are not real PINs. This change caused [our data integrity tests to start failing](https://github.com/ccao-data/data-architecture/actions/runs/15111442361/job/42497136366#step:7:618), since that test did not account for the removal of the class 999 PINs.

One thing is strange about this situation: I would have expected the changes in #807 to trigger the `default_vw_card_res_char_row_count` test, since [that test was present on the main branch at the time of the PR](https://github.com/ccao-data/data-architecture/blob/6865afd8d8b84c852c01d802aea0e399ae1931b1/dbt/models/default/schema/default.vw_card_res_char.yml#L113-L121) and editing the `default.vw_card_res_char` model should have triggered it as part of the "test new/modified models" step in our `build-and-test-dbt` CI job. Indeed, [the logs for the last workflow run on that PR](https://github.com/ccao-data/data-architecture/actions/runs/15005949266/job/42164514390#step:9:55) confirm that the `default_vw_card_res_char_unique_by_pin_card_and_year` test ran, but not `default_vw_card_res_char_row_count`.

It turns out the issue here is that our [indirect selection logic](https://docs.getdbt.com/reference/global-configs/indirect-selection) is faulty. This PR fixes the issue with indirect selection and introduces a new selector to encapsulate the logic.