### PR TITLE
Add filer "Reason for Appeal" to `default.vw_pin_appeal`

### DIFF
--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -132,9 +132,7 @@ SELECT
     CASE
         WHEN reasons.user40 = 'Y' THEN TRUE WHEN reasons.user40 = 'N' THEN FALSE
     END AS reason_other,
-    CASE
-        WHEN reasons.user81 = 'Y' THEN TRUE WHEN reasons.user81 = 'N' THEN FALSE
-    END AS reason_other_description,
+    reasons.user81 AS reason_other_description,
 
     -- Status and agent name come from different columns before and after 2020
     CASE

--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -10,6 +10,17 @@ WITH reasons AS (
         htpar.taxyr,
         htpar.caseno,
         htpar.user38,
+        htpar.user19,
+        htpar.user20,
+        htpar.user21,
+        htpar.user22,
+        htpar.user23,
+        htpar.user24,
+        htpar.user25,
+        htpar.user109,
+        htpar.user110,
+        htpar.user40,
+        htpar.user81,
         htpar.user104,
         htpar.resact,
         htpar.hrstatus,
@@ -86,6 +97,18 @@ SELECT
         WHEN reasons.user38 = 'OM' THEN 'omitted assessment'
         WHEN reasons.user38 = 'RS' THEN 'residential'
     END AS appeal_type,
+
+    reasons.user19 AS reason_lack_of_uniformity,
+    reasons.user20 AS reason_fire_damage,
+    reasons.user21 AS reason_building_no_longer_exists,
+    reasons.user22 AS reason_over_valuation,
+    reasons.user23 AS reason_property_description_error,
+    reasons.user24 AS reason_vacancy_occupancy,
+    reasons.user25 AS reason_building_is_uninhabitable,
+    reasons.user109 AS reason_homeowner_exemption,
+    reasons.user110 AS reason_legal_argument,
+    reasons.user40 AS reason_other,
+    reasons.user81 AS reason_other_description,
 
     -- Status and agent name come from different columns before and after 2020
     CASE

--- a/dbt/models/default/default.vw_pin_appeal.sql
+++ b/dbt/models/default/default.vw_pin_appeal.sql
@@ -98,17 +98,43 @@ SELECT
         WHEN reasons.user38 = 'RS' THEN 'residential'
     END AS appeal_type,
 
-    reasons.user19 AS reason_lack_of_uniformity,
-    reasons.user20 AS reason_fire_damage,
-    reasons.user21 AS reason_building_no_longer_exists,
-    reasons.user22 AS reason_over_valuation,
-    reasons.user23 AS reason_property_description_error,
-    reasons.user24 AS reason_vacancy_occupancy,
-    reasons.user25 AS reason_building_is_uninhabitable,
-    reasons.user109 AS reason_homeowner_exemption,
-    reasons.user110 AS reason_legal_argument,
-    reasons.user40 AS reason_other,
-    reasons.user81 AS reason_other_description,
+    CASE
+        WHEN reasons.user19 = 'Y' THEN TRUE WHEN reasons.user19 = 'N' THEN FALSE
+    END AS reason_lack_of_uniformity,
+    CASE
+        WHEN reasons.user20 = 'Y' THEN TRUE WHEN reasons.user20 = 'N' THEN FALSE
+    END AS reason_fire_damage,
+    CASE
+        WHEN reasons.user21 = 'Y' THEN TRUE WHEN reasons.user21 = 'N' THEN FALSE
+    END AS reason_building_no_longer_exists,
+    CASE
+        WHEN reasons.user22 = 'Y' THEN TRUE WHEN reasons.user22 = 'N' THEN FALSE
+    END AS reason_over_valuation,
+    CASE
+        WHEN reasons.user23 = 'Y' THEN TRUE WHEN reasons.user23 = 'N' THEN FALSE
+    END AS reason_property_description_error,
+    CASE
+        WHEN reasons.user24 = 'Y' THEN TRUE WHEN reasons.user24 = 'N' THEN FALSE
+    END AS reason_vacancy_occupancy,
+    CASE
+        WHEN reasons.user25 = 'Y' THEN TRUE WHEN reasons.user25 = 'N' THEN FALSE
+    END AS reason_building_is_uninhabitable,
+    CASE
+        WHEN reasons.user109 = 'Y' THEN TRUE WHEN
+            reasons.user109 = 'N'
+            THEN FALSE
+    END AS reason_homeowner_exemption,
+    CASE
+        WHEN reasons.user110 = 'Y' THEN TRUE WHEN
+            reasons.user110 = 'N'
+            THEN FALSE
+    END AS reason_legal_argument,
+    CASE
+        WHEN reasons.user40 = 'Y' THEN TRUE WHEN reasons.user40 = 'N' THEN FALSE
+    END AS reason_other,
+    CASE
+        WHEN reasons.user81 = 'Y' THEN TRUE WHEN reasons.user81 = 'N' THEN FALSE
+    END AS reason_other_description,
 
     -- Status and agent name come from different columns before and after 2020
     CASE

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -30,9 +30,9 @@ models:
       - name: pin
         description: '{{ doc("shared_column_pin") }}'
       - name: reason_building_is_uninhabitable
-        description: '{{ doc("shared_column_reason_code") }}'
+        description: '{{ doc("shared_column_appeal_reason") }}'
       - name: reason_building_no_longer_exists
-        description: '{{ doc("shared_column_reason_code") }}'
+        description: '{{ doc("shared_column_appeal_reason") }}'
       - name: reason_code1
         description: '{{ doc("shared_column_reason_code") }}'
       - name: reason_code2

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -30,9 +30,9 @@ models:
       - name: pin
         description: '{{ doc("shared_column_pin") }}'
       - name: reason_building_is_uninhabitable
-        description: Reason for appeal is building is uninhabitable
+        description: '{{ doc("shared_column_reason_code") }}'
       - name: reason_building_no_longer_exists
-        description: Reason for appeal is building no longer exists
+        description: '{{ doc("shared_column_reason_code") }}'
       - name: reason_code1
         description: '{{ doc("shared_column_reason_code") }}'
       - name: reason_code2

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -40,23 +40,23 @@ models:
       - name: reason_code3
         description: '{{ doc("shared_column_reason_code") }}'
       - name: reason_fire_damage
-        description: Reason for appeal is fire damage
+        description: '{{ doc("shared_column_appeal_reason") }}'
       - name: reason_homeowner_exemption
-        description: Reason for appeal is homeowner exemption
+        description: '{{ doc("shared_column_appeal_reason") }}'
       - name: reason_lack_of_uniformity
-        description: Reason for appeal is lack of uniformity
+        description: '{{ doc("shared_column_appeal_reason") }}'
       - name: reason_legal_argument
-        description: Reason for appeal is legal argument
+        description: '{{ doc("shared_column_appeal_reason") }}'
       - name: reason_other
-        description: Reason for appeal is other
+        description: '{{ doc("shared_column_appeal_reason") }}'
       - name: reason_other_description
         description: Description if reason for appeal is other
       - name: reason_over_valuation
-        description: Reason for appeal is over valuation
+        description: '{{ doc("shared_column_appeal_reason") }}'
       - name: reason_property_description_error
-        description: Reason for appeal is property description error
+        description: '{{ doc("shared_column_appeal_reason") }}'
       - name: reason_vacancy_occupancy
-        description: Reason for appeal is vacancy/occupancy
+        description: '{{ doc("shared_column_appeal_reason") }}'
       - name: status
         description: '{{ doc("shared_column_appeal_status") }}'
       - name: township_code

--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -29,12 +29,34 @@ models:
         description: '{{ doc("shared_column_mailed_tot") }}'
       - name: pin
         description: '{{ doc("shared_column_pin") }}'
+      - name: reason_building_is_uninhabitable
+        description: Reason for appeal is building is uninhabitable
+      - name: reason_building_no_longer_exists
+        description: Reason for appeal is building no longer exists
       - name: reason_code1
         description: '{{ doc("shared_column_reason_code") }}'
       - name: reason_code2
         description: '{{ doc("shared_column_reason_code") }}'
       - name: reason_code3
         description: '{{ doc("shared_column_reason_code") }}'
+      - name: reason_fire_damage
+        description: Reason for appeal is fire damage
+      - name: reason_homeowner_exemption
+        description: Reason for appeal is homeowner exemption
+      - name: reason_lack_of_uniformity
+        description: Reason for appeal is lack of uniformity
+      - name: reason_legal_argument
+        description: Reason for appeal is legal argument
+      - name: reason_other
+        description: Reason for appeal is other
+      - name: reason_other_description
+        description: Description if reason for appeal is other
+      - name: reason_over_valuation
+        description: Reason for appeal is over valuation
+      - name: reason_property_description_error
+        description: Reason for appeal is property description error
+      - name: reason_vacancy_occupancy
+        description: Reason for appeal is vacancy/occupancy
       - name: status
         description: '{{ doc("shared_column_appeal_status") }}'
       - name: township_code

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -154,6 +154,24 @@ Agent name, typically name of taxpayer or attorney filing appeal
 Result of appeal: `change` or `no change`
 {% enddocs %}
 
+## appeal_reason
+
+{% docs shared_column_appeal_reason %}
+Indicator for an appeal reason, selected by the applicant on appeal.
+
+Generally, the column name should describe the reason; for example,
+`reason_over_valuation` means the applicant claims that the appeal is justified
+by overvaluation. The one exception to this pattern is reason_other, which
+relies on the reason_other_description column to provide a description of the
+appeal reason.
+
+Possible values for this variable are:
+
+- TRUE: The applicant selected this reason
+- FALSE: The applicant did not select this reason
+- NULL: We are unsure, but we think this is equivalent to FALSE
+{% enddocs %}
+
 ## appeal_status
 
 {% docs shared_column_appeal_status %}


### PR DESCRIPTION
I went through an example of each column being `TRUE` to make sure it agreed with what appears in iasWorld, and it does.

@ccao-jardine @jeancochrane  while `TRUE` seems to indicate what you would assume, `FALSE` and `NULL` seem entirely interchangeable here. Do either of you have a preference for how to code NULL/FALSE? Should we just consider anything not `TRUE` as `FALSE`, or leave it as is? Case no. 24-74-1468720 is a good example. Only `reason_other` is `TRUE`, no other boxes are checked when you investigate in iasWorld, but for whatever reason `reason_lack_of_uniformity` is `FALSE`:

![image](https://github.com/user-attachments/assets/1b0b9676-525e-4c81-a35d-0ca26e0a5d68)

```
select case_no,
	pin,
	reason_lack_of_uniformity,
	reason_fire_damage,
	reason_building_no_longer_exists,
	reason_over_valuation,
	reason_property_description_error,
	reason_vacancy_occupancy,
	reason_building_is_uninhabitable,
	reason_homeowner_exemption,
	reason_legal_argument,
	reason_other,
	reason_other_description
from z_ci_823_add_filer_reason_for_appeal_to_defaultvw_pin_appeal_default.vw_pin_appeal
where case_no = '24-74-1468720'
```

| case_no       | pin            | reason_lack_of_uniformity | reason_fire_damage | reason_building_no_longer_exists | reason_over_valuation | reason_property_description_error | reason_vacancy_occupancy | reason_building_is_uninhabitable | reason_homeowner_exemption | reason_legal_argument | reason_other | reason_other_description |
|---------------|----------------|---------------------------|--------------------|----------------------------------|-----------------------|-----------------------------------|--------------------------|----------------------------------|----------------------------|-----------------------|--------------|--------------------------|
| 24-74-1468720 | 14324130621004 | false                     |                    |                                  |                       |                                   |                          |                                  |                            |                       | true         | see brief                |
| 24-74-1468720 | 14324130621002 | false                     |                    |                                  |                       |                                   |                          |                                  |                            |                       | true         | see brief                |
| 24-74-1468720 | 14324130621003 | false                     |                    |                                  |                       |                                   |                          |                                  |                            |                       | true         | see brief                |
| 24-74-1468720 | 14324130621005 | false                     |                    |                                  |                       |                                   |                          |                                  |                            |                       | true         | see brief                |
| 24-74-1468720 | 14324130621006 | false                     |                    |                                  |                       |                                   |                          |                                  |                            |                       | true         | see brief                |
| 24-74-1468720 | 14324130621001 | false                     |                    |                                  |                       |                                   |                          |                                  |                            |                       | true         | see brief                |

## Testing to make sure new view is consistent with prior row counts

```
with new as (
	select year,
		count(*) as new
	from z_ci_823_add_filer_reason_for_appeal_to_defaultvw_pin_appeal_default.vw_pin_appeal
	group by year
),
old as (
	select year,
		count(*) as old
	from default.vw_pin_appeal
	group by year
)
select new.year,
	new.new,
	old.old,
	new.new = old.old as match
from new
	full outer join old on new.year = old.year
```

| #  | year | new    | old    | match |
|----|------|--------|--------|-------|
| 8  | 2025 | 26489  | 26489  | true  |
| 15 | 2024 | 440467 | 440467 | true  |
| 22 | 2023 | 243427 | 243427 | true  |
| 18 | 2022 | 302331 | 302331 | true  |
| 11 | 2021 | 373640 | 373640 | true  |
| 20 | 2020 | 238034 | 238034 | true  |
| 5  | 2019 | 389870 | 389870 | true  |
| 10 | 2018 | 531406 | 531406 | true  |
| 21 | 2017 | 370217 | 370217 | true  |
| 17 | 2016 | 446840 | 446840 | true  |
| 25 | 2015 | 522393 | 522393 | true  |
| 7  | 2014 | 340849 | 340849 | true  |
| 1  | 2013 | 412460 | 412460 | true  |
| 4  | 2012 | 392624 | 392624 | true  |
| 19 | 2011 | 317395 | 317395 | true  |
| 16 | 2010 | 353612 | 353612 | true  |
| 23 | 2009 | 449028 | 449028 | true  |
| 14 | 2008 | 315669 | 315669 | true  |
| 3  | 2007 | 336395 | 336395 | true  |
| 27 | 2006 | 355976 | 355976 | true  |
| 6  | 2005 | 232970 | 232970 | true  |
| 2  | 2004 | 288567 | 288567 | true  |
| 9  | 2003 | 318327 | 318327 | true  |
| 13 | 2002 | 232716 | 232716 | true  |
| 24 | 2001 | 198419 | 198419 | true  |
| 12 | 2000 | 230578 | 230578 | true  |
| 26 | 1999 | 156621 | 156621 | true  |