### PR TITLE
Simplify `open_data_rows_join_rows_to_delete` macro

### DIFF
--- a/dbt/macros/open_data_join_rows_to_delete.sql
+++ b/dbt/macros/open_data_join_rows_to_delete.sql
@@ -5,11 +5,9 @@ Macro that can selectively add:
 - non-condo class
 rows to the open data views, as well as rows from tables other than pardat so
 that a ":deleted" flag associated with their row_id can be sent to the open data
-portal.
+portal. Currently this can only be "owndat".
 
-There are multiple complications here:
-- Feeder views can have different columns that define row_id.
-- The universe of parcels that might need to be purged from the open data assets
+The universe of parcels that might need to be purged from the open data assets
 is different for different feeder views. The macro takes arguments to specify
 how to construct the approriate universe of rows to purge.
 */

--- a/dbt/macros/open_data_join_rows_to_delete.sql
+++ b/dbt/macros/open_data_join_rows_to_delete.sql
@@ -17,31 +17,21 @@ how to construct the approriate universe of rows to purge.
     full outer join
         (
             select
-                {% if addn_table == "dweldat" %}
-                    pdat.parid || cast(addndat.card as varchar) || pdat.taxyr as row_id,
-                {% else %} pdat.parid || pdat.taxyr as row_id,
-                {% endif %}
+                pdat.parid || pdat.taxyr as row_id,
                 pdat.taxyr as year,
                 true as ":deleted"
             from {{ source("iasworld", "pardat") }} as pdat
-            {% if addn_table is not none %}
-                {% if addn_table == "dweldat" %} inner join
-                {% elif addn_table == "owndat" %} left join
-                {% endif %}
+            {% if addn_table == "owndat" %}
+                left join
                     {{ source("iasworld", addn_table) }} as addndat
                     on pdat.parid = addndat.parid
                     and pdat.taxyr = addndat.taxyr
             {% endif %}
             where
                 pdat.deactivat is not null
-                {% if addn_table == "dweldat" %} or addndat.deactivat is not null
-                {% elif addn_table == "owndat" %} or addndat.ownnum is null
-                {% endif %}
+                {% if addn_table == "owndat" %} or addndat.ownnum is null {% endif %}
                 {% if condo == true %} or pdat.class not in ('299', '399') {% endif %}
                 {% if allow_999 == false %} or pdat.class = '999' {% endif %}
         ) as deleted_rows
-        {% if addn_table == "dweldat" %}
-            on feeder.pin || cast(feeder.card as varchar) || feeder.year
-        {% else %} on feeder.pin || feeder.year
-        {% endif %} = deleted_rows.row_id
+        on feeder.pin || feeder.year = deleted_rows.row_id
 {% endmacro %}

--- a/dbt/macros/open_data_join_rows_to_delete.sql
+++ b/dbt/macros/open_data_join_rows_to_delete.sql
@@ -26,7 +26,7 @@ how to construct the approriate universe of rows to purge.
             from {{ source("iasworld", "pardat") }} as pdat
             {% if addn_table is not none %}
                 {% if addn_table == "dweldat" %} inner join
-                {% else %} left join
+                {% elif addn_table == "owndat" %} left join
                 {% endif %}
                     {{ source("iasworld", addn_table) }} as addndat
                     on pdat.parid = addndat.parid
@@ -34,10 +34,9 @@ how to construct the approriate universe of rows to purge.
             {% endif %}
             where
                 pdat.deactivat is not null
-                {% if addn_table == "dweldat" %}
-                    or addndat.deactivat is not null
+                {% if addn_table == "dweldat" %} or addndat.deactivat is not null
+                {% elif addn_table == "owndat" %} or addndat.ownnum is null
                 {% endif %}
-                {% if addn_table == "owndat" %} or addndat.ownnum is null {% endif %}
                 {% if condo == true %} or pdat.class not in ('299', '399') {% endif %}
                 {% if allow_999 == false %} or pdat.class = '999' {% endif %}
         ) as deleted_rows

--- a/dbt/macros/open_data_join_rows_to_delete.sql
+++ b/dbt/macros/open_data_join_rows_to_delete.sql
@@ -16,55 +16,32 @@ how to construct the approriate universe of rows to purge.
 {% macro open_data_join_rows_to_delete(allow_999=false, condo=false, addn_table=none) %}
     full outer join
         (
-            {% if addn_table == "sales" %}
-                select
-                    salekey as row_id, substr(saledt, 1, 4) as year, true as ":deleted"
-                from {{ source("iasworld", addn_table) }}
-                where deactivat is not null
-            {% elif addn_table == "permit" %}
-                select
-                    parid || coalesce(num, '') || coalesce(permdt, '') as row_id,
-                    substr(permdt, 1, 4) as year,
-                    true as ":deleted"
-                from {{ source("iasworld", addn_table) }}
-                where deactivat is not null
-            {% else %}
-                select
-                    {% if addn_table == "dweldat" %}
-                        pdat.parid
-                        || cast(addndat.card as varchar)
-                        || pdat.taxyr as row_id,
-                    {% else %} pdat.parid || pdat.taxyr as row_id,
-                    {% endif %}
-                    pdat.taxyr as year,
-                    true as ":deleted"
-                from {{ source("iasworld", "pardat") }} as pdat
-                {% if addn_table is not none %}
-                    {% if addn_table == "dweldat" %} inner join
-                    {% else %} left join
-                    {% endif %}
-                        {{ source("iasworld", addn_table) }} as addndat
-                        on pdat.parid = addndat.parid
-                        and pdat.taxyr = addndat.taxyr
+            select
+                {% if addn_table == "dweldat" %}
+                    pdat.parid || cast(addndat.card as varchar) || pdat.taxyr as row_id,
+                {% else %} pdat.parid || pdat.taxyr as row_id,
                 {% endif %}
-                where
-                    pdat.deactivat is not null
-                    {% if addn_table == "dweldat" %} or addndat.deactivat is not null
-                    {% endif %}
-                    {% if addn_table == "owndat" %} or addndat.ownnum is null
-                    {% endif %}
-                    {% if condo == true %} or pdat.class not in ('299', '399')
-                    {% endif %}
-                    {% if allow_999 == false %} or pdat.class = '999'
-                    {% endif %}
+                pdat.taxyr as year,
+                true as ":deleted"
+            from {{ source("iasworld", "pardat") }} as pdat
+            {% if addn_table is not none %}
+                {% if addn_table == "dweldat" %} inner join
+                {% else %} left join
+                {% endif %}
+                    {{ source("iasworld", addn_table) }} as addndat
+                    on pdat.parid = addndat.parid
+                    and pdat.taxyr = addndat.taxyr
             {% endif %}
+            where
+                pdat.deactivat is not null
+                {% if addn_table == "dweldat" %}
+                    or addndat.deactivat is not null
+                {% endif %}
+                {% if addn_table == "owndat" %} or addndat.ownnum is null {% endif %}
+                {% if condo == true %} or pdat.class not in ('299', '399') {% endif %}
+                {% if allow_999 == false %} or pdat.class = '999' {% endif %}
         ) as deleted_rows
-        {% if addn_table == "sales" %} on feeder.sale_key
-        {% elif addn_table == "permit" %}
-            on feeder.pin
-            || coalesce(feeder.permit_number, '')
-            || coalesce(feeder.date_issued, '')
-        {% elif addn_table == "dweldat" %}
+        {% if addn_table == "dweldat" %}
             on feeder.pin || cast(feeder.card as varchar) || feeder.year
         {% else %} on feeder.pin || feeder.year
         {% endif %} = deleted_rows.row_id

--- a/dbt/models/open_data/open_data.vw_appeal.sql
+++ b/dbt/models/open_data/open_data.vw_appeal.sql
@@ -25,4 +25,41 @@ SELECT
     feeder.status,
     {{ open_data_columns(row_id_cols=['pin', 'year', 'case_no']) }}
 FROM {{ ref('default.vw_pin_appeal') }} AS feeder
-{{ open_data_join_rows_to_delete(addn_table="htpar") }}
+FULL OUTER JOIN
+    (
+
+        -- htpar is by far the most complex here since row_id's can show
+        -- up multiple times, sometimes being deactivated and sometimes
+        -- not.
+        WITH
+        entire_case AS (
+            SELECT
+                addndat.parid || addndat.taxyr || addndat.caseno AS row_id,
+                addndat.taxyr AS year,
+                TRUE AS deleted,
+                AVG(
+                    CASE
+                        WHEN addndat.deactivat IS NOT NULL THEN 1 ELSE 0
+                    END
+                ) AS deactivat
+            FROM {{ source("iasworld", "htpar") }} AS addndat
+            LEFT JOIN
+                {{ source("iasworld", "pardat") }} AS pdat
+                ON addndat.parid = pdat.parid
+                AND addndat.taxyr = pdat.taxyr
+            WHERE addndat.caseno IS NOT NULL OR pdat.deactivat IS NOT NULL
+            GROUP BY
+                addndat.parid || addndat.taxyr || addndat.caseno,
+                addndat.taxyr
+        )
+
+        SELECT
+            row_id,
+            year,
+            deleted AS ":deleted" -- noqa: RF05
+        FROM entire_case
+        WHERE deactivat = 1
+
+    ) AS deleted_rows
+    ON feeder.pin || feeder.year || feeder.case_no
+    = deleted_rows.row_id

--- a/dbt/models/open_data/open_data.vw_appeal.sql
+++ b/dbt/models/open_data/open_data.vw_appeal.sql
@@ -27,9 +27,12 @@ SELECT
 FROM {{ ref('default.vw_pin_appeal') }} AS feeder
 FULL OUTER JOIN
     (
-        -- htpar is by far the most complex here since row_id's can show
-        -- up multiple times, sometimes being deactivated and sometimes
-        -- not.
+        /*
+        row_id's in htpar consist of PINs and appeal case numbers (as well as
+        years) and can show up multiple times, sometimes being deactivated and
+        sometimes not. We aggregate them and to figure out which case/PIN
+        combos have been entirely deactivated.
+        */
         WITH
         entire_case AS (
             SELECT

--- a/dbt/models/open_data/open_data.vw_appeal.sql
+++ b/dbt/models/open_data/open_data.vw_appeal.sql
@@ -27,7 +27,6 @@ SELECT
 FROM {{ ref('default.vw_pin_appeal') }} AS feeder
 FULL OUTER JOIN
     (
-
         -- htpar is by far the most complex here since row_id's can show
         -- up multiple times, sometimes being deactivated and sometimes
         -- not.
@@ -59,7 +58,6 @@ FULL OUTER JOIN
             deleted AS ":deleted" -- noqa: RF05
         FROM entire_case
         WHERE deactivat = 1
-
     ) AS deleted_rows
     ON feeder.pin || feeder.year || feeder.case_no
     = deleted_rows.row_id

--- a/dbt/models/open_data/open_data.vw_parcel_sale.sql
+++ b/dbt/models/open_data/open_data.vw_parcel_sale.sql
@@ -30,4 +30,16 @@ SELECT
     feeder.mydec_deed_type,
     {{ open_data_columns(row_id_cols=['sale_key']) }}
 FROM {{ ref('default.vw_pin_sale') }} AS feeder
-{{ open_data_join_rows_to_delete(addn_table="sales") }}
+FULL OUTER JOIN
+    (
+
+        SELECT
+            salekey AS row_id,
+            SUBSTR(saledt, 1, 4) AS year,
+            TRUE AS ":deleted" -- noqa: RF05
+        FROM {{ source("iasworld", "sales") }}
+        WHERE deactivat IS NOT NULL
+
+    ) AS deleted_rows
+    ON feeder.sale_key
+    = deleted_rows.row_id

--- a/dbt/models/open_data/open_data.vw_parcel_sale.sql
+++ b/dbt/models/open_data/open_data.vw_parcel_sale.sql
@@ -32,14 +32,12 @@ SELECT
 FROM {{ ref('default.vw_pin_sale') }} AS feeder
 FULL OUTER JOIN
     (
-
         SELECT
             salekey AS row_id,
             SUBSTR(saledt, 1, 4) AS year,
             TRUE AS ":deleted" -- noqa: RF05
         FROM {{ source("iasworld", "sales") }}
         WHERE deactivat IS NOT NULL
-
     ) AS deleted_rows
     ON feeder.sale_key
     = deleted_rows.row_id

--- a/dbt/models/open_data/open_data.vw_permit.sql
+++ b/dbt/models/open_data/open_data.vw_permit.sql
@@ -724,16 +724,13 @@ SELECT
 FROM {{ ref('default.vw_pin_permit') }} AS feeder
 FULL OUTER JOIN
     (
-
         SELECT
             parid || COALESCE(num, '') || COALESCE(permdt, '') AS row_id,
             SUBSTR(permdt, 1, 4) AS year,
             TRUE AS ":deleted" -- noqa: RF05
         FROM {{ source("iasworld", "permit") }}
         WHERE deactivat IS NOT NULL
-
     ) AS deleted_rows
-
     ON feeder.pin
     || COALESCE(feeder.permit_number, '')
     || COALESCE(feeder.date_issued, '')

--- a/dbt/models/open_data/open_data.vw_permit.sql
+++ b/dbt/models/open_data/open_data.vw_permit.sql
@@ -722,4 +722,19 @@ SELECT
     {% endfor %},
     {{ open_data_columns(row_id_cols=["pin", "permit_number", "date_issued"]) }}
 FROM {{ ref('default.vw_pin_permit') }} AS feeder
-{{ open_data_join_rows_to_delete(addn_table="permit") }}
+FULL OUTER JOIN
+    (
+
+        SELECT
+            parid || COALESCE(num, '') || COALESCE(permdt, '') AS row_id,
+            SUBSTR(permdt, 1, 4) AS year,
+            TRUE AS ":deleted" -- noqa: RF05
+        FROM {{ source("iasworld", "permit") }}
+        WHERE deactivat IS NOT NULL
+
+    ) AS deleted_rows
+
+    ON feeder.pin
+    || COALESCE(feeder.permit_number, '')
+    || COALESCE(feeder.date_issued, '')
+    = deleted_rows.row_id


### PR DESCRIPTION
The purpose here is to remove some of the complexity of the `open_data_rows_join_rows_to_delete` by performing the joins necessary to populate our `open_data` views with `:deleted` rows directly in those view scripts rather trying to abstract away every single one of them. Most views still employ the macro, but 4 now do not since their joins are rather complex and it's both useful to see the code explicitly and have the macro not be a minefield of conditional logic.  All of the queries below produce 0 rows, meaning the code changes have not altered the content of the views.

I more or less copy and pasted code from `dbt compile` into the views that have been changed, so there isn't a ton to see in the views. The macro has been gutted.

## Views adjusted directly

<details>

<summary>vw_appeal</summary>

```
with new as (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as new
	from z_ci_826_simplify_open_data_rows_join_rows_to_delete_macro_open_data.vw_appeal
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
old AS (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as old
	from open_data.vw_appeal
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
matches as (
	select new.":deleted",
		new.year,
		new.new,
		old.old,
		new.new = old.old as match
	from new
		full outer join old on new.year = old.year
		and new.":deleted" = old.":deleted"
	order by year desc
)
select *
from matches
where not match
	or match is null
```

</details>

<details>

<summary>vw_parcel_sale</summary>

```
with new as (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as new
	from z_ci_826_simplify_open_data_rows_join_rows_to_delete_macro_open_data.vw_parcel_sale
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
old AS (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as old
	from open_data.vw_parcel_sale
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
matches as (
	select new.":deleted",
		new.year,
		new.new,
		old.old,
		new.new = old.old as match
	from new
		full outer join old on new.year = old.year
		and new.":deleted" = old.":deleted"
	order by year desc
)
select *
from matches
where not match
	or match is null
```

</details>

<details>

<summary>vw_permit</summary>

```
with new as (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as new
	from z_ci_826_simplify_open_data_rows_join_rows_to_delete_macro_open_data.vw_permit
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
old AS (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as old
	from open_data.vw_permit
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
matches as (
	select new.":deleted",
		new.year,
		new.new,
		old.old,
		new.new = old.old as match
	from new
		full outer join old on new.year = old.year
		and new.":deleted" = old.":deleted"
	order by year desc
)
select *
from matches
where not match
	or match is null
```

</details>

<details>

<summary>vw_sf_mf_improvement_char</summary>

```
with new as (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as new
	from z_ci_826_simplify_open_data_rows_join_rows_to_delete_macro_open_data.vw_sf_mf_improvement_char
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
old AS (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as old
	from open_data.vw_sf_mf_improvement_char
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
matches as (
	select new.":deleted",
		new.year,
		new.new,
		old.old,
		new.new = old.old as match
	from new
		full outer join old on new.year = old.year
		and new.":deleted" = old.":deleted"
	order by year desc
)
select *
from matches
where not match
	or match is null
```

</details>

## Views adjusted indirectly

<details>

<summary>vw_assessed_value</summary>

```
with new as (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as new
	from z_ci_826_simplify_open_data_rows_join_rows_to_delete_macro_open_data.vw_assessed_value
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
old AS (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as old
	from open_data.vw_assessed_value
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
matches as (
	select new.":deleted",
		new.year,
		new.new,
		old.old,
		new.new = old.old as match
	from new
		full outer join old on new.year = old.year
		and new.":deleted" = old.":deleted"
	order by year desc
)
select *
from matches
where not match
	or match is null
```

</details>

<details>

<summary>vw_parcel_status</summary>

```
with new as (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as new
	from z_ci_826_simplify_open_data_rows_join_rows_to_delete_macro_open_data.vw_parcel_status
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
old AS (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as old
	from open_data.vw_parcel_status
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
matches as (
	select new.":deleted",
		new.year,
		new.new,
		old.old,
		new.new = old.old as match
	from new
		full outer join old on new.year = old.year
		and new.":deleted" = old.":deleted"
	order by year desc
)
select *
from matches
where not match
	or match is null
```

</details>

<details>

<summary>vw_parcel_address</summary>

```
with new as (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as new
	from z_ci_826_simplify_open_data_rows_join_rows_to_delete_macro_open_data.vw_parcel_address
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
old AS (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as old
	from open_data.vw_parcel_address
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
matches as (
	select new.":deleted",
		new.year,
		new.new,
		old.old,
		new.new = old.old as match
	from new
		full outer join old on new.year = old.year
		and new.":deleted" = old.":deleted"
	order by year desc
)
select *
from matches
where not match
	or match is null
```

</details>

<details>

<summary>vw_parcel_universe_historical</summary>

```
with new as (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as new
	from z_ci_826_simplify_open_data_rows_join_rows_to_delete_macro_open_data.vw_parcel_universe_historical
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
old AS (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as old
	from open_data.vw_parcel_universe_historical
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
matches as (
	select new.":deleted",
		new.year,
		new.new,
		old.old,
		new.new = old.old as match
	from new
		full outer join old on new.year = old.year
		and new.":deleted" = old.":deleted"
	order by year desc
)
select *
from matches
where not match
	or match is null
```

</details>

<details>

<summary>vw_property_tax_exempt_parcel</summary>

```
with new as (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as new
	from z_ci_826_simplify_open_data_rows_join_rows_to_delete_macro_open_data.vw_property_tax_exempt_parcel
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
old AS (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as old
	from open_data.vw_property_tax_exempt_parcel
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
matches as (
	select new.":deleted",
		new.year,
		new.new,
		old.old,
		new.new = old.old as match
	from new
		full outer join old on new.year = old.year
		and new.":deleted" = old.":deleted"
	order by year desc
)
select *
from matches
where not match
	or match is null
```

</details>

<details>

<summary>vw_res_condo_unit_char</summary>

```
with new as (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as new
	from z_ci_826_simplify_open_data_rows_join_rows_to_delete_macro_open_data.vw_res_condo_unit_char
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
old AS (
	select case
			when ":deleted" then true else false
		end as ":deleted",
		case
			when year is null then '' else cast(year as varchar)
		end as year,
		count(*) as old
	from open_data.vw_res_condo_unit_char
	group by case
			when year is null then '' else cast(year as varchar)
		end,
		":deleted"
),
matches as (
	select new.":deleted",
		new.year,
		new.new,
		old.old,
		new.new = old.old as match
	from new
		full outer join old on new.year = old.year
		and new.":deleted" = old.":deleted"
	order by year desc
)
select *
from matches
where not match
	or match is null
```

</details>