### PR TITLE
Resolve unexpected `NaN` for `phase_av_share` in `vw_assessment_roll_muni`

### DIFF
--- a/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
+++ b/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
@@ -161,8 +161,14 @@ SELECT
     SUM(tot_sum)
         OVER (PARTITION BY year, stage, municipality)
         AS phase_total_av,
-    CAST(tot_sum AS DOUBLE)
-    / CAST(
-        SUM(tot_sum) OVER (PARTITION BY year, stage, municipality) AS DOUBLE
-    ) AS phase_av_share
+    CASE WHEN SUM(tot_sum)
+                OVER (PARTITION BY year, stage, municipality)
+            = 0 THEN NULL ELSE
+            CAST(tot_sum AS DOUBLE)
+            / CAST(
+                SUM(tot_sum)
+                    OVER (PARTITION BY year, stage, municipality)
+                AS DOUBLE
+            )
+    END AS phase_av_share
 FROM muni_aggregated


### PR DESCRIPTION
> The `reporting_vw_assessment_roll_muni_phase_av_share_range` test [is failing](https://github.com/ccao-data/data-architecture/actions/runs/15533165101/job/43726325919#step:7:625) for a group whose total AV is zero and whose AV share is `NaN`. I believe the zero AV causes a division-by-zero error in the calculation of the `phase_av_share` column, which in turn causes the `NaN` value, though I'm not totally confident in that assessment.

Correct. Problem is resolved with a `CASE WHEN` to avoid calculating a phase av share when there's no phase av.  Results of
```
select *
from z_ci_833_resolve_unexpected_nan_for_phase_av_share_in_vw_assessment_roll_muni_reporting.vw_assessment_roll_muni
where phase_av_share is null
```
[are attached](https://github.com/user-attachments/files/20679727/d8ab8bf5-2b8e-4a75-b8b9-cdb9d48d161c.csv)  and as expected.
