### PR TITLE
Mask sensitive AWS identifiers in GitHub workflow logs

### DIFF
--- a/.github/actions/setup_dbt/action.yaml
+++ b/.github/actions/setup_dbt/action.yaml
@@ -5,7 +5,7 @@ inputs:
     description: AWS IAM role to assume when running dbt operations.
     required: true
   aws-account-id:
-    description: AWS account ID to use to create resources.
+    description: AWS account ID. Only used for masking the value in logs.
     required: true
   role-duration-seconds:
     description: Expiration time for AWS OIDC token. Default is one hour.

--- a/.github/actions/setup_dbt/action.yaml
+++ b/.github/actions/setup_dbt/action.yaml
@@ -4,6 +4,9 @@ inputs:
   role-to-assume:
     description: AWS IAM role to assume when running dbt operations.
     required: true
+  aws-account-id:
+    description: AWS account ID to use to create resources.
+    required: true
   role-duration-seconds:
     description: Expiration time for AWS OIDC token. Default is one hour.
     required: false
@@ -16,6 +19,12 @@ runs:
 
     - name: Load environment variables
       uses: ./.github/actions/load_environment_variables
+
+    - name: Mask sensitive AWS IDs from Terraform logs
+      run: |
+        echo "::add-mask::${{ inputs.role-to-assume }}"
+        echo "::add-mask::${{ inputs.aws-account-id }}"
+      shell: bash
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
           role-duration-seconds: 14400  # Worst-case time for full build
 
       - name: Restore dbt state cache

--- a/.github/workflows/build_daily_dbt_models.yaml
+++ b/.github/workflows/build_daily_dbt_models.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
           role-duration-seconds: 14400  # Worst-case time for full build
 
       - name: Restore dbt state cache

--- a/.github/workflows/cleanup_dbt_resources.yaml
+++ b/.github/workflows/cleanup_dbt_resources.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
       - name: Install requirements for cleaning up dbt resources
         run: sudo apt-get update && sudo apt-get install jq

--- a/.github/workflows/deploy_dbt_docs.yaml
+++ b/.github/workflows/deploy_dbt_docs.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -62,6 +62,7 @@ jobs:
         uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
           role-duration-seconds: 14400
 
       # Set these env vars as secrets so they get masked in the GitHub

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -74,8 +74,6 @@ jobs:
 
       - name: Upload to Socrata
         env:
-          AWS_IAM_ROLE_TO_ASSUME_ARN: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
-          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_ATHENA_S3_STAGING_DIR: ${{ vars.AWS_ATHENA_S3_STAGING_DIR }}
           SOCRATA_APP_TOKEN: ${{ secrets.SOCRATA_APP_TOKEN }}
           SOCRATA_USERNAME: ${{ secrets.SOCRATA_USERNAME }}

--- a/.github/workflows/test_dbt_models.yaml
+++ b/.github/workflows/test_dbt_models.yaml
@@ -70,6 +70,7 @@ jobs:
         uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
       - name: Restore dbt state cache
         id: cache

--- a/.github/workflows/test_dbt_source_freshness.yaml
+++ b/.github/workflows/test_dbt_source_freshness.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
       - name: Test source freshness
         run: dbt source freshness --target "$TARGET"

--- a/.github/workflows/test_iasworld_data.yaml
+++ b/.github/workflows/test_iasworld_data.yaml
@@ -65,6 +65,7 @@ jobs:
         uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
       - name: Restore dbt state cache
         id: cache

--- a/.github/workflows/test_open_data_assets.yaml
+++ b/.github/workflows/test_open_data_assets.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: ./.github/actions/setup_dbt
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
       - name: Compile dbt manifest
         run: dbt compile


### PR DESCRIPTION
This PR updates the `setup_dbt` composite action to add a [masks](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#masking-a-value-in-a-log) for sensitive AWS identifiers. This is a best practice to ensure that these sensitive identifiers never get accidentally printed to logs in the course of a dbt command or direct AWS CLI operation. All of our workflows that interact with AWS resources use the `setup_dbt` composite action, so by masking identifiers in the context of the action, we should get good coverage for protecting our logs.

See here for a log line showing the mask: https://github.com/ccao-data/data-architecture/actions/runs/15620684692/job/44004516960?pr=842#step:3:219