### PR TITLE
Fix school district geoid

### DIFF
--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-school.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-school.R
@@ -280,7 +280,14 @@ process_cps_file <- function(s3_bucket_uri, file_year, uri, dist_type) {
         boundarygr != "9, 10, 11, 12" &
         !(file_year %in% c("2017", "2018"))
     )) %>%
-    mutate(school_nm = str_replace(school_nm, "H S", "HS")) %>%
+    mutate(
+      school_nm = str_replace(school_nm, "H S", "HS"),
+      school_nm = str_replace(school_nm, "MERTO", "METRO"),
+      school_id = case_when(
+        school_nm == "HANCOCK HS" & file_year == "2011" ~ "609694",
+        TRUE ~ school_id
+      )
+    ) %>%
     group_by(grade_cat, school_id, school_nm) %>%
     summarise() %>%
     ungroup() %>%

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-school.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-school.R
@@ -209,6 +209,8 @@ county_districts_df <- st_join(
   filter(
     (year == census_year & district_type == census_district_type) | is.na(geoid)
   ) %>%
+  # Some districts don't properly join to census shapes and need to have geoids
+  # manually assigned
   mutate(geoid = case_when(
     district_type == "unified" & school_num == "205" ~ "1713970",
     district_type == "elementary" & school_num == "100" ~ "1706090",

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-school.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-school.R
@@ -211,7 +211,7 @@ county_districts_df <- st_join(
   ) %>%
   mutate(geoid = case_when(
     district_type == "unified" & school_num == "205" ~ "1713970",
-    district_type == "elementary" & school_num == "100" ~ "1737860",
+    district_type == "elementary" & school_num == "100" ~ "1706090",
     district_type == "elementary" & school_num == "125" ~ "1704560",
     school_num == "180" ~ "1730510",
     school_num == "157-" ~ "1715700",


### PR DESCRIPTION
@jeancochrane found two school districts with the same census geoids in `spatial.school`. Turns out I screwed up manually assigning geoids due to an incomplete join in the `spatial-school.R` warehouse script. Got the new geoid from tidycensus:
```
tidycensus::get_acs(
  geography = "school district (elementary)",
  table = "B01001",
  survey = "acs5",
  output = "wide",
  state = "IL",
  year = 2023,
  cache_table = TRUE
)
```
![image](https://github.com/user-attachments/assets/bc521168-10f8-4562-975b-a6aa306f8ef1)

Also found some random errors with the raw cps attendance data in 2011 that we were failing to address - one school number and one school name.

```
select geoid,
	year,
	count(*)
from spatial.school_district
where geoid is not null
group by geoid,
	year
having count(*) > 1
```

shows we're good now.
