### PR TITLE
Add township_name and detailed class column for better user output

### DIFF
--- a/dbt/models/pinval/pinval.vw_assessment_card.sql
+++ b/dbt/models/pinval/pinval.vw_assessment_card.sql
@@ -26,6 +26,13 @@ school_districts AS (
     FROM spatial.school_district
     WHERE geoid IS NOT NULL
     GROUP BY geoid, year
+),
+
+townships AS (
+    SELECT
+        township_code,
+        township_name
+    FROM spatial.township
 )
 
 SELECT
@@ -37,7 +44,8 @@ SELECT
     run.model_predictor_all_name,
     run.assessment_triad,
     run.assessment_year,
-    final.final_model_run_date
+    final.final_model_run_date,
+    tw.township_name
 FROM runs_to_include AS run
 INNER JOIN model.assessment_card AS ac
     ON run.run_id = ac.run_id
@@ -52,4 +60,6 @@ LEFT JOIN school_districts AS sec_sd
     AND ac.meta_year = sec_sd.year
 LEFT JOIN final_model_run AS final
     ON run.assessment_year = final.year
+LEFT JOIN townships AS tw
+    ON ac.township_code = tw.township_code
 WHERE ap.meta_triad_code = final.triad_code

--- a/dbt/models/pinval/pinval.vw_assessment_card.sql
+++ b/dbt/models/pinval/pinval.vw_assessment_card.sql
@@ -33,6 +33,13 @@ townships AS (
         township_code,
         township_name
     FROM spatial.township
+),
+
+class_dict AS (
+    SELECT
+        class_code,
+        class_desc
+    FROM ccao.class_dict
 )
 
 SELECT
@@ -45,7 +52,9 @@ SELECT
     run.assessment_triad,
     run.assessment_year,
     final.final_model_run_date,
-    tw.township_name
+    tw.township_name,
+    CONCAT(CAST(ac.char_class AS VARCHAR), ': ', cd.class_desc)
+        AS char_class_detailed
 FROM runs_to_include AS run
 INNER JOIN model.assessment_card AS ac
     ON run.run_id = ac.run_id
@@ -62,4 +71,6 @@ LEFT JOIN final_model_run AS final
     ON run.assessment_year = final.year
 LEFT JOIN townships AS tw
     ON ac.township_code = tw.township_code
+LEFT JOIN class_dict AS cd
+    ON ac.char_class = cd.class_code
 WHERE ap.meta_triad_code = final.triad_code

--- a/dbt/models/pinval/pinval.vw_assessment_card.sql
+++ b/dbt/models/pinval/pinval.vw_assessment_card.sql
@@ -46,15 +46,15 @@ SELECT
     ac.*,
     ap.pred_pin_final_fmv_round,
     ap.loc_property_address AS property_address,
+    tw.township_name,
+    CONCAT(CAST(ac.char_class AS VARCHAR), ': ', cd.class_desc)
+        AS char_class_detailed,
     elem_sd.name AS school_elementary_district_name,
     sec_sd.name AS school_secondary_district_name,
     run.model_predictor_all_name,
     run.assessment_triad,
     run.assessment_year,
-    final.final_model_run_date,
-    tw.township_name,
-    CONCAT(CAST(ac.char_class AS VARCHAR), ': ', cd.class_desc)
-        AS char_class_detailed
+    final.final_model_run_date
 FROM runs_to_include AS run
 INNER JOIN model.assessment_card AS ac
     ON run.run_id = ac.run_id

--- a/dbt/models/pinval/pinval.vw_assessment_card.sql
+++ b/dbt/models/pinval/pinval.vw_assessment_card.sql
@@ -69,8 +69,8 @@ LEFT JOIN school_districts AS sec_sd
     AND ac.meta_year = sec_sd.year
 LEFT JOIN final_model_run AS final
     ON run.assessment_year = final.year
-LEFT JOIN townships AS tw
+LEFT JOIN {{ source('spatial', 'township') }} AS tw
     ON ac.township_code = tw.township_code
-LEFT JOIN class_dict AS cd
+LEFT JOIN {{ ref('ccao.class_dict') }} AS cd
     ON ac.char_class = cd.class_code
 WHERE ap.meta_triad_code = final.triad_code

--- a/dbt/models/pinval/pinval.vw_assessment_card.sql
+++ b/dbt/models/pinval/pinval.vw_assessment_card.sql
@@ -26,20 +26,6 @@ school_districts AS (
     FROM spatial.school_district
     WHERE geoid IS NOT NULL
     GROUP BY geoid, year
-),
-
-townships AS (
-    SELECT
-        township_code,
-        township_name
-    FROM spatial.township
-),
-
-class_dict AS (
-    SELECT
-        class_code,
-        class_desc
-    FROM ccao.class_dict
 )
 
 SELECT


### PR DESCRIPTION
This PR updates `pinval.vw_assessment_card` to produce clean readable columns

- township name
- detailed class code

so we can bring them into the html doc for improved readability, based on this issue: https://github.com/ccao-data/pinval/issues/60