### PR TITLE
Fix `ward_num` type in `location.political` table

### DIFF
--- a/dbt/models/location/location.political.sql
+++ b/dbt/models/location/location.political.sql
@@ -141,7 +141,7 @@ ward_chicago AS (
     SELECT
         dp.x_3435,
         dp.y_3435,
-        MAX(cprod.ward_num) AS ward_num,
+        CAST(MAX(cprod.ward_num) AS VARCHAR) AS ward_num,
         MAX(cprod.ward_name) AS ward_name,
         MAX(
             CASE
@@ -185,7 +185,7 @@ ward_evanston AS (
     SELECT
         dp.x_3435,
         dp.y_3435,
-        MAX(cprod.ward_num) AS ward_num,
+        CAST(MAX(cprod.ward_num) AS VARCHAR) AS ward_num,
         MAX(cprod.ward_name) AS ward_name,
         MAX(
             CASE
@@ -233,7 +233,7 @@ SELECT
     cd.cook_commissioner_district_data_year,
     jd.cook_judicial_district_num,
     jd.cook_judicial_district_data_year,
-    CAST(COALESCE(we.ward_num, wc.ward_num) AS VARCHAR) AS ward_num,
+    COALESCE(we.ward_num, wc.ward_num) AS ward_num,
     COALESCE(we.ward_name, wc.ward_name) AS ward_name,
     wc.ward_chicago_data_year,
     we.ward_evanston_data_year,

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-political.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-political.R
@@ -59,6 +59,8 @@ columns <- list(
   "municipality_2020" = c("agency", "agency_desc"),
   "municipality_2021" = c("agency", "agency_desc"),
   "municipality_2022" = c("agency", "agency_desc"),
+  "municipality_2023" = c("agency", "agency_desc"),
+  "municipality_2024" = c("agency", "agency_desc"),
   "state_representative_district_2010" = c("district_n"),
   "state_representative_district_2023" = c("district_int", "district_txt"),
   "state_senate_district_2010" = c("senatenum", "senatedist"),


### PR DESCRIPTION
All of our district num columns are strings except for `ward_num`. Just want to make sure this isn't causing any issue further down the line if we expect these types of columns to be consistent.

```
with new as (
	select ward_num,
		count(*) as new
	from z_ci_fix_ward_num_type_in_pin_universe_location.political
	group by ward_num
),
old as (
	select cast(ward_num as varchar) as ward_num,
		count(*) as old
	from
		location.political
	group by ward_num
)
select old.ward_num
from old
	left join new on old.ward_num = new.ward_num
where new.new != old.old
```

returns nothing.

Also found an issue in the etl script that builds the spatial table that feeds this table. seems like it was run correctly at some point but the update to the script wasn't saved since these two most recent years of municipal data are in athena already.