### PR TITLE
Remove rows with null card numbers from `pinval.vw_assessment_card`

### DIFF
--- a/dbt/models/pinval/pinval.vw_assessment_card.sql
+++ b/dbt/models/pinval/pinval.vw_assessment_card.sql
@@ -66,3 +66,4 @@ LEFT JOIN {{ source('spatial', 'township') }} AS tw
 LEFT JOIN {{ ref('ccao.class_dict') }} AS cd
     ON ac.char_class = cd.class_code
 WHERE ap.meta_triad_code = final.triad_code
+    AND ac.meta_card_num IS NOT NULL


### PR DESCRIPTION
This PR fixes a tiny bug that I ran into while deploying North tri staging PINVAL reports. It turns out that five 2024 data rows in `model.assessment_card` for the final 2025 model contained null card numbers. These rows did not have final values, indicating that the model correctly filtered them out; however, we need to filter them out to avoid causing errors in the PINVAL report generation process.

QC details TK.