### PR TITLE
Simplify the `pinval.vw_assessment_card` data model

### DIFF
--- a/dbt/models/pinval/columns.md
+++ b/dbt/models/pinval/columns.md
@@ -6,7 +6,7 @@ When `TRUE`, this PIN is eligible for a PINVAL report for the given model run
 
 ## meta_card_num
 
-{% docs meta_card_num %}
+{% docs column_pinval_meta_card_num %}
 The card number for the card.
 
 There are two cases in which this column might be null:
@@ -22,14 +22,10 @@ There are two cases in which this column might be null:
 
 {% enddocs %}
 
-## model_run_id
+## run_id
 
-{% docs column_pinval_model_run_id %}
+{% docs column_pinval_run_id %}
 Run ID for the model run associated with this card and its values.
-
-Prefer this column to `run_id`, which comes from `model.assessment_card`,
-because `run_id` will be null if the parcel is ineligible for a report
-for this model run. In contrast, this column will never be null.
 
 In the case of a parcel that is ineligible for a PINVAL report, the presence
 of a value for this column might seem confusing because that parcel wasn't
@@ -41,65 +37,25 @@ every model run in this table should have a row for every parcel in its data
 year, regardless of whether that parcel was actually part of the model run.
 {% enddocs %}
 
-## parcel_class
+## char_class
 
-{% docs column_pinval_parcel_class %}
-The class for the parcel that this card is associated with.
+{% docs column_pinval_char_class %}
+The class for the card or parcel that this row represents.
 
-This field is different from `char_class`, which comes from
-`model.assessment_card` and represents the card class. Card classes do not
-necessarily match the class of the parcel that the card is associated with.
-This field will also always be present even if `char_class` is null, because
-this field comes from `default.vw_pin_universe` which contains PINs that
-are not present in the assessment set due to not being a residential
-regression class.
+If a row represents a card that was part of the model assessment set, then
+this column will be the card class that we used as a predictor in the model.
+If a row instead represents a parcel that was _not_ part of the assessment set,
+then this column will be the parcel class, and is used in the
+`reason_report_ineligible` column to explain why we excluded the parcel from
+the assessment set.
+
+This column will never be null.
 {% enddocs %}
 
-## parcel_class_description
+## char_class_desc
 
-{% docs column_pinval_parcel_class_description %}
-The short description for the card's parcel class.
-
-See `parcel_class` for details on the difference between parcel classes and
-card classes in the context of this view.
-{% enddocs %}
-
-## parcel_township_code
-
-{% docs column_pinval_parcel_township_code %}
-Township code for the card's parcel.
-
-See `parcel_class` for details on the difference between parcel classes and
-card classes in the context of this view.
-{% enddocs %}
-
-## parcel_township_name
-
-{% docs column_pinval_parcel_township_name %}
-Township name for the card's parcel.
-
-See `parcel_class` for details on the difference between parcel classes and
-card classes in the context of this view.
-{% enddocs %}
-
-## parcel_triad_name
-
-{% docs column_pinval_parcel_triad_name %}
-Triad name for the card's parcel.
-
-See `parcel_class` for details on the difference between parcel classes and
-card classes in the context of this view.
-{% enddocs %}
-
-## pin
-
-{% docs column_pinval_pin %}
-The card's parcel identification number (PIN).
-
-In general, you should prefer this column to `meta_pin` when querying from this
-table, since `meta_pin` comes from `model.assessment_card` and will be null for
-PINs that the res model does not value. You can safely use `meta_pin` when
-filtering by `is_report_eligible = TRUE`, however.
+{% docs column_pinval_char_class_desc %}
+A short description explaining the code contained in `char_class`
 {% enddocs %}
 
 ## reason_report_ineligible

--- a/dbt/models/pinval/columns.md
+++ b/dbt/models/pinval/columns.md
@@ -1,3 +1,24 @@
+## char_class
+
+{% docs column_pinval_char_class %}
+The class for the card or parcel that this row represents.
+
+If a row represents a card that was part of the model assessment set, then
+this column will be the card class that we used as a predictor in the model.
+If a row instead represents a parcel that was _not_ part of the assessment set,
+then this column will be the parcel class, and is used in the
+`reason_report_ineligible` column to explain why we excluded the parcel from
+the assessment set.
+
+This column will never be null.
+{% enddocs %}
+
+## char_class_desc
+
+{% docs column_pinval_char_class_desc %}
+A short description explaining the code contained in `char_class`
+{% enddocs %}
+
 ## is_report_eligible
 
 {% docs column_pinval_is_report_eligible %}
@@ -20,42 +41,6 @@ There are two cases in which this column might be null:
   causes the model to ignore the parcel for valuation purposes. In this case,
   the `reason_report_ineligible` column will have the value `'missing_card'`.
 
-{% enddocs %}
-
-## run_id
-
-{% docs column_pinval_run_id %}
-Run ID for the model run associated with this card and its values.
-
-In the case of a parcel that is ineligible for a PINVAL report, the presence
-of a value for this column might seem confusing because that parcel wasn't
-actually valued in the model run. However, since this table requires a row
-for every parcel in every eligible model run in order to compute parcel
-eligibility in the `is_report_eligible` and `reason_report_ineligible` columns,
-we add parcels to model runs that considered them ineligible. As a result,
-every model run in this table should have a row for every parcel in its data
-year, regardless of whether that parcel was actually part of the model run.
-{% enddocs %}
-
-## char_class
-
-{% docs column_pinval_char_class %}
-The class for the card or parcel that this row represents.
-
-If a row represents a card that was part of the model assessment set, then
-this column will be the card class that we used as a predictor in the model.
-If a row instead represents a parcel that was _not_ part of the assessment set,
-then this column will be the parcel class, and is used in the
-`reason_report_ineligible` column to explain why we excluded the parcel from
-the assessment set.
-
-This column will never be null.
-{% enddocs %}
-
-## char_class_desc
-
-{% docs column_pinval_char_class_desc %}
-A short description explaining the code contained in `char_class`
 {% enddocs %}
 
 ## reason_report_ineligible
@@ -83,4 +68,19 @@ Possible values for this variable are:
 - `NULL`: The PIN is eligible for a PINVAL report. This should only ever be
   the case when `is_report_eligible` is `TRUE`, and our data integrity
   tests check to make sure this is true
+{% enddocs %}
+
+## run_id
+
+{% docs column_pinval_run_id %}
+Run ID for the model run associated with this card and its values.
+
+In the case of a parcel that is ineligible for a PINVAL report, the presence
+of a value for this column might seem confusing because that parcel wasn't
+actually valued in the model run. However, since this table requires a row
+for every parcel in every eligible model run in order to compute parcel
+eligibility in the `is_report_eligible` and `reason_report_ineligible` columns,
+we add parcels to model runs that considered them ineligible. As a result,
+every model run in this table should have a row for every parcel in its data
+year, regardless of whether that parcel was actually part of the model run.
 {% enddocs %}

--- a/dbt/models/pinval/docs.md
+++ b/dbt/models/pinval/docs.md
@@ -11,29 +11,7 @@ do not have reports. Use the `is_report_eligible` column to filter for
 report-eligible PINs, and use the `reason_report_ineligible` column to explain
 missing reports.
 
-In general, parcel-level attributes that come from `default.vw_pin_universe`
-should have a `parcel_` prefix and should always be non-null. Card-level
-attributes that come from `model.assessment_card` should have one of the
-standard modeling prefixes and may be null. Standard modeling prefixes include:
-
-- `meta_`
-- `pred_`
-- `char_`
-- `loc_`
-- `prox_`
-- `acs5_`
-- `other_`
-- `time_`
-- `ind_`
-- `lag_`
-- `ccao_`
-- `shp_`
-- `flag_`
-
-See the docs for `model.assessment_card` for a detailed list of modeling
-attributes.
-
-**Primary Key**: `run_id`, `pin`, `meta_card_num`
+**Primary Key**: `run_id`, `meta_pin`, `meta_card_num`
 {% enddocs %}
 
 # vw_comp

--- a/dbt/models/pinval/pinval.vw_assessment_card.sql
+++ b/dbt/models/pinval/pinval.vw_assessment_card.sql
@@ -38,6 +38,7 @@ SELECT
     -- to generate detailed descriptions for why those parcels don't have
     -- reports
     COALESCE(ac.meta_pin, uni.pin) AS meta_pin,
+    ac.meta_card_num,
     COALESCE(ac.township_code, uni.township_code) AS meta_township_code,
     uni.township_name AS meta_township_name,
     LOWER(uni.triad_name) AS meta_triad_name,

--- a/dbt/models/pinval/pinval.vw_assessment_card.sql
+++ b/dbt/models/pinval/pinval.vw_assessment_card.sql
@@ -232,7 +232,7 @@ SELECT
     -- that's fine because this table is only ever intended to be used to
     -- extract individual rows and use those rows as the basis for PINVAL
     -- reports, in which case row-level duplication is useful
-    run.run_id AS model_run_id,
+    run.run_id,
     run.model_predictor_all_name,
     run.assessment_triad AS assessment_triad_name,
     run.assessment_year,

--- a/dbt/models/pinval/pinval.vw_assessment_card.sql
+++ b/dbt/models/pinval/pinval.vw_assessment_card.sql
@@ -193,6 +193,7 @@ SELECT
     ac.shp_parcel_mrr_area_ratio,
     ac.shp_parcel_mrr_side_ratio,
     ac.shp_parcel_num_vertices,
+    ac.pred_card_initial_fmv,
     ap.pred_pin_final_fmv_round,
     -- Pull some additional parcel-level info from `model.assessment_pin`
     CAST(

--- a/dbt/models/pinval/pinval.vw_comp.sql
+++ b/dbt/models/pinval/pinval.vw_comp.sql
@@ -57,7 +57,11 @@ sale_years AS (
 )
 
 SELECT
-    pc.*,
+    pc.pin,
+    pc.card,
+    pc.comp_num,
+    pc.comp_score,
+    pc.comp_document_num,
     COALESCE(pc.pin = pc.comp_pin, FALSE) AS is_subject_pin_sale,
     CASE
         WHEN train.ind_pin_is_multicard = TRUE THEN 'Subject card'
@@ -82,8 +86,9 @@ SELECT
             || CAST(sy.max_year AS VARCHAR)
     END AS sale_year_range
 FROM pivoted_comp AS pc
-LEFT JOIN {{ source('model', 'pinval_test_training_data') }} AS train
-    ON pc.comp_pin = train.meta_pin
+LEFT JOIN {{ ref('model.training_data') }} AS train
+    ON pc.run_id = train.run_id
+    AND pc.comp_pin = train.meta_pin
     AND pc.comp_document_num = train.meta_sale_document_num
 LEFT JOIN school_districts AS elem_sd
     ON train.loc_school_elementary_district_geoid = elem_sd.geoid

--- a/dbt/models/pinval/pinval.vw_comp.sql
+++ b/dbt/models/pinval/pinval.vw_comp.sql
@@ -21,6 +21,7 @@ pivoted_comp AS (
         SELECT
             pin,
             card,
+            year,
             {{ i }} AS comp_num,
             comp_pin_{{ i }} AS comp_pin,
             comp_score_{{ i }} AS comp_score,
@@ -38,7 +39,7 @@ school_districts AS (
         geoid,
         year,
         MAX(name) AS name
-    FROM spatial.school_district
+    FROM {{ source('spatial', 'school_district') }}
     WHERE geoid IS NOT NULL
     GROUP BY geoid, year
 ),
@@ -60,6 +61,7 @@ SELECT
     pc.pin,
     pc.card,
     pc.comp_num,
+    pc.comp_pin,
     pc.comp_score,
     pc.comp_document_num,
     COALESCE(pc.pin = pc.comp_pin, FALSE) AS is_subject_pin_sale,
@@ -87,7 +89,10 @@ SELECT
     END AS sale_year_range
 FROM pivoted_comp AS pc
 LEFT JOIN {{ ref('model.training_data') }} AS train
-    ON pc.run_id = train.run_id
+-- Join on year rather than run ID because `model.training_data` is
+-- guaranteed to be unique by year but may have a different run ID
+-- than the comps run
+    ON pc.year = train.assessment_year
     AND pc.comp_pin = train.meta_pin
     AND pc.comp_document_num = train.meta_sale_document_num
 LEFT JOIN school_districts AS elem_sd

--- a/dbt/models/pinval/schema.yml
+++ b/dbt/models/pinval/schema.yml
@@ -34,6 +34,11 @@ models:
               name: pinval_vw_assessment_card_meta_card_num_null_when_reason_report_ineligible_is_missing_card
               config:
                 where: reason_report_ineligible = 'missing_card'
+      - name: meta_pin
+        description: '{{ doc("shared_column_pin") }}'
+        data_tests:
+          - not_null:
+              name: pinval_assessment_card_meta_pin_not_null
       - name: meta_township_code
         description: '{{ doc("shared_column_township_code") }}'
         data_tests:
@@ -49,11 +54,6 @@ models:
         data_tests:
           - not_null:
               name: pinval_assessment_card_meta_triad_name_not_null
-      - name: pin
-        description: '{{ doc("shared_column_pin") }}'
-        data_tests:
-          - not_null:
-              name: pinval_assessment_card_pin_not_null
       - name: reason_report_ineligible
         description: '{{ doc("column_pinval_reason_report_ineligible") }}'
         data_tests:
@@ -74,7 +74,7 @@ models:
               values:
                 - non_tri
               config:
-                where: LOWER(parcel_triad_name) = LOWER(assessment_triad_name)
+                where: LOWER(meta_triad_name) = LOWER(assessment_triad_name)
           - not_accepted_values:
               name: pinval_vw_assessment_card_reason_report_ineligible_not_unknown
               values:
@@ -83,7 +83,7 @@ models:
         description: '{{ doc("column_pinval_run_id") }}'
         data_tests:
           - not_null:
-              name: pinval_assessment_card_run_id_not_null
+              name: pinval_assessment_card_meta_run_id_not_null
 
     data_tests:
       - expression_is_true:
@@ -106,8 +106,8 @@ models:
               )
             ) = 0
       - unique_combination_of_columns:
-          name: pinval_assessment_card_unique_run_id_pin_card
+          name: pinval_assessment_card_unique_run_id_meta_pin_meta_card_num
           combination_of_columns:
             - run_id
-            - pin
+            - meta_pin
             - meta_card_num

--- a/dbt/models/pinval/schema.yml
+++ b/dbt/models/pinval/schema.yml
@@ -85,8 +85,26 @@ models:
           - not_null:
               name: pinval_assessment_card_run_id_not_null
 
-    # TODO: Test contains all predictors
     data_tests:
+      - expression_is_true:
+          name: pinval_assessment_card_contains_a_column_for_all_predictors
+          # It'd be nice to use the `model` Relation that is the first argument
+          # to the `expression_is_true` generic test instead of relying on
+          # `ref()` to extract the database and table name, but since this
+          # expression gets evaluated at compile time, it does not point to
+          # the correct model if we try to reference `model`
+          expression: |
+            CARDINALITY(
+              ARRAY_EXCEPT(
+                model_predictor_all_name,
+                (
+                  SELECT ARRAY_AGG(column_name)
+                  FROM information_schema.columns
+                  WHERE table_schema = '{{ ref("pinval.vw_assessment_card").schema }}'
+                    AND table_name = '{{ ref("pinval.vw_assessment_card").identifier }}'
+                )
+              )
+            ) = 0
       - unique_combination_of_columns:
           name: pinval_assessment_card_unique_run_id_pin_card
           combination_of_columns:

--- a/dbt/models/pinval/schema.yml
+++ b/dbt/models/pinval/schema.yml
@@ -88,6 +88,19 @@ models:
     data_tests:
       - expression_is_true:
           name: pinval_assessment_card_contains_a_column_for_all_predictors
+          # Test that every `model_predictor_all_name` array for every row is a
+          # subset of the columns in the table. This ensures that we never face
+          # a situation where we accidentally forget to update columns to add
+          # new model predictors, which might cause empty characteristics in
+          # the rendered reports.
+          #
+          # This test query is a bit complicated, but basically we're
+          # using `ARRAY_EXCEPT()` to perform a set difference between each
+          # `model_predictor_all_name` array on the left side, and the columns
+          # in the view on the right side. The `CARDINALITY(...) = 0` expression
+          # ensures that we return any rows where the length of the set
+          # difference is >0.
+          #
           # It'd be nice to use the `model` Relation that is the first argument
           # to the `expression_is_true` generic test instead of relying on
           # `ref()` to extract the database and table name, but since this

--- a/dbt/models/pinval/schema.yml
+++ b/dbt/models/pinval/schema.yml
@@ -13,54 +13,44 @@ models:
   - name: pinval.vw_assessment_card
     description: '{{ doc("view_pinval_vw_assessment_card") }}'
     columns:
+      - name: char_class
+        description: '{{ doc("column_pinval_char_class") }}'
+        data_tests:
+          - not_null:
+              name: pinval_assessment_card_char_class_not_null
+              config:
+                where: reason_report_ineligible = 'non_regression_class'
+      - name: char_class_desc
+        description: '{{ doc("column_pinval_char_class_desc") }}'
       - name: is_report_eligible
         description: '{{ doc("column_pinval_is_report_eligible") }}'
         data_tests:
           - not_null:
               name: pinval_assessment_card_is_report_eligible_not_null
       - name: meta_card_num
+        description: '{{ doc("column_pinval_meta_card_num") }}'
         data_tests:
           - is_null:
               name: pinval_vw_assessment_card_meta_card_num_null_when_reason_report_ineligible_is_missing_card
               config:
                 where: reason_report_ineligible = 'missing_card'
-      - name: model_run_id
-        description: '{{ doc("column_pinval_model_run_id") }}'
+      - name: meta_township_code
+        description: '{{ doc("shared_column_township_code") }}'
         data_tests:
           - not_null:
-              name: pinval_assessment_card_model_run_id_not_null
-      - name: parcel_class
-        description: '{{ doc("column_pinval_parcel_class") }}'
+              name: pinval_assessment_card_meta_township_code_not_null
+      - name: meta_township_name
+        description: '{{ doc("shared_column_township_name") }}'
         data_tests:
           - not_null:
-              name: pinval_assessment_card_parcel_class_not_null
-              config:
-                where: reason_report_ineligible = 'non_regression_class'
-      - name: parcel_class_description
-        description: '{{ doc("column_pinval_parcel_class_description") }}'
-      - name: parcel_township_code
-        description: '{{ doc("column_pinval_parcel_township_code") }}'
-        data_tests:
-          - columns_match:
-              name: pinval_assessment_card_parcel_township_code_matches_meta_township_code
-              matching_column_names:
-                - meta_township_code
-              config:
-                where: meta_township_code IS NOT NULL
-          - not_null:
-              name: pinval_assessment_card_parcel_township_code_not_null
-      - name: parcel_township_name
-        description: '{{ doc("column_pinval_parcel_township_name") }}'
+              name: pinval_assessment_card_meta_township_name_not_null
+      - name: meta_triad_name
+        description: '{{ doc("shared_column_triad_name") }}'
         data_tests:
           - not_null:
-              name: pinval_assessment_card_parcel_township_name_not_null
-      - name: parcel_triad_name
-        description: '{{ doc("column_pinval_parcel_triad_name") }}'
-        data_tests:
-          - not_null:
-              name: pinval_assessment_card_parcel_triad_name_not_null
+              name: pinval_assessment_card_meta_triad_name_not_null
       - name: pin
-        description: '{{ doc("column_pinval_pin") }}'
+        description: '{{ doc("shared_column_pin") }}'
         data_tests:
           - not_null:
               name: pinval_assessment_card_pin_not_null
@@ -89,7 +79,13 @@ models:
               name: pinval_vw_assessment_card_reason_report_ineligible_not_unknown
               values:
                 - unknown
+      - name: run_id
+        description: '{{ doc("column_pinval_run_id") }}'
+        data_tests:
+          - not_null:
+              name: pinval_assessment_card_run_id_not_null
 
+    # TODO: Test contains all predictors
     data_tests:
       - unique_combination_of_columns:
           name: pinval_assessment_card_unique_run_id_pin_card


### PR DESCRIPTION
This PR follows up on the changes we made to `pinval.vw_assessment_card` in https://github.com/ccao-data/data-architecture/pull/851 to add rows for every parcel in the County for every model run. That PR used a confusing convention of `parcel_*` and `model_*` column name prefixes for new columns in order to skirt around the problem that we select `*` from `model.assessment_card` and so can't rename any of its columns. This PR resolves this problem at the root by instead selecting the specific columns that we want from `model.assessment_card` such that we can filter them, rename them, or transform them.

Note that this choice introduces a maintenance burden, in that we have to manually add any new predictors to the set of selected columns in `pinval.vw_assessment_card` whenever we add new predictors to the res model. We make two changes to mitigate the risk that we will forget to do this:

1. The addition of a new data integrity test in this PR to ensure that every `model_predictor_all_name` array in this table is a subset of the columns of the `pinval.vw_assessment_card` table
2. A corresponding PR in `model-res-avm` to update the annual model finalization checklist to include an item for updating `pinval.vw_assessment_card` to include any new predictors (https://github.com/ccao-data/model-res-avm/pull/384)

This PR also folds in one small unrelated data model change to `pinval.vw_comp`, switching from the temporary `model.pinval_test_training_data` table to the permanent `model.training_data` table that we added in https://github.com/ccao-data/data-architecture/pull/804 in order to augment comps with training data characteristics. That change resolves https://github.com/ccao-data/data-architecture/issues/803.

Connects https://github.com/ccao-data/data-architecture/issues/855.

Companion PRs:
- PINVAL: https://github.com/ccao-data/pinval/pull/85
- Res model: https://github.com/ccao-data/model-res-avm/pull/384