### PR TITLE
Add `not_null` test for PINVAL card num field to support better char table UX

### DIFF
--- a/dbt/models/pinval/schema.yml
+++ b/dbt/models/pinval/schema.yml
@@ -30,6 +30,10 @@ models:
       - name: meta_card_num
         description: '{{ doc("column_pinval_meta_card_num") }}'
         data_tests:
+          - not_null:
+              name: pinval_vw_assessment_card_meta_card_num_not_null_when_is_report_eligible
+              config:
+                where: is_report_eligible
           - is_null:
               name: pinval_vw_assessment_card_meta_card_num_null_when_reason_report_ineligible_is_missing_card
               config:


### PR DESCRIPTION
In https://github.com/ccao-data/pinval/pull/93, we're changing the PINVAL reports based on the assumption that report-eligible PINs will always have not-null card numbers (see in particular [this comment](https://github.com/ccao-data/pinval/pull/93/files#r2208624634)). This PR adds a data test to enforce that assumption so we will be notified if we ever break it.