### PR TITLE
Simplify IC reference file logging config

### DIFF
--- a/dbt/scripts/export_models.py
+++ b/dbt/scripts/export_models.py
@@ -92,9 +92,9 @@ if __name__ == "__main__":
         log_group_name=args.log_to_cloudwatch_group,
     )
 
-    logger.info("Starting model export")
-
     try:
+        logger.info("Starting model export")
+
         export_models(
             args.target,
             args.select,
@@ -107,12 +107,8 @@ if __name__ == "__main__":
         logger.info("Export completed successfully.")
 
     except Exception as e:
-        # The CloudWatch log handler does not include "ERROR - " at the
-        # beginning of log lines, so we need to preface the message with
-        # "ERROR - " to trigger alarms.
-        logger.error(f"ERROR - {e}")
-
-        # Suppress the error if we're uploading to Cloudwatch so that we can
-        # perform cleanup below, but otherwise, raise the error
-        if args.log_to_cloudwatch_group is None:
-            raise
+        logger.error(
+            str(e) or f"{type(e).__name__} raised with no message",
+            exc_info=True,
+        )
+        raise

--- a/dbt/scripts/utils/helpers.py
+++ b/dbt/scripts/utils/helpers.py
@@ -28,14 +28,25 @@ def create_logger(
     if log_file_path is not None and os.path.exists(log_file_path):
         os.remove(log_file_path)
 
-    # Create and start the default stream logger
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(levelname)s - %(message)s",
-        datefmt="%Y-%m-%d_%H:%M:%S.%f",
-        force=True,
+    formatter = logging.Formatter(
+        fmt="%(asctime)s.%(msecs)03d - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d_%H:%M:%S",
     )
+
+    # Create logger and add custom handlers
     logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    # Clear handlers in case we accidentally call this function multiple times
+    logger.handlers.clear()
+
+    # Always log to the console
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    # Turn off log propagation to the root logger to avoid duplication with
+    # the stream handler
+    logger.propagate = False
 
     # Log to CloudWatch if desired
     if log_group_name is not None:
@@ -45,10 +56,13 @@ def create_logger(
             log_group_name=log_group_name,
             stream_name=stream_name,
         )
+        cw_handler.setFormatter(formatter)
         logger.addHandler(cw_handler)
 
     # Add a file handler to write logs to a local file if specified
     if log_file_path is not None:
-        logger.addHandler(logging.FileHandler(log_file_path))
+        file_handler = logging.FileHandler(log_file_path)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
 
     return logger

--- a/dbt/scripts/utils/helpers.py
+++ b/dbt/scripts/utils/helpers.py
@@ -56,7 +56,12 @@ def create_logger(
             log_group_name=log_group_name,
             stream_name=stream_name,
         )
-        cw_handler.setFormatter(formatter)
+
+        # Don't push timestamps to CloudWatch, since CloudWatch adds its own
+        # timestamps
+        cw_handler.setFormatter(
+            logging.Formatter(fmt="%(levelname)s - %(message)s")
+        )
         logger.addHandler(cw_handler)
 
     # Add a file handler to write logs to a local file if specified


### PR DESCRIPTION
This PR adds a few suggestions on top of https://github.com/ccao-data/data-architecture/pull/860 to improve remote logging for the IC reference file export script. Python logging is annoying and confusing but I think with these changes we'll be in good shape.

See the log stream for today for the three example scenarios I tested (script completes successfully, script encounters an error with a message, script encounters an error without a message).