### PR TITLE
Remove `val48` tests from negative `asmt` value QC workbooks

### DIFF
--- a/dbt/models/qc/qc.vw_neg_asmt_value.sql
+++ b/dbt/models/qc/qc.vw_neg_asmt_value.sql
@@ -54,7 +54,6 @@ SELECT
     asmt.val45,
     asmt.val46,
     asmt.val47,
-    asmt.val48,
     asmt.val49,
     asmt.val50,
     asmt.val51,

--- a/dbt/models/qc/qc.vw_report_town_close_neg_asmt_value.sql
+++ b/dbt/models/qc/qc.vw_report_town_close_neg_asmt_value.sql
@@ -3,8 +3,8 @@
     'val11', 'val12', 'val13', 'val16', 'val17', 'val18', 'val19', 'val20', 'val21', 'val22', 'val23',
     'val24', 'val25', 'val26', 'val27', 'val28', 'val29', 'val30', 'val31', 'val32', 'val33', 'val34',
     'val35', 'val36', 'val37', 'val38', 'val39', 'val40', 'val41', 'val42', 'val43', 'val44', 'val45',
-    'val46', 'val47', 'val48', 'val49', 'val50', 'val51', 'val52', 'val53', 'val54', 'val55', 'val56',
-    'val57', 'val58', 'val59', 'val60', 'valapr1', 'valapr2', 'valapr3', 'valasm1', 'valasm2', 'valasm3'
+    'val46', 'val47', 'val49', 'val50', 'val51', 'val52', 'val53', 'val54', 'val55', 'val56', 'val57',
+    'val58', 'val59', 'val60', 'valapr1', 'valapr2', 'valapr3', 'valasm1', 'valasm2', 'valasm3'
 ] %}
 
 SELECT

--- a/dbt/models/qc/schema.yml
+++ b/dbt/models/qc/schema.yml
@@ -857,14 +857,6 @@ models:
                 table_name: asmt
                 description: val47 (45. .:) should not be negative
               <<: *test-non-negative
-      - name: val48
-        data_tests:
-          - accepted_range:
-              name: qc_vw_neg_asmt_value_val48_gte_0
-              meta:
-                table_name: asmt
-                description: val48 (46. .:) should not be negative
-              <<: *test-non-negative
       - name: val49
         data_tests:
           - accepted_range:


### PR DESCRIPTION
This PR edits a few QC views and removes a test to reflect the fact that Res Val doesn't want to test the `asmt.val48` field anymore because it is not used by the CCAO.

Closes https://github.com/ccao-data/data-architecture/issues/878.