### PR TITLE
Increase threshold for `model_assessment_card_meta_card_num_not_null` test

### DIFF
--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -13,7 +13,7 @@ sources:
                   name: model_assessment_card_meta_card_num_not_null
                   config:
                     where: meta_class != '299'
-                    error_if:  ">560"
+                    error_if:  ">571"
         data_tests:
           - unique_combination_of_columns:
               name: model_assessment_card_unique_pin_card_year_run


### PR DESCRIPTION
We recently ran a model using 2025 assessment data to test the effect of different grouping criteria for townhomes. The 2025 assesment set contains a known issue where 11 PINs have regression-eligible classes but have no dwellings, which leads to rows in `model.assessment_card` with no card number; as a result, this new model run is causing a failure in [the test that checks for null cards](https://github.com/ccao-data/data-architecture/actions/runs/17207119142/job/48810067167). Since this is a known issue with the 2025 assessment data that we are not planning to fix, this PR simply bumps the threshold for that test to account for this new model run.