### PR TITLE
Bump threshold for not-null test on `model.assessment_card.meta_card_num`

### DIFF
--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -13,7 +13,7 @@ sources:
                   name: model_assessment_card_meta_card_num_not_null
                   config:
                     where: meta_class != '299'
-                    error_if:  ">571"
+                    error_if:  ">585"
         data_tests:
           - unique_combination_of_columns:
               name: model_assessment_card_unique_pin_card_year_run


### PR DESCRIPTION
Similar to https://github.com/ccao-data/data-architecture/pull/885, the `model_assessment_card_meta_card_num_not_null` test [is failing again](https://github.com/ccao-data/data-architecture/actions/runs/17375666797/job/49321314303#step:7:674) because we ran two new model runs on prior years whose assessment sets contained parcels with missing cards. This PR bumps that threshold... again.

This test relies on the assumption that we won't run models on old assessment years; that assumption has generally been true since the introduction of this test, but in recent weeks we've initiated a spike in model development that has broken the assumption. I'm wondering if there's a better way to approach this test, though I don't have any ideas that I would consider to be a slam dunk.

My best idea is to wait until the 2026 modeling season begins, and then configure the test to only test model runs whose assessment year is greater than or equal to 2026, at which point we will be able to work with other departments to resolve any missing cards that remain. That should work well, but it means we'll have another couple of months where we will have to keep bumping this test threshold whenever we do modeling work. That will be annoying but I think it's probably for the best, since the test is helpful in preventing us from introducing serious bugs into the model, even though it's too sensitive right now.