### PR TITLE
Anticipate different year values between Athena and Socrata assets

### DIFF
--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -21,7 +21,7 @@ pd.set_option("display.max_rows", None)
 
 # Create a session object so HTTP requests can be pooled
 session = requests.Session()
-session.headers.update({"X-App-Token": os.getenv("SOCRATA_APP_TOKEN")})
+session.headers.update({"X-App-Token": str(os.getenv("SOCRATA_APP_TOKEN"))})
 session.auth = (
     str(os.getenv("SOCRATA_USERNAME")),
     str(os.getenv("SOCRATA_PASSWORD")),


### PR DESCRIPTION
Addressing an issue where we get new years for data in Athena which don't already exist in Socrata, or years are deleted from Athena and the corresponding rows need to be removed from Socrata. Before, this would error out trying to find a `row_id` column in an empty dataframe if the year value wasn't present on Socrata, or would leave rows undeleted on Socrata if they had a year value that had been removed from Athena.

This hasn't caused us an issue yet since we've almost exclusively been using the script to update the present year (2025) of data for each asset, and when I tested the script updating all years in the past enough time hadn't passed between runs for there to be differences in year values.

[This run of the workflow](https://github.com/ccao-data/data-architecture/actions/runs/17444977323/job/49537092859) successfully handled `year = 205` which was causing the error [here](https://github.com/ccao-data/data-architecture/actions/runs/17441950840/job/49526909163) (205 had been added to athena but wasn't present in socrata), but ended up failing when athena got nuked.

[Here's a run](https://github.com/ccao-data/data-architecture/actions/runs/17476185532/job/49636504132) I initialized after solving the data is on athena but not on socrata issue. There was still a one row difference between the athena and socrata assets due to a year value that no longer existed in athena. The run found the row on socrata and removed it.