### PR TITLE
Limit concurrent dbt builds to one per branch on CI

### DIFF
--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -17,6 +17,15 @@ on:
 jobs:
   build-and-test-dbt:
     runs-on: ubuntu-latest
+    # Restrict concurrent jobs, since builds can cause race conditions
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      # Cancel in-progress jobs on PRs because we are more likely to push
+      # to PRs very frequently and hence waste resources on oudated builds.
+      # While this might increase the risk of half-completed builds that
+      # end up in weird states, that's OK because PRs run in disposable
+      # environments
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint
     # so that we can authenticate with AWS
     permissions:

--- a/.github/workflows/build_and_test_dbt.yaml
+++ b/.github/workflows/build_and_test_dbt.yaml
@@ -21,10 +21,10 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       # Cancel in-progress jobs on PRs because we are more likely to push
-      # to PRs very frequently and hence waste resources on oudated builds.
-      # While this might increase the risk of half-completed builds that
-      # end up in weird states, that's OK because PRs run in disposable
-      # environments
+      # to PRs very frequently and hence waste Athena resources on outdated
+      # builds. While this might increase the risk of half-completed builds
+      # that end up in weird states, that's OK because PRs run in dedicated
+      # temporary environments
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint
     # so that we can authenticate with AWS


### PR DESCRIPTION
Today we encountered an issue where a PR altered a table that was associated with a lot of intensive tests, so when a team member pushed a number of commits to that PR in rapid succession, the cumulative `build-and-test-dbt` workflows for each of those commits queued a huge number of queries in total and caused Athena to crash. This PR implements a quick way of reducing the impact of that situation by limiting the number of concurrent builds that we allow for the `build-and-test-dbt` workflow to one per branch, and configuring PRs so that they cancel outdated builds when new ones come in. (For pushes to the main branch, we queue new builds instead of canceling old ones.)

This is not the most sophisticated or effective way of resolving the query load problem because the `dbt-athena` plugin [does not cancel queries when the `dbt` invocation is canceled](https://github.com/dbt-labs/dbt-adapters/issues/406). That means that if an outdated build started some queries before getting canceled by a subsequent build in the concurrency group, the build cancellation by itself won't cancel the running queries. However, I think this PR might still reduce the impact of rapid sequences of commits since it could cancel builds before they get to the dbt build/test step, or it could prevent a dbt build/test step from issuing more than a certain number of queries.

I also think this is a good change to make regardless of the particular issue that inspired it, since the build step is prone to race conditions regardless of its effect on Athena load. (By "race condition", I mean a situation in which two simultaneous jobs attempt to build the same dbt models at the same time.) Limiting concurrency to one job per environment means that we'll protect ourselves from race conditions in addition to any protection that we gain from Athena load problems.

Docs on workflow concurrency: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

Evidence of a workflow run that was canceled due to a new build in the concurrency group.: https://github.com/ccao-data/data-architecture/actions/runs/17446742049 