### PR TITLE
Update `pinval.model_run` with new 2024 `comps` run

### DIFF
--- a/dbt/seeds/pinval/pinval.model_run.csv
+++ b/dbt/seeds/pinval/pinval.model_run.csv
@@ -3,7 +3,7 @@ assessment_year,type,run_id
 2024,shap,2024-02-06-relaxed-tristan
 2024,card,2024-03-17-stupefied-maya
 2024,shap,2024-03-17-stupefied-maya
-2024,comp,2024-06-18-calm-nathan
+2024,comp,2025-09-07-adoring-jean
 2025,card,2025-02-11-charming-eric
 2025,shap,2025-04-25-fancy-free-billy
 2025,comp,2025-06-14-flamboyant-rob


### PR DESCRIPTION
This PR updates `pinval.model_run` to add a new `comps` run for 2024 based on our QC.