### PR TITLE
Fix edge case for null classes in class mismatch QC town close view

### DIFF
--- a/dbt/models/qc/qc.vw_report_town_close_bldg_parcel_class_mismatch.sql
+++ b/dbt/models/qc/qc.vw_report_town_close_bldg_parcel_class_mismatch.sql
@@ -20,17 +20,16 @@ LEFT JOIN {{ source('iasworld', 'legdat') }} AS legdat
         SELECT
             {{ tablename }}.parid,
             {{ tablename }}.taxyr,
-            -- If the comparison table only has one row for this PIN and the
-            -- class for that row is null, a naive `ARRAY_AGG()` will return
-            -- an array with one null element, which causes the `CONTAINS()`
-            -- check below to return null and so exclude the row from the
-            -- result set (even though this should count as a mismatch).
-            -- To handle this edge case, ignore nulls when building the array
-            -- of distinct classes, and format any resulting empty arrays as
-            -- ['NULL'] so that they will always fail the `CONTAINS()` check
-            -- below while also returning output that the `ARRAY_JOIN()` call
-            -- in the `SELECT` clause above can turn into useful, human-readable
-            -- output
+            -- If the comparison table only has rows for this PIN/year with
+            -- null class codes, a naive `ARRAY_AGG()` will return an array
+            -- with one null element, which causes the `CONTAINS()` check below
+            -- to return null and so exclude the row from the result set (even
+            -- though this should count as a mismatch). To handle this edge
+            -- case, ignore nulls when building the array of distinct classes,
+            -- and format any resulting empty arrays as ['NULL'] so that they
+            -- will always fail the `CONTAINS()` check below while also
+            -- returning output that the `ARRAY_JOIN()` call in the `SELECT`
+            -- clause above can turn into useful, human-readable output
             COALESCE(
                 ARRAY_AGG(DISTINCT {{ tablename }}.class) FILTER (
                     WHERE {{ tablename }}.class IS NOT NULL


### PR DESCRIPTION
## Background

Valuations notified me of a handful of PINs that seemed to have fallen through the cracks of our "Building-parcel class mismatch" QC town close report. I investigated and discovered that the PINs all have only one commercial card and that card has a null class, which causes this conditional expression to return null and so remove the row from the result set:

https://github.com/ccao-data/data-architecture/blob/16cb39e5be97d3af3f10ff341b44b36f259808db/dbt/models/qc/qc.vw_report_town_close_bldg_parcel_class_mismatch.sql#L45-L50

This PR adds some specific handling for this edge case.

## Testing

This query confirms that the new version of the view contains 51 new rows, all of which have a COMDAT entry with a null class code, and otherwise has no differences from the prod view:

```sql
select
    dev.parid as dev_parid,
    prod.parid as prod_parid,
    dev.taxyr as dev_taxyr,
    prod.taxyr as prod_taxyr,
    dev.township_code as dev_township_code,
    prod.township_code as prod_township_code,
    dev.parcel_class as dev_parcel_class,
    prod.parcel_class as prod_parcel_class,
    dev.comdat_classes as dev_comdat_classes,
    prod.comdat_classes as prod_comdat_classes,
    dev.dweldat_classes as dev_dweldat_classes,
    prod.dweldat_classes as prod_dweldat_classes,
    dev.oby_classes as dev_oby_classes,
    prod.oby_classes as prod_oby_classes
from z_ci_jeancochrane_fix_edge_case_for_null_classes_in_town_close_class_mismatch_view_qc.vw_report_town_close_bldg_parcel_class_mismatch as dev
full outer join qc.vw_report_town_close_bldg_parcel_class_mismatch as prod
    on dev.parid = prod.parid
    and dev.taxyr = prod.taxyr
where dev.parid is null
    or prod.parid is null
    or dev.township_code != prod.township_code
    or dev.parcel_class != prod.parcel_class
    or not array_sort(transform(split(dev.comdat_classes, ', '), x -> trim(x)))
         = array_sort(transform(split(prod.comdat_classes, ', '), x -> trim(x)))
    or not array_sort(transform(split(dev.dweldat_classes, ', '), x -> trim(x)))
         = array_sort(transform(split(prod.dweldat_classes, ', '), x -> trim(x)))
    or not array_sort(transform(split(dev.oby_classes, ', '), x -> trim(x)))
         = array_sort(transform(split(prod.oby_classes, ', '), x -> trim(x)))
```

I also confirmed that all of the missing PINs that Valuations sent to me are present in the result set for this query.