### PR TITLE
Fix enterprise zone ingest

### DIFF
--- a/etl/scripts-ccao-data-raw-us-east-1/spatial/spatial-economy.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/spatial/spatial-economy.R
@@ -8,6 +8,29 @@ AWS_S3_RAW_BUCKET <- Sys.getenv("AWS_S3_RAW_BUCKET")
 output_bucket <- file.path(AWS_S3_RAW_BUCKET, "spatial", "economy")
 current_year <- strftime(Sys.Date(), "%Y")
 
+##### ENTERPRISE ZONE #####
+remote_file_enterprise_zone <- file.path(
+  output_bucket, "enterprise_zone",
+  paste0("2021", ".geojson")
+)
+
+# Write file to S3 if it doesn't already exist
+if (!aws.s3::object_exists(remote_file_enterprise_zone)) {
+  tmp_file_enterprise_zone <- tempfile(fileext = ".geojson")
+  download.file(
+    paste0(
+      "https://data.cityofchicago.org/api/geospatial",
+      "/bwpt-y235?method=export&format=GeoJSON"
+    ),
+    tmp_file_enterprise_zone
+  )
+  save_local_to_s3(
+    remote_file_enterprise_zone,
+    tmp_file_enterprise_zone
+  )
+  file.remove(tmp_file_enterprise_zone)
+}
+
 ##### INDUSTRIAL GROWTH ZONE #####
 remote_file_industrial_growth_zone <- file.path(
   output_bucket, "industrial_growth_zone",

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-economy.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-economy.R
@@ -59,12 +59,7 @@ clean_enterprise_zone <- function(shapefile, economic_unit) {
   if (economic_unit == "enterprise_zone") {
     return(
       shapefile %>%
-        filter(str_detect(County, "Will", negate = TRUE)) %>%
-        group_by(Name) %>%
-        summarise() %>%
-        mutate(ez_num = as.character(NA)) %>%
-        select(ez_num, ez_name = Name, geometry) %>%
-        ungroup()
+        select(ez_num = name, ez_name = name, geometry)
     )
   } else {
     return(shapefile)


### PR DESCRIPTION
Our current enterprise zone data is not what the [city of chicago makes available](https://data.cityofchicago.org/Community-Economic-Development/Boundaries-Enterprise-Zones/64xf-pyvh). Our ingest of the data we have is undocumented and our data seems to be industrial growth zones (which we already have separately) rather than enterprise zones. This PR fixes this by pointing our `spatial-economy` ingest script to the city of chicago's data and then updating the relevant warehouse script to correctly process the new shapefile.

Once these updates and the new data has been reviewed I will trigger glue crawlers and rebuilds in dbt.

Cleaned version of new data can be inspected from `etl` using `geoarrow::read_geoparquet_sf("s3://ccao-data-warehouse-us-east-1/spatial/economy/enterprise_zone/year=2021/part-0.parquet")`