### PR TITLE
Update pre-commit version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
   - repo: https://github.com/sqlfluff/sqlfluff
     rev: 3.1.0
     hooks:
-    -   id: sqlfluff-lint
-    -   id: sqlfluff-fix
+      - id: sqlfluff-lint
+      - id: sqlfluff-fix
   - repo: https://github.com/tconbeer/sqlfmt
     rev: v0.19.2
     hooks:


### PR DESCRIPTION
After installing new versions of R and RStudio on the server the old version of pre-commit will fail to build [digest](https://github.com/eddelbuettel/digest) and needs to be updated.