### PR TITLE
Add appeals warning to data catalog

### DIFF
--- a/dbt/models/default/docs.md
+++ b/dbt/models/default/docs.md
@@ -33,6 +33,9 @@ and mailing (owner/taxpayer address).
 # vw_pin_appeal
 
 {% docs view_vw_pin_appeal %}
+***Appeals are currently unavailable pre-2021. We expect to have them back by
+the end of 2025.***
+
 View of assessment appeals by stage (wide format). Shows appeal decision,
 reason, and results.
 

--- a/dbt/models/iasworld/docs.md
+++ b/dbt/models/iasworld/docs.md
@@ -184,6 +184,9 @@ Hearing date and note maintenance.
 # htpar
 
 {% docs table_htpar %}
+***Appeals are currently unavailable pre-2021. We expect to have them back by
+the end of 2025.***
+
 Main appeal tracking table. Used in the construction of Data Department
 appeal views.
 


### PR DESCRIPTION
See https://github.com/ccao-data/data-architecture/issues/925

Not adding this to the open data view for appeals since we don't interact with that view for anything but feeding open data, where there's already a warning.