### PR TITLE
Increase `default_vw_pin_appeal_row_count` threshold

### DIFF
--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -68,7 +68,7 @@ models:
       - row_count:
           name: default_vw_pin_appeal_row_count
           # The exact row count is too complex to compute, so approximate it
-          above: 2800000
+          above: 2400000
       - unique_combination_of_columns:
           name: default_vw_pin_appeal_unique_by_14_digit_pin_year_caseno
           combination_of_columns:


### PR DESCRIPTION
We didn't update this [row count test threshold](https://github.com/ccao-data/data-architecture/actions/runs/19427347068/job/55577852576) after the second loss of appeals, so it needs to be lowered again.