### PR TITLE
Remove upper year limit for market tracker view

### DIFF
--- a/dbt/models/reporting/reporting.vw_market_tracker.sql
+++ b/dbt/models/reporting/reporting.vw_market_tracker.sql
@@ -98,7 +98,6 @@ FROM {{ ref('default.vw_pin_sale') }} AS vps
 LEFT JOIN
     {{ ref('default.vw_pin_universe') }} AS vpu
     ON vps.pin = vpu.pin AND vps.year = vpu.year
-    AND vpu.lat IS NOT NULL AND vpu.lon IS NOT NULL
 LEFT JOIN
     {{ ref('ccao.class_dict') }} AS cls
     ON vps.class = cls.class_code
@@ -123,3 +122,4 @@ LEFT JOIN {{ ref('sale.deed_type') }} AS deeds
     ON vps.deed_type = deeds.deed_num
 WHERE vps.year >= '2020'
     AND cls.modeling_group IN ('SF', 'CONDO', 'MF')
+    AND vpu.lat IS NOT NULL AND vpu.lon IS NOT NULL


### PR DESCRIPTION
Just removing the upper year limit on which sales can make it into the view.

```
with new as (
	select year,
		count() as new
	from z_ci_932_adjust_year_filter_in_vw_market_tracker_to_include_most_recent_sales_reporting.vw_market_tracker
	group by year
),
old as (
	select year,
		count() as old
	from reporting.vw_market_tracker
	group by year
)
select new.year,
	old,
	new
from new
	left join old on new.year = old.year
```

| year | old    | new    |
|------|--------|--------|
| 2025 |        | 43110  |
| 2024 | 67202  | 67202  |
| 2023 | 69520  | 69520  |
| 2022 | 88220  | 88220  |
| 2021 | 94580  | 94580  |
| 2020 | 101699 | 101699 |