### PR TITLE
Add `FINALEAV` to `procname` dbt column docs

### DIFF
--- a/dbt/models/iasworld/columns.md
+++ b/dbt/models/iasworld/columns.md
@@ -741,6 +741,10 @@ fields. Possible values include:
 - `CCAOVALUE` = CCAO mailed values (pre-appeal)
 - `CCAOFINAL` = CCAO certified values (after Assessor appeals)
 - `BORVALUE` = BoR certified values (after Board of Review appeals)
+- `FINALEAV` = Final equalized assessed values. This `procname` is new to us,
+  so we don't know much about it yet, but we know it should be present for all
+  PINs in an assessment year once second installment bills have mailed for that
+  year.
 {% enddocs %}
 
 ## prodamage

--- a/dbt/models/iasworld/schema/iasworld.asmt_all.yml
+++ b/dbt/models/iasworld/schema/iasworld.asmt_all.yml
@@ -205,7 +205,7 @@ sources:
                   meta:
                     description: TOT32 (Value After HIE) should be TOT29 - TOT30 - TOT31
           - name: tot51
-            description: Equalized AV
+            description: Equalized assessed value. Only guaranteed to be correct when `procname = 'FINALEAV'`.
           - name: tottax
             description: Total tax
           - name: trans_id


### PR DESCRIPTION
Yesterday we learned that `ASMT.TOT51` will represent the final EAV for a PIN if and only if the procname for the row is `"FINALEAV"`. We had never heard of this procname before, so I took a moment to add what we've learned about it to our dbt docs.

At some point, we may want to incorporate this procname into `default.vw_pin_value` or another view that might benefit from having a canonical EAV column. However, at this point I think we still don't know enough about the procname or what we would use it for, so this PR considers actual code changes to be out of scope.

One subtlety -- the procname docs are shared between a number of tables that have a `procname` column, including `cvleg`, `exapp`, `exdet`, `aprval`, `legdat`, and `pardat`. Based on a quick scan of the iasWorld UI, it doesn't seem like this field is displayed for `pardat`, `legdat`, or `aprval` (the three tables whose UI I can see), so I'm guessing it's vestigial and doesn't matter outside of `asmt`. Still, I want to call it out in case someone else has more context and can weigh in on whether this change should or should not apply to the tables that have a `procname` beyond `asmt`. 