### PR TITLE
Add hearing type coding to open data appeals view

### DIFF
--- a/dbt/models/open_data/open_data.vw_appeal.sql
+++ b/dbt/models/open_data/open_data.vw_appeal.sql
@@ -20,7 +20,9 @@ SELECT
         WHEN hearing_type = 'A' THEN 'Current year appeal'
         WHEN hearing_type = 'C' THEN 'Current appeal & certificate of error'
         WHEN hearing_type = 'E' THEN 'Certificate of error only'
-        WHEN hearing_type = 'F' THEN 'Smartfile exemption coe filing'
+        WHEN
+            hearing_type = 'F'
+            THEN 'Smartfile exemption certificate of error filing'
         WHEN hearing_type = 'O' THEN 'Omitted assessment'
         WHEN hearing_type = 'R' THEN 'Re-review'
         WHEN hearing_type = 'S' THEN 'Specific objection'

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -208,7 +208,7 @@ Possible values for this variable are:
 - `A` = Current year appeal
 - `C` = Current appeal & certificate of error
 - `E` = Certificate of error only
-- `F` = Smartfile exemption coe filing
+- `F` = Smartfile exemption certificate of error filing
 - `O` = Omitted assessment
 - `R` = Re-review
 - `S` = Specific objection


### PR DESCRIPTION
Forgot to include the variable codes for `hearing_type` in the open data view in https://github.com/ccao-data/data-architecture/pull/945.

```
select distinct hearing_type
from z_ci_add_hearing_type_coding_to_open_data_view_open_data.vw_appeal
```

| HearingType                           |
|---------------------------------------|
| Current appeal & certificate of error | 
| Current year appeal                   | 
