### PR TITLE
Update Commercial Open Data asset with 2025 public model

### DIFF
--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-commercial_valuation.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-commercial_valuation.R
@@ -227,5 +227,5 @@ output <- list.files(
   distinct()
 
 output %>%
-  group_by(year) %>% skim()
+  group_by(year) %>%
   write_partitions_to_s3(output_bucket, is_spatial = FALSE, overwrite = TRUE)


### PR DESCRIPTION
If I exclude the columns `loaded_at` from the old data (which only gets added during upload), `gross_building_area` from the new data (which is a new column), and `taxpayer` from both, the 2021-2024 data match exactly using `dplyr::all_equal()`. Taxpayer is the only column that no longer matches, because I added it to the declared `char_cols` so it doesn't get reduced only to the numbers it contains through `parse_number()`. This is an improvement, though it's a shame I hadn't been handling it correctly in the past.

I have not uploaded the new data yet to S3. My primary concern was overwriting the old data and changing it, but I'm confident now that the old data has been accurately reproduced.