### PR TITLE
Fix first day of new year issue

### DIFF
--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -174,7 +174,7 @@ def parse_years_list(athena_asset, years=None):
     elif not years and os.getenv("WORKFLOW_EVENT_NAME") == "schedule":
         # Update most recent year only on scheduled workflow. In some
         # cases the max year is incorrectly in the future, so we
-        # append the current year to the list and take the minimum.
+        # take whatever the max year in the asset is up till the current year.
         years_list = (
             cursor.execute(
                 "SELECT MAX(year) AS year FROM "


### PR DESCRIPTION
The open data upload script [failed](https://github.com/ccao-data/data-architecture/actions/runs/20637432586/job/59264337703) (😒) while trying to upload our permits asset. It failed because we make the script choose the minimum value between the current year and the maximum year in the asset - when the clock rolled over to 2026, the script had to compare the maximum value in the permits asset, `2032`, and the current year, `2026`. Because there are no values in the permit asset for 2026, the script returned an empty dataframe, which it doesn't expect.

This fix ensures the script can't query an asset for a year that isn't in that asset and chooses the maximum year from an asset less than or equal to the current year.