### PR TITLE
Fix ARI model join

### DIFF
--- a/dbt/models/model/model.vw_pin_shared_input.sql
+++ b/dbt/models/model/model.vw_pin_shared_input.sql
@@ -110,7 +110,7 @@ distressed_communities_index AS (
         AND dci.year <= zcta.year
 ),
 
--- This CTA creates a crosswalk of which ARI years should be joined to which
+-- This CTE creates a crosswalk of which ARI years should be joined to which
 -- census years
 ari_join_years AS (
     SELECT


### PR DESCRIPTION
We added an additional year of ARI data, but the join in `model.vw_pin_shared_input` assumes there is only one year. This PR addresses that problem by creating a join crosswalk using a CTE.

```
select meta_pin,
	meta_year,
	count(*)
from z_ci_fix_ari_model_join_model.vw_pin_shared_input
group by meta_pin,
	meta_year
having count(*) > 1
```

returns no rows

[input views are now unique](https://github.com/ccao-data/data-architecture/actions/runs/21307970440/job/61339350918)

tangentially, lat is no longer missing from all the input views:

```
select year,
	count(*) as missing_lat
from z_ci_fix_ari_model_join_model.vw_card_res_input
where loc_latitude is null
group by year
```

| year | missing_lat    |
|------|---------|
| 2025 |       3 |
| 2024 |       2 |
| 2023 |       2 |
| 2021 |       1 |
| 2018 |      62 |
| 2017 |      54 |
| 2016 |     127 |
| 2015 |      10 |
| 2014 |       8 |
| 2013 |       6 |
| 2012 |       1 |
| 2011 |       2 |
| 2010 |     615 |
| 2009 |       6 |
| 2008 |       1 |
| 2007 |       1 |
| 2005 |     129 |
| 2004 |     181 |
| 2003 |     166 |
| 2002 |     168 |
| 2001 |     163 |
| 2000 |     874 |
| 1999 | 1057865 |
