### PR TITLE
Add data tests to ensure neighborhood + tax code prefixes match township code

### DIFF
--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -501,14 +501,12 @@ models:
               name: model_vw_pin_shared_input_meta_township_code_matches_meta_nbhd_code
               expression: = SUBSTR(meta_nbhd_code, 1, 2)
               config:
-                # Exclude dummy neighborhood codes and non-res classes
-                where: meta_nbhd_code != '99999' and SUBSTR(meta_class, 1, 1) = '2'
-                # A couple thousand of these already exist. We've sent the most
-                # problematic ones over to our data owners for fixing, but in
-                # the meantime, we just want to make sure we don't see new ones.
-                # We should periodically check this count to see if we can
-                # reduce it as our data owners fix the underlying issues
-                error_if: ">2388"
+                # Exclude dummy neighborhood codes, non-res classes, and old
+                # records that we can't update
+                where: >
+                  meta_nbhd_code != '99999'
+                  AND SUBSTR(meta_class, 1, 1) = '2'
+                  AND meta_year >= '2026'
           - expression_is_true:
               name: model_vw_pin_shared_input_meta_township_code_matches_meta_tax_code
               expression: = SUBSTR(meta_tax_code, 1, 2)


### PR DESCRIPTION
In theory, parcel neighborhoods and tax codes should always start with two digits corresponding to the parcel's two-digit township code. In practice, we've noticed a couple thousand PINs where the neighborhood code doesn't match the township code.

This PR adds two quick data tests to catch errors like this in the future. Our motivation is twofold:

1. Neighborhood code is an important feature for residential modeling, so we want to make sure it is as correct as possible for residential PINs; if the neighborhood code doesn't match the township code, it's a strong signal that one of those two pieces of information is incorrect
2. Our analysis and reporting code often uses a PIN's tax code to derive its township code, so we want to make sure we are always reporting PINs as being in the correct township