### PR TITLE
Add year filter to resolve `model_assessment_card_meta_card_num_not_null` test failures

### DIFF
--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -12,8 +12,9 @@ sources:
               - not_null:
                   name: model_assessment_card_meta_card_num_not_null
                   config:
-                    where: meta_class != '299'
-                    error_if:  ">667"
+                    where: >
+                      meta_class != '299'
+                      AND year >= '2026'
         data_tests:
           - unique_combination_of_columns:
               name: model_assessment_card_unique_pin_card_year_run


### PR DESCRIPTION
This test [perpetually fails](https://github.com/ccao-data/data-architecture/actions/runs/21822893887/job/62960464408) and adds noise to our dbt failure alarms. Maybe there's a more permanent solution that's preferred, but while we're modeling it would be nice to know an alarm means something new and unexpected has happened.