### PR TITLE
Bump test threshold for `default.vw_pin_appeal` uniqueness test

### DIFF
--- a/dbt/models/default/schema/default.vw_pin_appeal.yml
+++ b/dbt/models/default/schema/default.vw_pin_appeal.yml
@@ -81,11 +81,14 @@ models:
             - pin
             - year
           config:
-            # As of 2/23/2026 we're seeing 8 rows that aren't unique by these
-            # keys. If we add subkey we don't encounter any duplicates, but I
-            # don't currently feel confident enough about how that column works
-            # to include it as a key.
-            error_if: ">10"
+            # As of 3/3/2026 we're seeing 13 rows that aren't unique by these
+            # keys. The issue seems to be that folks are neglecting to
+            # deactivate old appeals, resulting in multiple active rows that
+            # contain the same data but with different subkeys. Our
+            # stakeholders are working on cleaning up the duplicate rows, but
+            # in the meantime we don't want this test to fail on data that we
+            # are already tracking
+            error_if: ">13"
 
 unit_tests:
   - name: default_vw_pin_appeal_class_strips_non_alphanumerics


### PR DESCRIPTION
`default_vw_pin_appeal_unique_by_14_digit_pin_year_caseno_hearing_type` [is failing](https://github.com/ccao-data/data-architecture/actions/runs/22303734980/job/64517645700#step:7:734) due to ~two~ five new appeals that appear to have dupes. We notified stakeholders about the issue and they are working on fixing it, but in the meantime, this PR bumps the test threshold to prevent it from failing our data integrity tests.