### PR TITLE
Finish 2026 south tri ingest

### DIFF
--- a/etl/scripts-ccao-data-warehouse-us-east-1/sale/sale-flag_review.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/sale/sale-flag_review.R
@@ -53,17 +53,17 @@ dfs$valuations_sale_review_02_04_2026_diane <-
   filter(`Sale Doc No` != "2516802041")
 
 # Another duplicate, we keep the observation that had consistency with the
-# person who sent the workbook, and the `WHOM` column. And we exclude this one
+# person who sent the workbook and the `WHOM` column. And we exclude this one
 # since the whom column in this row was from 'DIANE`, but the workbook was
 # sent showing review from lydia and monica.
 dfs$valuations_sale_review_02_04_2026_lydia_monica <-
   dfs$valuations_sale_review_02_04_2026_lydia_monica %>%
   filter(`Sale Doc No` != "2516702083")
 
-# This excel workbook came the email displaying only data that had the
-# WHOM column marked with 'MONICA'. However, some of the minimized rows
+# This excel workbook sourced from email arrived displaying only data that
+# had the WHOM column marked with 'MONICA'. However, some of the minimized rows
 # had other reviewed data (some by lydia), and those were not being filtered
-# out since our filter is based on NA values in our key fields. This causes
+# out since our filter is based on NA values in our key fields. This caused
 # a lot of duplication and disagreement. Since it doesn't seem like those rows
 # were intended to be used (they were minimized), we filter them out here
 dfs$valuations_sale_review_02_04_2026_monica <-


### PR DESCRIPTION
Finish up ingesting the final round of south tri 2026 sales from valuations' 2026 capacity.

Total number of reviewed sales increased from 4103 to 4737.

The main complication with this ingest was that some data had hidden rows with different reviewers in the `WHOM` field that this script was picking up due the way we detect which rows to keep (NA checking), which took me a while to figure out. I basically ignore these fields, on the assumption that since they were hidden they weren't meant to be the ones we were looking at.

Also fixed some other duplication that arose upon replacing the updated files.