### PR TITLE
Update 2026 comps run to use unweighted algorithm

### DIFF
--- a/dbt/seeds/pinval/pinval.model_run.csv
+++ b/dbt/seeds/pinval/pinval.model_run.csv
@@ -9,4 +9,4 @@ assessment_year,type,run_id
 2025,comp,2025-06-14-flamboyant-rob
 2026,card,2026-02-11-recursing-rob
 2026,shap,2026-02-11-recursing-rob
-2026,comp,2026-02-13-peaceful-rina
+2026,comp,2026-02-25-confident-damani


### PR DESCRIPTION
Now that the significant sales algorithm is configurable in the res model (https://github.com/ccao-data/model-res-avm/pull/449), we were able to run a model with the unweighted version of the algorithm. We'd like to use this version of the algorithm for internal review purposes in 2026, so this PR updates the `pinval.model_run` seed in order to enable HomeVal deployments using the unweighted comps model run.

Info about this model run:

```sql
select run_id, run_note, comp_enable, comp_algorithm
from model.metadata
where run_id = '2026-02-25-confident-damani'
```

| run_id | run_note | comp_enable | comp_algorithm |
| --- | --- | --- | --- |
| `2026-02-25-confident-damani` | Generate unweighted comps for 2026 assessment year | true | unweighted |
