### PR TITLE
Add previous year to years updated monthly for assessed value open data asset

### DIFF
--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -84,5 +84,7 @@ jobs:
           OVERWRITE: ${{ inputs.overwrite }}
           YEARS: ${{ inputs.years }}
           WORKFLOW_EVENT_NAME: ${{ github.event_name }}
-          UPLOAD_SCHEDULE: ${{ github.event.schedule == '0 11 1 * *' && 'monthly' || github.event.schedule == '0 11 15 * *' && 'semimonthly' || '' }}
+          UPLOAD_SCHEDULE: >
+            ${{ github.event.schedule == '0 11 1 * *' && 'monthly' ||
+            github.event.schedule == '0 11 15 * *' && 'semimonthly' || '' }}
         run: python ./socrata/socrata_upload.py

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -26,6 +26,8 @@ on:
   schedule:
   # First of every month at 11am UTC (6am UTC-5)
     - cron: '0 11 1 * *'
+  # Fifteenth of every month at 11am UTC (6am UTC-5)
+    - cron: '0 11 15 * *'
 
 
 env:
@@ -82,4 +84,8 @@ jobs:
           OVERWRITE: ${{ inputs.overwrite }}
           YEARS: ${{ inputs.years }}
           WORKFLOW_EVENT_NAME: ${{ github.event_name }}
+          if: github.event.schedule == '0 11 1 * *'
+          UPLOAD_SCHEDULE: 'monthly'
+          if: github.event.schedule == '0 11 15 * *'
+          UPLOAD_SCHEDULE: 'semimonthly'
         run: python ./socrata/socrata_upload.py

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -24,9 +24,13 @@ on:
         description: Overwrite socrata asset
         required: false
   schedule:
-  # First of every month at 11am UTC (6am UTC-5)
+  # We use these schedules to determine the value of the `UPLOAD_SCHEDULE`
+  # env var below, so make sure to change that env var definition if you
+  # change any of these schedules.
+  # 
+  # Run a monthly job on the first of every month at 11am UTC (6am UTC-5).
     - cron: '0 11 1 * *'
-  # Fifteenth of every month at 11am UTC (6am UTC-5)
+  # Run a semi-monthly job on the fifteenth of every month at 11am UTC (6am UTC-5).
     - cron: '0 11 15 * *'
 
 
@@ -84,6 +88,10 @@ jobs:
           OVERWRITE: ${{ inputs.overwrite }}
           YEARS: ${{ inputs.years }}
           WORKFLOW_EVENT_NAME: ${{ github.event_name }}
+          # Determine if we're running on the monthly or semi-monthly schedule.
+          # These cron expressions are shared by the `on.schedule` workflow
+          # attribute defined above, so make sure to change that attribute
+          # definition alongside any changes you make here
           UPLOAD_SCHEDULE: >
             ${{ github.event.schedule == '0 11 1 * *' && 'monthly' ||
             github.event.schedule == '0 11 15 * *' && 'semimonthly' || '' }}

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -84,8 +84,5 @@ jobs:
           OVERWRITE: ${{ inputs.overwrite }}
           YEARS: ${{ inputs.years }}
           WORKFLOW_EVENT_NAME: ${{ github.event_name }}
-          if: github.event.schedule == '0 11 1 * *'
-          UPLOAD_SCHEDULE: 'monthly'
-          if: github.event.schedule == '0 11 15 * *'
-          UPLOAD_SCHEDULE: 'semimonthly'
+          UPLOAD_SCHEDULE: ${{ github.event.schedule == '0 11 1 * *' && 'monthly' || github.event.schedule == '0 11 15 * *' && 'semimonthly' || '' }}
         run: python ./socrata/socrata_upload.py

--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -2,6 +2,8 @@ exposures:
   - name: appeals
     label: Appeals
     type: dashboard
+    tags:
+      - monthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Appeals/y282-6ig3
     depends_on:
       - ref('open_data.vw_appeal')
@@ -26,6 +28,8 @@ exposures:
   - name: assessed_values
     label: Assessed Values
     type: dashboard
+    tags:
+      - semimonthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Assessed-Values/uzyt-m557
     depends_on:
       - ref('open_data.vw_assessed_value')
@@ -48,6 +52,8 @@ exposures:
   - name: parcel_addresses
     label: Parcel Addresses
     type: dashboard
+    tags:
+      - monthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Parcel-Addresses/3723-97qp
     depends_on:
       - ref('open_data.vw_parcel_address')
@@ -95,6 +101,8 @@ exposures:
   - name: parcel_sales
     label: Parcel Sales
     type: dashboard
+    tags:
+      - monthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Parcel-Sales/wvhk-k5uv
     depends_on:
       - ref('open_data.vw_parcel_sale')
@@ -137,6 +145,8 @@ exposures:
   - name: parcel_universe_current_year
     label: Parcel Universe (Current Year Only)
     type: dashboard
+    tags:
+      - monthly
     url: https://datacatalog.cookcountyil.gov/dataset/Assessor-Parcel-Universe-Current-Year-/pabr-t5kh
     depends_on:
       - ref('open_data.vw_parcel_universe_current')
@@ -158,6 +168,8 @@ exposures:
   - name: parcel_universe_historical
     label: Parcel Universe (Historic)
     type: dashboard
+    tags:
+      - monthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Parcel-Universe/nj4t-kc8j
     depends_on:
       - ref('open_data.vw_parcel_universe_historical')
@@ -179,6 +191,8 @@ exposures:
   - name: permits
     label: Permits
     type: dashboard
+    tags:
+      - monthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Permits/6yjf-dfxs
     depends_on:
       - ref('open_data.vw_permit')
@@ -199,6 +213,8 @@ exposures:
   - name: property_tax_exempt_parcels
     label: Property Tax-Exempt Parcels
     type: dashboard
+    tags:
+      - monthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Property-Tax-Exempt-Parcels/vgzx-68gb
     depends_on:
       - ref('open_data.vw_property_tax_exempt_parcel')
@@ -223,6 +239,7 @@ exposures:
     type: dashboard
     tags:
       - type_condo
+      - monthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Residential-Condominium-Unit-Characteri/3r7i-mrz4
     depends_on:
       - ref('open_data.vw_res_condo_unit_char')
@@ -248,6 +265,7 @@ exposures:
     type: dashboard
     tags:
       - type_res
+      - monthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Single-and-Multi-Family-Improvement-Chara/x54s-btds
     depends_on:
       - ref('open_data.vw_sf_mf_improvement_char')

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -75,9 +75,9 @@ def parse_assets(assets=None):
     # any assets tagged with "tag:monthly" since those are only meant to be
     # updated once per month. If the upload is running on a monthly schedule,
     # we want to include those assets.
-    monthly_tag = ""
-    if os.getenv("UPLOAD_SCHEDULE") == "semi-monthly":
-        monthly_tag = "tag:monthly"
+    monthly_tag = (
+        "tag:monthly" if os.getenv("UPLOAD_SCHEDULE") == "semi-monthly" else ""
+    )
 
     DBT = dbtRunner()
     dbt_list_args = [

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -71,6 +71,10 @@ def parse_assets(assets=None):
 
     os.chdir("./dbt")
 
+    # If the upload is running on a semi-monthly schedule, we want to exclude
+    # any assets tagged with "tag:monthly" since those are only meant to be
+    # updated once per month. If the upload is running on a monthly schedule,
+    # we want to include those assets.
     monthly_tag = ""
     if os.getenv("UPLOAD_SCHEDULE") == "semi-monthly":
         monthly_tag = "tag:monthly"

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -76,7 +76,7 @@ def parse_assets(assets=None):
     # updated once per month. If the upload is running on a monthly schedule,
     # we want to include those assets.
     monthly_tag = (
-        "tag:monthly" if os.getenv("UPLOAD_SCHEDULE") == "semi-monthly" else ""
+        "tag:monthly" if os.getenv("UPLOAD_SCHEDULE") == "semimonthly" else ""
     )
 
     DBT = dbtRunner()

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -71,6 +71,10 @@ def parse_assets(assets=None):
 
     os.chdir("./dbt")
 
+    monthly_tag = ""
+    if os.getenv("UPLOAD_SCHEDULE") == "semi-monthly":
+        monthly_tag = "tag:monthly"
+
     DBT = dbtRunner()
     dbt_list_args = [
         "--quiet",
@@ -80,7 +84,7 @@ def parse_assets(assets=None):
         "--resource-types",
         "exposure",
         "--exclude",
-        "tag:inactive",
+        " ".join(filter(None, ["tag:inactive", monthly_tag])),
         "--output",
         "json",
         "--output-keys",


### PR DESCRIPTION
We'd like to update the "Assessed Values" asset on the 1st and 15th of every month rather than just the 1st. We can keep our old monthly cadence for all the other active assets.