### PR TITLE
Resolve saturating connection pools

### DIFF
--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -8,9 +8,9 @@ import time
 from datetime import datetime
 from urllib.parse import quote
 
-import botocore
 import pandas as pd
 import requests
+from botocore.config import Config
 from dbt.cli.main import dbtRunner
 from pyathena import connect
 from pyathena.pandas.cursor import PandasCursor
@@ -49,9 +49,7 @@ session.mount(
 )
 
 # Configure the botocore client to allow for more pool connections
-client_config = botocore.config.Config(
-    max_pool_connections=50  # Increase from the default of 10
-)
+client_config = Config(max_pool_connections=50)
 
 # Connect to Athena
 cursor = connect(

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -8,6 +8,7 @@ import time
 from datetime import datetime
 from urllib.parse import quote
 
+import botocore
 import pandas as pd
 import requests
 from dbt.cli.main import dbtRunner
@@ -47,11 +48,17 @@ session.mount(
     "https://datacatalog.cookcountyil.gov", HTTPAdapter(max_retries=retries)
 )
 
+# Configure the botocore client to allow for more pool connections
+client_config = botocore.config.Config(
+    max_pool_connections=50  # Increase from the default of 10
+)
+
 # Connect to Athena
 cursor = connect(
     s3_staging_dir="s3://ccao-athena-results-us-east-1/",
     region_name="us-east-1",
     cursor_class=PandasCursor,
+    config=client_config,
 ).cursor(unload=True)
 
 


### PR DESCRIPTION
We were getting aws [connection pool errors](https://github.com/ccao-data/data-architecture/actions/runs/23444548712/job/68204524939) when trying to update the parcel address open data asset through the `upload-open-data-assets` action. Increasing the [max number of connections per pool](https://docs.aws.amazon.com/botocore/latest/reference/config.html#) seems to have resolved the issue.

[Run without connection pool issues.](https://github.com/ccao-data/data-architecture/actions/runs/23455017073/job/68241780931)