### PR TITLE
Use `trim` instead of `ltrim` + `rtrim` for address concatenation 

### DIFF
--- a/dbt/macros/concat_address.sql
+++ b/dbt/macros/concat_address.sql
@@ -4,15 +4,11 @@
 {% macro concat_address(address_columns) %}
     {% set column_name = address_columns | join(", ") %}
     nullif(
-        rtrim(
-            ltrim(
-                regexp_replace(
-                    regexp_replace(
-                        concat_ws(' ', {{ column_name }}), '[[:cntrl:]]', ''
-                    ),
-                    '\s+',
-                    ' '
-                )
+        trim(
+            regexp_replace(
+                regexp_replace(concat_ws(' ', {{ column_name }}), '[[:cntrl:]]', ''),
+                '\s+',
+                ' '
             )
         ),
         ''


### PR DESCRIPTION
Stupid bad code I'd like to fix real fast:

```sql
with new as (
	select pin,
		year,
		mail_address_name,
		mail_address_full
	from z_ci_fast_follow_macro_improvement_default.vw_pin_address
),
old as (
	select pin,
		year,
		mail_address_name,
		mail_address_full
	from default.vw_pin_address
)
select new.pin,
	new.year,
	new.mail_address_name as mail_address_name_new,
	old.mail_address_name as mail_address_name_old,
	new.mail_address_full as mail_address_full_new,
	old.mail_address_full as mail_address_full_old
from new
	left join old on new.pin = old.pin
	and new.year = old.year
where new.mail_address_name != old.mail_address_name
    or (new.mail_address_name is null and old.mail_address_name is not null)
    or (new.mail_address_name is not null and old.mail_address_name is null)
	or new.mail_address_full != old.mail_address_full
    or (new.mail_address_full is null and old.mail_address_full is not null)
    or (new.mail_address_full is not null and old.mail_address_full is null)
```

returns zero rows, which we expect.