### PR TITLE
Revert "Move HIE counts to res model view"

### DIFF
--- a/dbt/models/default/default.vw_card_res_char.sql
+++ b/dbt/models/default/default.vw_card_res_char.sql
@@ -12,58 +12,6 @@ WITH multicodes AS (
     GROUP BY parid, taxyr
 ),
 
--- Gather HIE start and end years from both ADDN and OBY tables. We need to
--- stack them to properly count the number of active and expiring HIEs for each
--- PIN-year combination below. We define unique start and end dates within cards
--- as separate HIEs.
-all_hies AS (
-    SELECT DISTINCT
-        parid AS pin,
-        card,
-        taxyr AS year,
-        CAST(taxyr AS INT) AS year_int,
-        userval1 AS hie_start,
-        userval2 AS hie_end
-    FROM {{ source('iasworld', 'addn') }}
-    WHERE lline > 0
-        AND cur = 'Y'
-        AND deactivat IS NULL
-        AND userval1 IS NOT NULL
-        AND userval2 IS NOT NULL
-    UNION ALL
-    SELECT DISTINCT
-        parid AS pin,
-        card,
-        taxyr AS year,
-        CAST(taxyr AS INT) AS year_int,
-        CAST(user10 AS INT) AS hie_start,
-        CAST(user14 AS INT) AS hie_end
-    FROM {{ source('iasworld', 'oby') }}
-    WHERE cur = 'Y'
-        AND deactivat IS NULL
-        AND user10 IS NOT NULL
-        AND user14 IS NOT NULL
-        AND class = '288'
-),
-
-hies AS (
-    SELECT
-        pin,
-        year,
-        SUM(
-            CAST(
-                -- HIE adjustments to AVs in iasworld.asmt include the start and
-                -- end years, so we use a between statement here.
-                year_int BETWEEN hie_start AND hie_end AS INT
-            )
-        ) AS hie_num_active,
-        SUM(CAST(year_int = hie_end AS INT)) AS hie_num_expiring
-    FROM all_hies
-    GROUP BY
-        pin,
-        year
-),
-
 -- Conditionals in CTE do not ensure distinct outputs
 pools AS (
     SELECT
@@ -181,11 +129,7 @@ SELECT
     -- This is a brand new characteristic being collected by Valuations and we
     -- are not yet confident about its completeness or accuracy.
     -- This is not currently being used in open data or modeling.
-    COALESCE(pools.in_ground_pool, FALSE) AS char_in_ground_pool,
-
-    -- HIE data
-    COALESCE(hies.hie_num_active, 0) AS hie_num_active,
-    COALESCE(hies.hie_num_expiring, 0) AS hie_num_expiring
+    COALESCE(pools.in_ground_pool, FALSE) AS char_in_ground_pool
 
 FROM {{ source('iasworld', 'pardat') }} AS par
 INNER JOIN {{ source('iasworld', 'dweldat') }} AS dwel
@@ -207,9 +151,6 @@ LEFT JOIN {{ source('iasworld', 'legdat') }} AS leg
 LEFT JOIN pools
     ON dwel.parid = pools.parid
     AND dwel.taxyr = pools.taxyr
-LEFT JOIN hies
-    ON dwel.parid = hies.pin
-    AND dwel.taxyr = hies.year
 WHERE par.cur = 'Y'
     AND par.deactivat IS NULL
     AND par.class NOT IN ('999')

--- a/dbt/models/default/schema/default.vw_card_res_char.yml
+++ b/dbt/models/default/schema/default.vw_card_res_char.yml
@@ -84,10 +84,6 @@ models:
         description: '{{ doc("shared_column_char_yrblt") }}'
       - name: class
         description: '{{ doc("shared_column_class") }}'
-      - name: hie_num_active
-        description: '{{ doc("shared_column_hie_num_active") }}'
-      - name: hie_num_expiring
-        description: '{{ doc("shared_column_hie_num_expiring") }}'
       - name: pin
         description: '{{ doc("shared_column_pin") }}'
       - name: pin10

--- a/dbt/models/iasworld/columns.md
+++ b/dbt/models/iasworld/columns.md
@@ -431,18 +431,6 @@ Group adjustment value
 Homesite indicator
 {% enddocs %}
 
-## hie_end
-
-{% docs column_hie_end %}
-Home improvement exemption end year
-{% enddocs %}
-
-## hie_start
-
-{% docs column_hie_start %}
-Home improvement exemption start year
-{% enddocs %}
-
 ## iasw_id
 
 {% docs column_iasw_id %}

--- a/dbt/models/iasworld/docs.md
+++ b/dbt/models/iasworld/docs.md
@@ -12,14 +12,6 @@ Control table for `asmt` admin module - multi-jurisdiction version.
 Residential additions. Stores data about Home Improvement Exemptions (HIEs)
 and other information about `iasworld.dweldat` properties.
 
-### Nuance
-
-- In order to isolate HIEs, condition on `lline > 0`
-- HIEs from `addn` can be joined to dweldat by card
-- The characteristic changes in `addn` are applied immediately to the
-corresponding `dweldat` characteristics rather then when HIEs "roll off".
-- Individual HIEs are defined within start/end year and card
-
 **Primary Key**: `jur`, `taxyr`, `parid`, `card`, `lline`
 {% enddocs %}
 
@@ -305,15 +297,6 @@ Taxpayer information such as name and mailing address.
 {% docs table_oby %}
 Outbuilding table. This is the main storage table for condo unit-level data.
 It also stores other miscellaneous sub-PIN information like HIEs.
-
-### Nuance
-
-- In order to isolate HIEs, condition on `class = '288'`
-- HIEs from `oby` cannot necessarily be joined to `dweldat` by card, though that
-is the intended behavior
-- The characteristic changes in `oby` are applied immediately to the
-corresponding `dweldat` characteristics rather then when HIEs "roll off".
-- Individual HIEs are defined within start/end year and card
 
 **Primary Key**: `jur`, `taxyr`, `parid`, `card`, `lline`
 {% enddocs %}

--- a/dbt/models/iasworld/schema/iasworld.addn.yml
+++ b/dbt/models/iasworld/schema/iasworld.addn.yml
@@ -265,10 +265,6 @@ sources:
             description: '{{ doc("column_trans_id") }}'
           - name: upd_status
             description: '{{ doc("column_upd_status") }}'
-          - name: userval1
-            description: '{{ doc("column_hie_start") }}'
-          - name: userval2
-            description: '{{ doc("column_hie_end") }}'
           - name: value
             description: Value of the addition
           - name: vect

--- a/dbt/models/iasworld/schema/iasworld.oby.yml
+++ b/dbt/models/iasworld/schema/iasworld.oby.yml
@@ -448,10 +448,6 @@ sources:
             description: Number of identical units
           - name: upd_status
             description: '{{ doc("column_upd_status") }}'
-          - name: user10
-            description: '{{ doc("column_hie_start") }}'
-          - name: user14
-            description: '{{ doc("column_hie_end") }}'
           - name: user16
             description: '{{ doc("shared_column_alternative_cdu") }}'
           - name: valmeth

--- a/dbt/models/model/model.vw_card_res_input.sql
+++ b/dbt/models/model/model.vw_card_res_input.sql
@@ -114,8 +114,6 @@ forward_fill AS (
         ch.char_ncu,
         ch.char_tp_plan,
         ch.char_recent_renovation,
-        ch.hie_num_active,
-        ch.hie_num_expiring,
 
         -- Land and lot size indicators
         sp.char_land_sf_95_percentile,
@@ -218,8 +216,6 @@ SELECT
     f1.char_ncu,
     f1.char_tp_plan,
     f1.char_recent_renovation,
-    f1.hie_num_active,
-    f1.hie_num_expiring,
     f1.char_land_sf_95_percentile,
     f1.ind_land_gte_95_percentile,
     f1.char_bldg_sf_95_percentile,

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -955,10 +955,6 @@ models:
         description: '{{ doc("shared_column_char_use") }}'
       - name: char_yrblt
         description: '{{ doc("shared_column_char_yrblt") }}'
-      - name: hie_num_active
-        description: '{{ doc("shared_column_hie_num_active") }}'
-      - name: hie_num_expiring
-        description: '{{ doc("shared_column_hie_num_expiring") }}'
       - name: ind_bldg_gte_95_percentile
         description: |
           Indicator for a PIN with building square footage larger

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1113,18 +1113,6 @@ Possible values for this variable are:
 Year the property was constructed
 {% enddocs %}
 
-## hie_num_active
-
-{% docs shared_column_hie_num_active %}
-Number of active home improvement exemptions
-{% enddocs %}
-
-## hie_num_expiring
-
-{% docs shared_column_hie_num_expiring %}
-Number of home improvement exemptions that will expire after the current year
-{% enddocs %}
-
 # Cook County
 
 ## card


### PR DESCRIPTION
Reverts ccao-data/data-architecture#995

@jeancochrane If we don't need HIE flags, there's no reason I can think of to add these columns to the model view, and they create [extra work in the model pipeline](https://github.com/ccao-data/model-res-avm/pull/455/changes#diff-6b1854802e961990f3d40a59c31191eb3d9a78b65a65c1658f16e6c081bf95f9R262) since they only apply to the assessment set. We can move any information cataloged here to the issue I have to record HIE knowledge.