### PR TITLE
Bump lower bound year for iasWorld data tests

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -29,7 +29,7 @@ vars:
   # year, since errors in past data cannot usually be amended once records are
   # closed. Set as an integer for compatibility with comparison operators and
   # SQL's BETWEEN
-  data_test_iasworld_year_start: 2025
+  data_test_iasworld_year_start: 2026
 
   # End year for iasWorld data tests. Typically set to a date in the future,
   # but can also be use to select specific time frames for testing


### PR DESCRIPTION
Our daily iasWorld data tests have been failing for a few months without notifying us. [See here for example logs](https://github.com/ccao-data/data-architecture/actions/runs/24028806842/job/70073022635). We haven't noticed because we're not really using these test results for anything right now: [`test-dbt-models`](https://github.com/ccao-data/data-architecture/actions/workflows/test_dbt_models.yaml) is the workflow we use to keep track of the data integrity problems that we have control over, and we do run iasWorld data tests for our stakeholders sometimes, but we always run them manually in order to get the freshest data.

The test workflow [is configured to send us an alert via SNS on failure](https://github.com/ccao-data/data-architecture/blob/5dcb6dc79b42ae1bc4a834bcd28ea851e525256f/.github/workflows/test_iasworld_data.yaml#L130-L142), but recent logs reveal that the workflow [is erroring out randomly during workbook generation and skipping the notification step](https://github.com/ccao-data/data-architecture/actions/runs/24077560519/job/70229718525#step:7:2299). The error must be catastrophic and system-level, since it's causing the workflow to skip the `failure()` condition that should trigger in the event of a normal error or failure. This smells like an out-of-memory (OOM) error to me. 

One likely root cuase explaining why we might be running out of memory is that we haven't yet updated the `data_test_iasworld_year_start` config variable for 2026. This config variable determines the lower bound for years of data that we will test. Since it's still set to 2025, we are likely doubling the number of failures that we're trying to output to a workbook. This PR bumps that config variable to 2026 to see if it solves the error in the daily test workflow.

See here for an example job demonstrating that the workflow no longer raises an error: https://github.com/ccao-data/data-architecture/actions/runs/24093403570/job/70285526377

To avoid us forgetting to bump this config in the future, I opened https://github.com/ccao-data/wiki/issues/68 and popped it in our upcoming sprint to make sure we document all of these yearly config updates.