### PR TITLE
Exclude by doc no, not failure count, in `sale.vw_flag_group` uniqueness test

### DIFF
--- a/dbt/models/sale/schema.yml
+++ b/dbt/models/sale/schema.yml
@@ -357,11 +357,12 @@ models:
             - run_id
             - doc_no
           config:
-            # This threshold is based on an existing data problem in which there are
-            # 4 violations of this assumption
-            # more details: https://github.com/ccao-data/data-architecture/pull/913#discussion_r2475427865
-            # If there are any more duplicates, we will be pushed over 4 and this test will flag it
-            error_if: ">4"
+            # There are two doc numbers that are incorrectly assigned to at
+            # least one sale, causing test failures if we include them.
+            # We hope to fix this problem in the source data eventually, but
+            # for now we exclude those doc numbers from testing.
+            # More details: https://github.com/ccao-data/data-architecture/pull/913#discussion_r2475427865
+            where: doc_no NOT IN ('1536210019', '2530811032')
 
   - name: sale.vw_outlier
     description: '{{ doc("vw_outlier") }}'


### PR DESCRIPTION
The test `sale_vw_flag_group_unique_by_run_id_and_doc_no` has a number of different failures due to two doc numbers that have two different representations in iasWorld. In both cases, one of these iasWorld representations is incorrect, in that the sale has a different doc number in [the Clerk's deeds database](https://crs.cookcountyclerkil.gov/Search). See here for a recent failure log: https://github.com/ccao-data/data-architecture/actions/runs/24340877987/job/71069226118#step:7:734

We hope to convince our data stakeholders to fix these incorrect doc numbers, but in the meantime, this PR tweaks the test to exclude them, which should be a more future-proof way of ignoring the existing failures. By ignoring these doc numbers, we can ensure that we don't add any more failing rows any time we rerun the sales validation model on these sales in the future.