### PR TITLE
Update dataflow diagram

### DIFF
--- a/dbt/assets/dataflow-diagram.mmd
+++ b/dbt/assets/dataflow-diagram.mmd
@@ -1,7 +1,7 @@
 flowchart TD
   mainframe[(Mainframe + AS/400)] & input[User input] & mydec[MyDec]--> ias[(iasWorld)]
   ias -- Spark ingest --> athena[(AWS Athena\nwarehouse)]
-  public["Public data sources\n(e.g. Census, OSM, GIS)"] & private["Private data sources\n(e.g. foreclosures)"] -- R extraction scripts --> athena
+  public["Public data sources\n(e.g. IDOR, Census, OSM, GIS)"] & private["Private data sources\n(e.g. foreclosures)"] -- R extraction scripts --> athena
   athena --> github{GitHub Actions}
   github --> dbt{dbt tables + views} --> athena
   github --> batch{AWS Batch\nmodeling\ninstances} --> athena

--- a/dbt/assets/dataflow-diagram.mmd
+++ b/dbt/assets/dataflow-diagram.mmd
@@ -1,13 +1,13 @@
 flowchart TD
-  A[(Mainframe + AS/400)] & B[User input] & M[MyDec]--> C[(iasWorld)]
-  C -- Spark ingest --> D[(AWS Athena\nwarehouse)]
-  E["Public data sources\n(e.g. Census, OSM, GIS)"] & F["Private data sources\n(e.g. foreclosures)"] -- R extraction scripts --> D
-  D --> H{GitHub Actions}
-  H --> I{dbt tables + views} --> D
-  H --> J{AWS Batch\nmodeling\ninstances} --> D
-  H --> L[Socrata open\ndata portal]
-  D --> K[On-prem\ndev server] -- Socrata agent --> L
-  D -- Scheduled extracts --> M[Tableau reports]
-  D --> N[Windows VMs] --> O[Appeal\nworkbooks]
-  N --> P[IC reference\nfiles]
-  D --> Q[ETL scripts] --> D
+  mainframe[(Mainframe + AS/400)] & input[User input] & mydec[MyDec]--> ias[(iasWorld)]
+  ias -- Spark ingest --> athena[(AWS Athena\nwarehouse)]
+  public["Public data sources\n(e.g. Census, OSM, GIS)"] & private["Private data sources\n(e.g. foreclosures)"] -- R extraction scripts --> athena
+  athena --> github{GitHub Actions}
+  github --> dbt{dbt tables + views} --> athena
+  github --> batch{AWS Batch\nmodeling\ninstances} --> athena
+  github --> socrata[Socrata open\ndata portal]
+  athena --> server[On-prem\ndev server] -- Socrata agent --> socrata
+  athena -- Scheduled extracts --> tableau[Tableau reports]
+  athena --> vm[Windows VMs] --> appeal[Appeal\nworkbooks]
+  vm --> ic[IC reference\nfiles]
+  athena --> etl[ETL scripts] --> athena

--- a/dbt/assets/dataflow-diagram.mmd
+++ b/dbt/assets/dataflow-diagram.mmd
@@ -1,13 +1,13 @@
 flowchart TD
-  A[Mainframe + AS/400] & B[User input] & M[MyDec]--> C[(iasWorld)]
-  C -- service-sqoop-iasworld --> D[(AWS Athena\nwarehouse)]
-  E["Public data sources\n(e.g. Census, OSM, GIS)"] & F["Private data sources\n(e.g. RPIE, sales)"] -- R extraction scripts --> D
-  D -- R transformation scripts --> D
-  D --> I{dbt} --> D
-  D ----> K[AWS Glue jobs]
-  K ---> L(Ratio stats) -- reporting database --> D
-  K ---> N(Sales flagging) -- sale database --> D
-  D --> O[On-prem dev. server] -- Socrata agent --> P[Open data portal]
-  L --> Q[Tableau reports]
-  D -- Scheduled extracts --> Q
-  D -- GitHub Actions --> Z{AWS Batch\nmodeling\ninstances} --> D
+  A[(Mainframe + AS/400)] & B[User input] & M[MyDec]--> C[(iasWorld)]
+  C -- Spark ingest --> D[(AWS Athena\nwarehouse)]
+  E["Public data sources\n(e.g. Census, OSM, GIS)"] & F["Private data sources\n(e.g. foreclosures)"] -- R extraction scripts --> D
+  D --> H{GitHub Actions}
+  H --> I{dbt tables + views} --> D
+  H --> J{AWS Batch\nmodeling\ninstances} --> D
+  H --> L[Socrata open\ndata portal]
+  D --> K[On-prem\ndev server] -- Socrata agent --> L
+  D -- Scheduled extracts --> M[Tableau reports]
+  D --> N[Windows VMs] --> O[Appeal\nworkbooks]
+  N --> P[IC reference\nfiles]
+  D --> Q[ETL scripts] --> D

--- a/dbt/assets/dataflow-diagram.mmd
+++ b/dbt/assets/dataflow-diagram.mmd
@@ -1,5 +1,5 @@
 flowchart TD
-  mainframe[(Mainframe + AS/400)] & input[User input] & mydec[MyDec]--> ias[(iasWorld)]
+  input[User input] & mydec[MyDec] --> ias[(iasWorld)]
   ias -- Spark ingest --> athena[(AWS Athena\nwarehouse)]
   public["Public data sources\n(e.g. IDOR, Census, OSM, GIS)"] & private["Private data sources\n(e.g. foreclosures)"] -- R extraction scripts --> athena
   athena --> github{GitHub Actions}


### PR DESCRIPTION
The dataflow diagram that lives on the main landing page of [our docs](https://ccao-data.github.io/data-architecture/#!/overview) is out of date. This PR brings it up to date so that it more accurately captures the current state of our infra.

There are a few infra services that are missing from this list:

- AWS CloudWatch for logging + monitoring + alerting
- AWS CloudFront for serving HomeVal
- GitHub Pages for static site hosting

I don't feel that these services are core to our "data flow" such that they merit inclusion in the diagram; plus, the more services we show, the harder the diagram is to parse. Still, I could be convinced to include them if someone else feels strongly about it.

Visit [this Mermaid Editor link](https://mermaid.ai/live/edit#pako:eNp9Ul1P2zAU_StXfphAS6sWKCl5mNTRiSENdaJsSEv64CS3iUViR_5ogar_fdfOOkE1LUriE-ec43uPvWOFKpElbN2obVFzbeFhnkkAITtn0x8GdQ9X8AHalxKL9O5ljsVqMPgEgpv0hF6PSjfl6SrIuIHBAJYd108krNBY8FRua5Q8PZk9LmEWcJbJLddYK2ew13Yub0SRZux7AFByy8Eopws0xD7BYTWE2_niPoJrlMaZCBbLuwhubpenGfMFdlpsuEVv0aN_e6yVxqJRxmk0QUkV3wM-W80LK5QEU2jRWfOmcl9fj8JkJWzt8t2NsF9dDrOgMntP6v8EUpnbHT1ged6ggY-wEbg1-yPXN4Kc26Le-Yg-e0T1trQ5DcVIUEhjuaQ2_mNgVKGp4XTZj6A6lCQNIXRKW96sjhqh_d2gThdy0GlsPRc3fyZDLAcnXqG0b9d45wPLosbSNVgeUuyzC51zlz70I2j0VZjjIjZt-ihkqbYGft6ZVd9f1yFv0lkY_FlR-ilX6qkXb9pAotNye02ua9RI0RBtLSjqY3-0Tfrl4dthW1fvAmQRq7QoWWK1w4i1qFvuP9nOu2SMaC1mLCFY0qHOWCb3pOm4_KVUe5Bp5aqaJWveGPpyHUWOc8Erzdu_s1RjifpaOWlZMh0HD5bs2DNLxuN4eHVxNhn7-2wUj84j9sKSyWg4nsYX09HV2eVkfH4Z7yP2GlYdDafxZETXxeTy_CqexvH-NzzeRBM) to see a visualization of the new version of the diagram. Here's a screenshot:

<img width="1971" height="1234" alt="image" src="https://github.com/user-attachments/assets/995595b1-1971-4507-9a20-17eef7baeac4" />


