### PR TITLE
Fix semimonthly socrata upload

### DIFF
--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -27,7 +27,7 @@ on:
   # We use these schedules to determine the value of the `UPLOAD_SCHEDULE`
   # env var below, so make sure to change that env var definition if you
   # change any of these schedules.
-  # 
+  #
   # Run a monthly job on the first of every month at 11am UTC (6am UTC-5).
     - cron: '0 11 1 * *'
   # Run a semi-monthly job on the fifteenth of every month at 11am UTC (6am UTC-5).
@@ -94,5 +94,5 @@ jobs:
           # definition alongside any changes you make here
           UPLOAD_SCHEDULE: >
             ${{ github.event.schedule == '0 11 1 * *' && 'monthly' ||
-            github.event.schedule == '0 11 15 * *' && 'semimonthly' || '' }}
+            github.event.schedule == '0 11 15 * *' && 'semimonthly' || 'semimonthly' }}
         run: python ./socrata/socrata_upload.py

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -92,7 +92,7 @@ jobs:
           # These cron expressions are shared by the `on.schedule` workflow
           # attribute defined above, so make sure to change that attribute
           # definition alongside any changes you make here
-          UPLOAD_SCHEDULE: >
+          UPLOAD_SCHEDULE: >-
             ${{ github.event.schedule == '0 11 1 * *' && 'monthly' ||
             github.event.schedule == '0 11 15 * *' && 'semimonthly' || 'semimonthly' }}
         run: python ./socrata/socrata_upload.py

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -9,7 +9,7 @@ on:
           Comma-separated list of names of Socrata assets to update.
           Asset names are the same as the asset title in Socrata (or dbt
           exposure labels), minus the "Assessor - " prefix.
-        required: false
+        required: true
       years:
         # Comma separated list of years
         type: string
@@ -94,5 +94,5 @@ jobs:
           # definition alongside any changes you make here
           UPLOAD_SCHEDULE: >-
             ${{ github.event.schedule == '0 11 1 * *' && 'monthly' ||
-            github.event.schedule == '0 11 15 * *' && 'semimonthly' || 'semimonthly' }}
+            github.event.schedule == '0 11 15 * *' && 'semimonthly' || '' }}
         run: python ./socrata/socrata_upload.py

--- a/.github/workflows/socrata_upload.yaml
+++ b/.github/workflows/socrata_upload.yaml
@@ -9,7 +9,7 @@ on:
           Comma-separated list of names of Socrata assets to update.
           Asset names are the same as the asset title in Socrata (or dbt
           exposure labels), minus the "Assessor - " prefix.
-        required: true
+        required: false
       years:
         # Comma separated list of years
         type: string

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -76,9 +76,7 @@ def parse_assets(assets=None):
     # updated once per month. If the upload is running on a monthly schedule,
     # we want to include those assets.
     monthly_tag = (
-        "tag:monthly"
-        if str(os.getenv("UPLOAD_SCHEDULE")).strip() == "semimonthly"
-        else ""
+        "tag:monthly" if os.getenv("UPLOAD_SCHEDULE") == "semimonthly" else ""
     )
 
     DBT = dbtRunner()
@@ -496,10 +494,7 @@ if __name__ == "__main__":
     event_type = " ".join(
         filter(
             None,
-            [
-                str(os.getenv("UPLOAD_SCHEDULE")).strip(),
-                os.getenv("WORKFLOW_EVENT_NAME"),
-            ],
+            [os.getenv("UPLOAD_SCHEDULE"), os.getenv("WORKFLOW_EVENT_NAME")],
         )
     )
     print(f"Running upload for event type: {event_type}")

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -491,7 +491,13 @@ def socrata_upload(asset_info, overwrite=False, years=None):
 
 
 if __name__ == "__main__":
-    print(f"Running upload for event type: {os.getenv('WORKFLOW_EVENT_NAME')}")
+    event_type = " ".join(
+        filter(
+            None,
+            [os.getenv("UPLOAD_SCHEDULE"), os.getenv("WORKFLOW_EVENT_NAME")],
+        )
+    )
+    print(f"Running upload for event type: {event_type}")
 
     # Retrieve asset(s)
     all_assets = parse_assets(os.getenv("SOCRATA_ASSET"))

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -76,7 +76,9 @@ def parse_assets(assets=None):
     # updated once per month. If the upload is running on a monthly schedule,
     # we want to include those assets.
     monthly_tag = (
-        "tag:monthly" if os.getenv("UPLOAD_SCHEDULE") == "semimonthly" else ""
+        "tag:monthly"
+        if str(os.getenv("UPLOAD_SCHEDULE")).strip() == "semimonthly"
+        else ""
     )
 
     DBT = dbtRunner()
@@ -494,7 +496,10 @@ if __name__ == "__main__":
     event_type = " ".join(
         filter(
             None,
-            [os.getenv("UPLOAD_SCHEDULE"), os.getenv("WORKFLOW_EVENT_NAME")],
+            [
+                str(os.getenv("UPLOAD_SCHEDULE")).strip(),
+                os.getenv("WORKFLOW_EVENT_NAME"),
+            ],
         )
     )
     print(f"Running upload for event type: {event_type}")


### PR DESCRIPTION
I've reverted some of the changes to `socrata_upload.yaml`, but you can see what they were like when I successfully triggered a semimonthly scheduled workflow [here](https://github.com/ccao-data/data-architecture/blob/5a6a2d3bc79fb1497a940455e3678a4c9ba9ebad/.github/workflows/socrata_upload.yaml) (disabled requirement for user to define assets, `workflow_dispatch` event returns `semimonthly` for `UPLOAD_SCHEDULE`).

This let me print what was being passed to `UPLOAD_SCHEDULE` and it seems like it was `semimonthly` but with a newline at the end. Using a folded block scalar with strip chomping `>-` for `UPLOAD_SCHEDULE` [sorts this out](https://github.com/ccao-data/data-architecture/actions/runs/24796610729/job/72567997220).

You can see a workflow with the unwanted newline in `UPLOAD_SCHEDULE` [here](https://github.com/ccao-data/data-architecture/actions/runs/24795524548/job/72564126704).