### PR TITLE
Add second year to scheduled updates for assessed values asset

### DIFF
--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -18,6 +18,7 @@ exposures:
         - subkey
         - pin
         - year
+      years_active: 1
     description: |
       Land, building, and total assessed values, pre and post-appeal with the Cook County Assessor’s office, for all Cook County parcels, from 1999 to present.
 
@@ -41,6 +42,7 @@ exposures:
       primary_key:
         - pin
         - year
+      years_active: 2
     description: |
       Land, building, and total assessed values for all Cook County parcels, from 1999 to present.
 
@@ -65,6 +67,7 @@ exposures:
       primary_key:
         - pin
         - year
+      years_active: 1
     description: |
       Situs and mailing addresses of Cook County parcels.
 
@@ -91,6 +94,7 @@ exposures:
       primary_key:
         - pin10
         - year
+      years_active: 1
     description: |
       Cook County 10-digit parcels with attached distances to various spatial features.
 
@@ -113,6 +117,7 @@ exposures:
       asset_id: wvhk-k5uv
       primary_key:
         - sale_key
+      years_active: 1
     description: |
       Parcel sales for real property in Cook County, from 1999 to present.
 
@@ -137,6 +142,7 @@ exposures:
       primary_key:
         - pin
         - year
+      years_active: 1
     description: |
       Collection of various different PIN-level physical and assessment-related
       statuses collected and documented across the CCAO and Data Department.
@@ -158,6 +164,7 @@ exposures:
       primary_key:
         - pin
         - year
+      years_active: 1
     description: |
       Most recent year universe of Cook County parcels with attached geographic, governmental, and spatial data.
 
@@ -181,6 +188,7 @@ exposures:
       primary_key:
         - pin
         - year
+      years_active: 1
     description: |
       A complete, historic universe of Cook County parcels with attached geographic, governmental, and spatial data.
 
@@ -206,6 +214,7 @@ exposures:
         - pin
         - permit_number
         - date_issued
+      years_active: 1
     description: |
       Building permits organized by PIN, with extra metadata recorded by CCAO
       permit specialists during the permit processing workflow.
@@ -226,6 +235,7 @@ exposures:
       primary_key:
         - pin
         - year
+      years_active: 1
     description: |
       Parcels with property tax-exempt status across all of Cook County per tax year, from Tax Year 2022 on, with geographic coordinates and addresses.
 
@@ -251,6 +261,7 @@ exposures:
       primary_key:
         - pin
         - year
+      years_active: 1
     description: |
       Residential condominium unit characteristics collected and maintained by the Assessor's office for all of Cook County, from 1999 to present.
 
@@ -278,6 +289,7 @@ exposures:
         - pin
         - card
         - year
+      years_active: 1
     description: |
       Single and multi-family (less than 7 units) property characteristics collected and maintained by the Assessor's Office for all of Cook County, from 1999 to present.
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -200,7 +200,8 @@ def parse_years_list(athena_asset, years=None, years_active=1):
         )
 
         # For assets with more than 1 active year, we want to update all active
-        # years
+        # years. Append years_active - 1 previous years to the list of years to
+        # update
         if years_active > 1:
             base_year = years_list[0]
             years_list.extend(

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -470,7 +470,10 @@ def upload(asset_id, sql_query, overwrite, missing_years):
                 data=input_data.iloc[i : i + 10000].to_json(orient="records"),
             )
             overwrite = False
-            print(response.content)
+            formatted_response = re.sub(
+                '\n|{|}|"', "", response.content.decode("utf-8")
+            ).strip()
+            print(formatted_response)
 
         overwrite = False
 

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -118,8 +118,13 @@ def parse_assets(assets=None):
         all_assets["depends_on.nodes"].str[0].str.split(pat=".", n=2).str[-1]
     )
 
-    all_assets = all_assets[["label", "meta.asset_id", "athena_asset"]].rename(
-        columns={"meta.asset_id": "asset_id"}
+    all_assets = all_assets[
+        ["label", "meta.asset_id", "meta.years_active", "athena_asset"]
+    ].rename(
+        columns={
+            "meta.asset_id": "asset_id",
+            "meta.years_active": "years_active",
+        }
     )
 
     # If no assets are entered return metadata for all assets otherwise filter
@@ -130,7 +135,7 @@ def parse_assets(assets=None):
         all_assets = all_assets[all_assets["label"].isin(assets)]
 
     print("Assets that will be updated:")
-    print(all_assets["label"])
+    print("\n".join(all_assets["label"]))
 
     # Return a dict with labels as keys
     all_assets = all_assets.set_index("label").to_dict("index")
@@ -159,7 +164,7 @@ def parse_years(years=None):
     return years
 
 
-def parse_years_list(athena_asset, years=None):
+def parse_years_list(athena_asset, years=None, years_active=1):
     """
     Helper function to determine what years need to be iterated over for
     upload.
@@ -194,9 +199,13 @@ def parse_years_list(athena_asset, years=None):
             .to_list()
         )
 
-        # For assessed values, we want to update the two most recent years
-        if athena_asset == "open_data.vw_assessed_value":
-            years_list.append(years_list[0] - 1)
+        # For assets with more than 1 active year, we want to update all active
+        # years
+        if years_active > 1:
+            base_year = years_list[0]
+            years_list.extend(
+                base_year - offset for offset in range(1, years_active)
+            )
 
     else:
         years_list = None
@@ -475,11 +484,17 @@ def socrata_upload(asset_info, overwrite=False, years=None):
     (update rather than overwrite).
     """
 
-    athena_asset, asset_id = asset_info["athena_asset"], asset_info["asset_id"]
+    athena_asset, asset_id, years_active = (
+        asset_info["athena_asset"],
+        asset_info["asset_id"],
+        asset_info["years_active"],
+    )
 
     missing_years = check_missing_years(athena_asset, asset_id)
 
-    years_list = parse_years_list(years=years, athena_asset=athena_asset)
+    years_list = parse_years_list(
+        years=years, athena_asset=athena_asset, years_active=years_active
+    )
 
     sql_query = build_query_dict(
         athena_asset=athena_asset,

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -201,7 +201,9 @@ def parse_years_list(athena_asset, years=None, years_active=1):
 
         # For assets with more than 1 active year, we want to update all active
         # years. Append years_active - 1 previous years to the list of years to
-        # update
+        # update. For example, if the max year in an asset is 2024 and
+        # years_active is 3, we want to update 2024, 2023, and 2022 since all
+        # three of those years are active.
         if years_active > 1:
             base_year = years_list[0]
             years_list.extend(

--- a/socrata/socrata_upload.py
+++ b/socrata/socrata_upload.py
@@ -194,6 +194,10 @@ def parse_years_list(athena_asset, years=None):
             .to_list()
         )
 
+        # For assessed values, we want to update the two most recent years
+        if athena_asset == "open_data.vw_assessed_value":
+            years_list.append(years_list[0] - 1)
+
     else:
         years_list = None
 


### PR DESCRIPTION
Our [Assessed Values](https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Assessed-Values/uzyt-m557/about_data) asset includes data from 2025 (BOR values) that are actively being updated. We should make sure those values are up to date along with values from 2026.

This PR adds a new meta field for open data assets in dbt, `years_active`. For values greater than 1, the socrata upload script will now fetch and update the most recent `years_active` number of years rather than just the most recent year.

I ran this locally, simulating a semimonthly upload scheduled, and it successfully updated assessed values for 2025-2026.

Open to changing the name of `years_active` if it feels too ambiguous.