### PR TITLE
Update `tax` docs and tests for 2024 PTAXSIM changes

### DIFF
--- a/dbt/models/tax/docs.md
+++ b/dbt/models/tax/docs.md
@@ -12,6 +12,18 @@ Used within the [PTAXSIM](https://github.com/ccao-data/ptaxsim) package and data
 **Primary Key**: `year`, `agency_num`
 {% enddocs %}
 
+# agency_crosswalk
+
+{% docs table_agency_crosswalk %}
+Crosswalk that maps agency numbers that have changed over time to their final, canonical
+representation.
+
+Used primarily to handle the Clerk's 2024 change that switched reporting some agencies to funds.
+See [the PTAXSIM changelog](https://ccao-data.github.io/ptaxsim/news#ptaxsim-1.1.0) for details.
+
+Used within the [PTAXSIM](https://github.com/ccao-data/ptaxsim) package and database.
+{% enddocs %}
+
 # agency_fund
 
 {% docs table_agency_fund %}
@@ -24,6 +36,18 @@ Pulled from the second sheet of the Cook County Clerk's
 Used within the [PTAXSIM](https://github.com/ccao-data/ptaxsim) package and database.
 
 **Primary Key**: `year`, `agency_num`, `fund_num`
+{% enddocs %}
+
+# agency_fund_crosswalk
+
+{% docs table_agency_fund_crosswalk %}
+Crosswalk that maps fund numbers that have changed over time to their final, canonical
+representation.
+
+Used primarily to handle the Clerk's 2024 change that switched reporting some agencies to funds.
+See [the PTAXSIM changelog](https://ccao-data.github.io/ptaxsim/news#ptaxsim-1.1.0) for details.
+
+Used within the [PTAXSIM](https://github.com/ccao-data/ptaxsim) package and database.
 {% enddocs %}
 
 # agency_fund_info

--- a/dbt/models/tax/docs.md
+++ b/dbt/models/tax/docs.md
@@ -22,6 +22,8 @@ Used primarily to handle the Clerk's 2024 change that switched reporting some ag
 See [the PTAXSIM changelog](https://ccao-data.github.io/ptaxsim/news#ptaxsim-1.1.0) for details.
 
 Used within the [PTAXSIM](https://github.com/ccao-data/ptaxsim) package and database.
+
+**Primary Key**: `agency_num`
 {% enddocs %}
 
 # agency_fund
@@ -48,6 +50,8 @@ Used primarily to handle the Clerk's 2024 change that switched reporting some ag
 See [the PTAXSIM changelog](https://ccao-data.github.io/ptaxsim/news#ptaxsim-1.1.0) for details.
 
 Used within the [PTAXSIM](https://github.com/ccao-data/ptaxsim) package and database.
+
+**Primary Key**: `agency_num`, `fund_num`
 {% enddocs %}
 
 # agency_fund_info
@@ -118,6 +122,19 @@ Used within the [PTAXSIM](https://github.com/ccao-data/ptaxsim) package and data
 **Primary Key**: `pin`, `year`
 {% enddocs %}
 
+# pin_tif_distribution
+
+{% docs table_pin_tif_distribution %}
+TIF EAV, frozen EAV, and distribution percentage by PIN.
+
+This table is only populated with years starting in 2024, when the Clerk changed
+their TIF distribution methodology to calculate TIF increment at the PIN level.
+
+Used within the [PTAXSIM](https://github.com/ccao-data/ptaxsim) package and database.
+
+**Primary Key**: `year`, `pin`, `agency_num`
+{% enddocs %}
+
 # tax_code
 
 {% docs table_tax_code %}
@@ -153,6 +170,9 @@ Used within the [PTAXSIM](https://github.com/ccao-data/ptaxsim) package and data
 
 {% docs table_tif_distribution %}
 TIF EAV, frozen EAV, and distribution percentage by tax code.
+
+This table is only populated with years up to 2024, when the Clerk changed
+their TIF distribution methodology to calculate TIF increment at the PIN level.
 
 Used within the [PTAXSIM](https://github.com/ccao-data/ptaxsim) package and database.
 

--- a/dbt/models/tax/schema.yml
+++ b/dbt/models/tax/schema.yml
@@ -14,6 +14,16 @@ sources:
               meta:
                 description: agency is unique by year and agency_num
 
+      - name: agency_crosswalk
+        description: '{{ doc("table_agency_crosswalk") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: tax_agency_crosswalk_unique_by_agency_num
+              combination_of_columns:
+                - agency_num
+              meta:
+                description: agency_crosswalk is unique by agency_num
+
       - name: agency_fund
         description: '{{ doc("table_agency_fund") }}'
         data_tests:
@@ -26,15 +36,27 @@ sources:
               meta:
                 description: agency_fund is unique by year, agency_num and fund_num
 
+      - name: agency_fund_crosswalk
+        description: '{{ doc("table_agency_fund_crosswalk") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: tax_agency_fund_crosswalk_unique_by_agency_num_fund_num
+              combination_of_columns:
+                - agency_num
+                - fund_num
+              meta:
+                description: agency_fund_crosswalk is unique by agency_num and fund_num
+
       - name: agency_fund_info
         description: '{{ doc("table_agency_fund_info") }}'
         data_tests:
           - unique_combination_of_columns:
-              name: tax_agency_fund_info_unique_by_fund_num
+              name: tax_agency_fund_info_unique_by_agency_num_fund_num
               combination_of_columns:
+                - agency_num
                 - fund_num
               meta:
-                description: agency_fund_info is unique by fund_num
+                description: agency_fund_info is unique by agency_num and fund_num
 
       - name: agency_info
         description: '{{ doc("table_agency_info") }}'

--- a/dbt/models/tax/schema.yml
+++ b/dbt/models/tax/schema.yml
@@ -163,6 +163,18 @@ sources:
               meta:
                 description: pin_geometry_raw is unique by pin10 start_year and end_year
 
+      - name: pin_tif_distribution
+        description: '{{ doc("table_pin_tif_distribution") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: tax_pin_tif_distribution_unique_by_year_pin_agency_num
+              combination_of_columns:
+                - year
+                - pin
+                - agency_num
+              meta:
+                description: pin_tif_distribution is unique by year, pin, and agency_num
+
       - name: tax_code
         description: '{{ doc("table_tax_code") }}'
         data_tests:


### PR DESCRIPTION
This PR updates the docs and tests for the `tax` schema to accommodate the changes to the PTAXSIM database that we had to make to support the 2024 data release.

For more background on those changes, see this changelog PR: https://github.com/ccao-data/ptaxsim/pull/85

See this workflow run for proof that all of the `tax` tests pass on this branch, with 2024 data now in the database: https://github.com/ccao-data/data-architecture/actions/runs/25393217504

Connects https://github.com/ccao-data/ptaxsim/issues/59.