### PR TITLE
Switch from `user24` to `external_propct` in `dweldat` for card proration

### DIFF
--- a/dbt/models/default/default.vw_card_res_char.sql
+++ b/dbt/models/default/default.vw_card_res_char.sql
@@ -45,7 +45,7 @@ SELECT
         WHEN par.tiebldgpct IS NOT NULL THEN par.tiebldgpct / 100.0
         ELSE 1.0
     END AS tieback_proration_rate,
-    CAST(dwel.user24 AS DOUBLE) / 100.0 AS card_proration_rate,
+    dwel.external_propct / 100.0 AS card_proration_rate,
     multicodes.pin_is_multicard,
     multicodes.pin_num_cards,
     COALESCE(aggregate_land.num_landlines > 1, FALSE) AS pin_is_multiland,

--- a/dbt/models/default/default.vw_card_res_char.sql
+++ b/dbt/models/default/default.vw_card_res_char.sql
@@ -46,7 +46,7 @@ SELECT
         ELSE 1.0
     END AS tieback_proration_rate,
     CASE
-        WHEN dwel.taxyr < '2020' THEN CAST(dwel.user24 AS DOUBLE) / 100 ELSE
+        WHEN dwel.taxyr < '2024' THEN CAST(dwel.user24 AS DOUBLE) / 100 ELSE
             COALESCE(dwel.external_propct, 0) / 100.0
     END AS card_proration_rate,
     multicodes.pin_is_multicard,

--- a/dbt/models/default/default.vw_card_res_char.sql
+++ b/dbt/models/default/default.vw_card_res_char.sql
@@ -46,7 +46,7 @@ SELECT
         ELSE 1.0
     END AS tieback_proration_rate,
     CASE
-        WHEN dwel.taxyr < '2019' THEN CAST(dwel.user24 AS DOUBLE) / 100 ELSE
+        WHEN dwel.taxyr < '2020' THEN CAST(dwel.user24 AS DOUBLE) / 100 ELSE
             COALESCE(dwel.external_propct, 0) / 100.0
     END AS card_proration_rate,
     multicodes.pin_is_multicard,

--- a/dbt/models/default/default.vw_card_res_char.sql
+++ b/dbt/models/default/default.vw_card_res_char.sql
@@ -46,7 +46,7 @@ SELECT
         ELSE 1.0
     END AS tieback_proration_rate,
     CASE
-        WHEN dwel.taxyr < 2019 THEN CAST(dwel.user24 AS DOUBLE) / 100 ELSE
+        WHEN dwel.taxyr < '2019' THEN CAST(dwel.user24 AS DOUBLE) / 100 ELSE
             COALESCE(dwel.external_propct, 0) / 100.0
     END AS card_proration_rate,
     multicodes.pin_is_multicard,

--- a/dbt/models/default/default.vw_card_res_char.sql
+++ b/dbt/models/default/default.vw_card_res_char.sql
@@ -45,7 +45,10 @@ SELECT
         WHEN par.tiebldgpct IS NOT NULL THEN par.tiebldgpct / 100.0
         ELSE 1.0
     END AS tieback_proration_rate,
-    dwel.external_propct / 100.0 AS card_proration_rate,
+    CASE
+        WHEN dwel.taxyr < 2019 THEN CAST(dwel.user24 AS DOUBLE) / 100 ELSE
+            COALESCE(dwel.external_propct, 0) / 100.0
+    END AS card_proration_rate,
     multicodes.pin_is_multicard,
     multicodes.pin_num_cards,
     COALESCE(aggregate_land.num_landlines > 1, FALSE) AS pin_is_multiland,

--- a/dbt/models/default/default.vw_pin_condo_char.sql
+++ b/dbt/models/default/default.vw_pin_condo_char.sql
@@ -79,8 +79,15 @@ chars AS (
                 THEN 0
             ELSE 1.0
         END AS tieback_proration_rate,
+        -- Card proration logic is year-dependent because source fields changed.
+        -- < 2024: use legacy fields (oby.user20 for class 299, com.user24 for
+        -- class 399).
+        -- >= 2024: use replacement field external_propct from oby/comdat.
+        -- For mismatched joins or missing class-specific values, fall back to
+        -- whichever table has a non-NULL proration value for that year.
         CASE
             WHEN par.taxyr < '2024'
+                -- Legacy proration columns
                 THEN
                 CAST(
                     COALESCE(
@@ -97,6 +104,7 @@ chars AS (
                 ) / 100.0
 
             ELSE
+                -- Current proration columns (2024+)
                 COALESCE(
                     CASE
                         WHEN

--- a/dbt/models/default/default.vw_pin_condo_char.sql
+++ b/dbt/models/default/default.vw_pin_condo_char.sql
@@ -9,7 +9,21 @@ should only be the case while condo characteristics are pulled from excel
 workbooks rather than iasWorld.
 */
 
-WITH aggregate_land AS (
+WITH par AS (
+    SELECT
+        parid,
+        taxyr,
+        REGEXP_REPLACE(class, '[^[:alnum:]]', '') AS class,
+        tieback,
+        tiebldgpct,
+        note2,
+        unitno
+    FROM {{ source('iasworld', 'pardat') }}
+    WHERE cur = 'Y'
+        AND deactivat IS NULL
+),
+
+aggregate_land AS (
     SELECT
         pin AS parid,
         year AS taxyr,
@@ -64,7 +78,7 @@ chars AS (
                 (oby.card IS NULL OR com.card IS NULL)
                 THEN COALESCE(oby.card, com.card)
             WHEN
-                REGEXP_REPLACE(par.class, '[^[:alnum:]]', '') = '299'
+                par.class = '299'
                 THEN oby.card
             WHEN par.class = '399' THEN com.card
         END AS card,
@@ -93,8 +107,7 @@ chars AS (
                     COALESCE(
                         CASE
                             WHEN
-                                REGEXP_REPLACE(par.class, '[^[:alnum:]]', '')
-                                = '299'
+                                par.class = '299'
                                 THEN oby.user20
                             WHEN par.class = '399' THEN com.user24
                         END,
@@ -108,8 +121,7 @@ chars AS (
                 COALESCE(
                     CASE
                         WHEN
-                            REGEXP_REPLACE(par.class, '[^[:alnum:]]', '')
-                            = '299'
+                            par.class = '299'
                             THEN oby.external_propct
                         WHEN par.class = '399' THEN com.external_propct
                     END,
@@ -121,12 +133,12 @@ chars AS (
         oby.lline,
         COALESCE(oby.num_lines, com.num_lines) AS num_lines,
         SUBSTR(par.parid, 1, 10) AS pin10,
-        REGEXP_REPLACE(par.class, '[^[:alnum:]]', '') AS class,
+        par.class,
         par.taxyr AS year,
         leg.user1 AS township_code,
         CASE
             WHEN
-                REGEXP_REPLACE(par.class, '[^[:alnum:]]', '') = '299'
+                par.class = '299'
                 THEN oby.user16
             WHEN
                 par.class = '399' AND nonlivable.flag != '399 GR'
@@ -138,7 +150,7 @@ chars AS (
         -- Very rarely use 'effyr' rather than 'yrblt' when 'yrblt' is NULL
         CASE
             WHEN
-                REGEXP_REPLACE(par.class, '[^[:alnum:]]', '') = '299'
+                par.class = '299'
                 THEN COALESCE(
                     oby.yrblt, oby.effyr, com.yrblt, com.effyr
                 )
@@ -151,7 +163,7 @@ chars AS (
         MAX(
             CASE
                 WHEN
-                    REGEXP_REPLACE(par.class, '[^[:alnum:]]', '') = '299'
+                    par.class = '299'
                     THEN COALESCE(
                         oby.yrblt, oby.effyr, com.yrblt, com.effyr
                     )
@@ -176,12 +188,7 @@ chars AS (
         par.note2 AS note,
         COALESCE(SUM(
             CASE
-                WHEN
-                    REGEXP_REPLACE(par.class, '[^[:alnum:]]', '') NOT IN (
-                        '299', '399'
-                    )
-                    THEN 1
-                ELSE 0
+                WHEN par.class NOT IN ('299', '399') THEN 1 ELSE 0
             END
         )
             OVER (
@@ -189,7 +196,7 @@ chars AS (
             )
         > 0, FALSE)
             AS bldg_is_mixed_use
-    FROM {{ source('iasworld', 'pardat') }} AS par
+    FROM par
 
     -- Left joins because par contains both 299s & 399s (oby and comdat
     -- do not) and pin_condo_char doesn't contain all condos
@@ -215,9 +222,7 @@ chars AS (
         nonlivable detection, but upon human review have been deemed livable. */
     LEFT JOIN {{ source('ccao', 'pin_nonlivable') }} AS nonlivable
         ON par.parid = nonlivable.pin
-    WHERE par.cur = 'Y'
-        AND par.deactivat IS NULL
-        AND (oby.row_no = 1 OR com.row_no = 1)
+    WHERE (oby.row_no = 1 OR com.row_no = 1)
 ),
 
 filled AS (

--- a/dbt/models/default/default.vw_pin_condo_char.sql
+++ b/dbt/models/default/default.vw_pin_condo_char.sql
@@ -80,14 +80,35 @@ chars AS (
             ELSE 1.0
         END AS tieback_proration_rate,
         CASE
-            WHEN (oby.user20 IS NULL OR com.user24 IS NULL)
-                THEN CAST(COALESCE(oby.user20, com.user24) AS DOUBLE) / 100.0
-            WHEN
-                REGEXP_REPLACE(par.class, '[^[:alnum:]]', '') = '299'
-                THEN CAST(oby.user20 AS DOUBLE) / 100.0
-            WHEN
-                par.class = '399'
-                THEN CAST(com.user24 AS DOUBLE) / 100.0
+            WHEN par.taxyr < '2024'
+                THEN
+                CAST(
+                    COALESCE(
+                        CASE
+                            WHEN
+                                REGEXP_REPLACE(par.class, '[^[:alnum:]]', '')
+                                = '299'
+                                THEN oby.user20
+                            WHEN par.class = '399' THEN com.user24
+                        END,
+                        oby.user20,
+                        com.user24
+                    ) AS DOUBLE
+                ) / 100.0
+
+            ELSE
+                COALESCE(
+                    CASE
+                        WHEN
+                            REGEXP_REPLACE(par.class, '[^[:alnum:]]', '')
+                            = '299'
+                            THEN oby.external_propct
+                        WHEN par.class = '399' THEN com.external_propct
+                    END,
+                    oby.external_propct,
+                    com.external_propct,
+                    0
+                ) / 100.0
         END AS card_proration_rate,
         oby.lline,
         COALESCE(oby.num_lines, com.num_lines) AS num_lines,

--- a/dbt/models/default/default.vw_pin_condo_char.sql
+++ b/dbt/models/default/default.vw_pin_condo_char.sql
@@ -106,23 +106,18 @@ chars AS (
                 CAST(
                     COALESCE(
                         CASE
-                            WHEN
-                                par.class = '299'
-                                THEN oby.user20
+                            WHEN par.class = '299' THEN oby.user20
                             WHEN par.class = '399' THEN com.user24
                         END,
                         oby.user20,
                         com.user24
                     ) AS DOUBLE
                 ) / 100.0
-
             ELSE
                 -- Current proration columns (2024+)
                 COALESCE(
                     CASE
-                        WHEN
-                            par.class = '299'
-                            THEN oby.external_propct
+                        WHEN par.class = '299' THEN oby.external_propct
                         WHEN par.class = '399' THEN com.external_propct
                     END,
                     oby.external_propct,

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1575,7 +1575,8 @@ on price from higher tax burdens
 Proration rate for a card on a given PIN.
 
 Prorated cards split their total value across multiple PINs. An example is
-something like a building that crosses multiple PINs
+something like a building that crosses multiple PINs. Constructed using `user24`
+pre-2024 and `external_propct` 2024 and on.
 {% enddocs %}
 
 ## external_occpct
@@ -1592,8 +1593,9 @@ and we expect it to eventually become the standard.
 {% docs shared_column_external_propct %}
 Calculated proration rate used for computing fields like `external_rcnld`.
 
-This field is used in the new system for calculating proration and occupancy,
-and we expect it to eventually become the standard.
+This field is used in the new system for calculating proration and occupancy.
+As of 2024 this is the maintained card proration column in iasWorld and `user24`
+has been deprecated outside of pre-2024 `comdat`, `dweldat`, and `oby` data.
 {% enddocs %}
 
 ## lline

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1594,8 +1594,9 @@ and we expect it to eventually become the standard.
 Calculated proration rate used for computing fields like `external_rcnld`.
 
 This field is used in the new system for calculating proration and occupancy.
-As of 2024 this is the maintained card proration column in iasWorld and `user24`
-has been deprecated outside of pre-2024 `comdat`, `dweldat`, and `oby` data.
+As of 2024 this is the maintained card proration column in iasWorld and
+`user24`/`user20` have been deprecated outside of pre-2024 `comdat`, `dweldat`,
+and `oby` data.
 {% enddocs %}
 
 ## lline


### PR DESCRIPTION
We need to switch to using a new card proration column (`external_propct`) from iasworld. It has only been active since 2024, so we need to append it to the old column (`user24`) prior to that:

<details>

<summary>user24 and external_propct from iasworld.dweldat:</summary>

This data has been cleaned slightly - `user24` has some bad values above 100 and I replaced those with `NA` so the comparison was more useful.

| taxyr | complete_rate_user24 | complete_rate_external_propct | mean_user24      | mean_external_propct |
|-------|----------------------|-------------------------------|------------------|----------------------|
|  1999 |   0.0466621748378317 |                           0.0 |  49.021100687591 |                      |
|  2000 |   0.0471597645212222 |                           0.0 |  48.939305599465 |                      |
|  2001 |   0.0467546718989093 |                           0.0 | 48.9693205724934 |                      |
|  2002 |   0.0467943551368698 |                           0.0 | 48.9345069488613 |                      |
|  2003 |   0.0467355046904039 |                           0.0 | 48.9390323292017 |                      |
|  2004 |    0.046783609632195 |                           0.0 |  48.900596297001 |                      |
|  2005 |   0.0464686428803992 |                           0.0 | 48.8860412570608 |                      |
|  2006 |   0.0462319661492182 |                           0.0 | 48.9203220907154 |                      |
|  2007 |   0.0461501769615054 |                           0.0 | 48.9118024975344 |                      |
|  2008 |   0.0460789483253936 |                           0.0 | 48.9162569501825 |                      |
|  2009 |   0.0460177940927686 |                           0.0 | 48.9224136691373 |                      |
|  2010 |   0.0461032541922177 |                           0.0 | 48.9194562771476 |                      |
|  2011 |   0.0460741940473699 |                           0.0 | 48.9133926745793 |                      |
|  2012 |   0.0461678340517241 |                           0.0 | 48.9065687202082 |                      |
|  2013 |   0.0461601511805286 |                           0.0 | 48.8877914860412 |                      |
|  2014 |   0.0461116602365845 |                           0.0 |  48.896373762965 |                      |
|  2015 |   0.0461071927803555 |                           0.0 | 48.8904920060832 |                      |
|  2016 |   0.0460346341161343 |                           0.0 | 48.8876852570671 |                      |
|  2017 |   0.0459997251139367 |                           0.0 |  48.885503090409 |                      |
|  2018 |    0.045917949446025 |                           0.0 | 48.8779833051889 |                      |
|  2019 |   0.0458121543341651 |            0.0458121543341651 | 48.8677900862035 |     48.8677900862035 |
|  2020 |   0.0456556609653197 |            0.0456620298299422 | 48.8726929165006 |     48.8733682138801 |
|  2021 |   0.0455685497071769 |            0.0455430868284166 |  48.875725529346 |     48.8766943661269 |
|  2022 |   0.0456178076041495 |            0.0455732740522079 |  48.874413973064 |     48.8769196825144 |
|  2023 |   0.0455608728421856 |             0.045506388311252 | 48.8619588334363 |     48.8626763626205 |
|  2024 |   0.0432656947876754 |            0.0456816378352642 | 48.8727899000168 |     48.8661589881283 |
|  2025 |   0.0305886555170363 |            0.0455443785265662 | 48.7825983388163 |     48.8819524003742 |
|  2026 |  0.00925571740647746 |            0.0455062952656339 | 48.9924544961316 |     48.8798338079398 |

</details>

<details>

<summary>new res char view vs old:</summary>

| column              | year | complete_rate_new | complete_rate_old | mean_new           | mean_old           |
|---------------------|------|-------------------|-------------------|--------------------|--------------------|
| card_proration_rate | 1999 |               1.0 |               1.0 | 0.0228743117102733 | 0.0228743117102733 |
| card_proration_rate | 2000 |               1.0 |               1.0 |  0.023079661279029 |  0.023079661279029 |
| card_proration_rate | 2001 |               1.0 |               1.0 | 0.0228954451647943 | 0.0228954451647943 |
| card_proration_rate | 2002 |               1.0 |               1.0 | 0.0228985869661264 | 0.0228985869661264 |
| card_proration_rate | 2003 |               1.0 |               1.0 | 0.0228719037496523 | 0.0228719037496523 |
| card_proration_rate | 2004 |               1.0 |               1.0 | 0.0228774640794045 | 0.0228774640794045 |
| card_proration_rate | 2005 |               1.0 |               1.0 | 0.0227166799301082 | 0.0227166799301082 |
| card_proration_rate | 2006 |               1.0 |               1.0 |  0.022616826749068 |  0.022616826749068 |
| card_proration_rate | 2007 |               1.0 |               1.0 | 0.0225728834076742 | 0.0225728834076742 |
| card_proration_rate | 2008 |               1.0 |               1.0 | 0.0225400967627914 | 0.0225400967627914 |
| card_proration_rate | 2009 |               1.0 |               1.0 | 0.0225130155874761 | 0.0225130155874761 |
| card_proration_rate | 2010 |               1.0 |               1.0 | 0.0225534612769042 | 0.0225534612769042 |
| card_proration_rate | 2011 |               1.0 |               1.0 | 0.0225364514560377 | 0.0225364514560377 |
| card_proration_rate | 2012 |               1.0 |               1.0 | 0.0225791034871381 | 0.0225791034871381 |
| card_proration_rate | 2013 |               1.0 |               1.0 | 0.0225666784587783 | 0.0225666784587783 |
| card_proration_rate | 2014 |               1.0 |               1.0 | 0.0225469297375889 | 0.0225469297375889 |
| card_proration_rate | 2015 |               1.0 |               1.0 | 0.0225420334005091 | 0.0225420334005091 |
| card_proration_rate | 2016 |               1.0 |               1.0 | 0.0225052670359382 | 0.0225052670359382 |
| card_proration_rate | 2017 |               1.0 |               1.0 | 0.0224871970421531 | 0.0224871970421531 |
| card_proration_rate | 2018 |               1.0 |               1.0 | 0.0224437676643132 | 0.0224437676643132 |
| card_proration_rate | 2019 |               1.0 |               1.0 | 0.0223873874139873 | 0.0223873874139873 |
| card_proration_rate | 2020 | 0.999961786812265 | 0.999961786812265 | 0.0223140036717908 | 0.0223140036717908 |
| card_proration_rate | 2021 | 0.998354916154378 | 0.998354916154378 | 0.0390579399793775 | 0.0390579399793775 |
| card_proration_rate | 2022 | 0.997070782899843 | 0.997070782899843 | 0.0349264036744204 | 0.0349264036744203 |
| card_proration_rate | 2023 | 0.995080046856697 | 0.995080046856697 | 0.0364161558784719 | 0.0364161558784719 |
| card_proration_rate | 2024 |               1.0 | 0.903767394111758 | 0.0223229225059673 |   207936.737730761 |
| card_proration_rate | 2025 |               1.0 | 0.628892718663564 |  0.022263041981573 |   298717.922911765 |
| card_proration_rate | 2026 |               1.0 | 0.618477419448408 | 0.0222434821480304 |   303706.257441829 |

</details>

<details>

<summary>code i used to gather this data:</summary>

```r
library(DBI)
library(dplyr)
library(noctua)
library(skimr)
library(tidyr)

noctua_options(unload = TRUE)
AWS_ATHENA_CONN_NOCTUA <- dbConnect(noctua::athena(), rstudio_conn_tab = FALSE)

old <- dbGetQuery(
  conn = AWS_ATHENA_CONN_NOCTUA,
  "SELECT
    year,
    card_proration_rate,
    'old' AS source
  from default.vw_card_res_char"
)

new <- dbGetQuery(
  conn = AWS_ATHENA_CONN_NOCTUA,
  "SELECT
    year,
    card_proration_rate,
    'new' AS source
  from z_ci_1030_switch_from_user24_to_external_propct_in_dweldat_for_card_proration_default.vw_card_res_char"
)

bind_rows(old, new) %>%
  group_by(year, source) %>%
  skim()%>%
  rename("column" = skim_variable, "mean" = numeric.mean) %>%
  pivot_wider(
    names_from = source,
    values_from = c(complete_rate, mean),
    id_cols = c(column, year)
  )

iasworld <- dbGetQuery(
  conn = AWS_ATHENA_CONN_NOCTUA,
  "SELECT
    taxyr,
    case when user24 = '0' then null else user24 end as user24,
    external_propct
  from iasworld.dweldat where cur = 'Y' and deactivat is null"
) %>%
  mutate(
    across(c(user24, external_propct), as.numeric),
    user24 = case_when(user24 > 100 ~ NA_real_, TRUE ~ user24)
  )

iasworld  %>%
  group_by(taxyr) %>%
  skim() %>%
  rename("column" = skim_variable, "mean" = numeric.mean) %>%
  pivot_wider(
    names_from = column,
    values_from = c(complete_rate, mean),
    id_cols = taxyr
  )

```

</details>
