### PR TITLE
Fix `cleanup_dbt_resources.sh` error following uv change in GitHub workflows

### DIFF
--- a/.github/scripts/cleanup_dbt_resources.sh
+++ b/.github/scripts/cleanup_dbt_resources.sh
@@ -36,7 +36,8 @@ if [ "$1" == "prod" ]; then
     exit 1
 fi
 
-schemas_json=$(dbt --quiet list --resource-types model seed --target "$1" \
+schemas_json=$(uv run --frozen dbt \
+    --quiet list --resource-types model seed --target "$1" \
     --exclude config.materialized:ephemeral --output json --output-keys schema \
 ) || (\
     echo "Error in dbt call" && exit 1

--- a/.github/scripts/cleanup_dbt_resources.sh
+++ b/.github/scripts/cleanup_dbt_resources.sh
@@ -20,11 +20,11 @@ delete_database() {
             # that xargs continues executing.
             echo "Continuing execution due to expected 404 response."
         else
-            exit 255  # Unexpected error; signal to xargs to quit
+            exit 255 # Unexpected error; signal to xargs to quit
         fi
     fi
 }
-export -f delete_database  # Make delete_database useable by xargs
+export -f delete_database # Make delete_database useable by xargs
 
 if [[ "$#" -eq 0 ]]; then
     echo "Missing first argument representing dbt target"
@@ -36,13 +36,14 @@ if [ "$1" == "prod" ]; then
     exit 1
 fi
 
-schemas_json=$(uv run --frozen dbt \
-    --quiet list --resource-types model seed --target "$1" \
-    --exclude config.materialized:ephemeral --output json --output-keys schema \
-) || (\
+schemas_json=$(
+    uv run --frozen dbt \
+        --quiet list --resource-types model seed --target "$1" \
+        --exclude config.materialized:ephemeral --output json --output-keys schema
+) || (
     echo "Error in dbt call" && exit 1
 )
-schemas=$(echo "$schemas_json"| sort | uniq | jq ' .schema') || (\
+schemas=$(echo "$schemas_json" | sort | uniq | jq ' .schema') || (
     echo "Error in schema parsing" && exit 1
 )
 


### PR DESCRIPTION
Hotfix following https://github.com/ccao-data/data-architecture/pull/1032. In that PR, I neglected to update `cleanup_dbt_resources.sh` to wrap the `dbt list` call in `uv run`; this mistake caused the `cleanup-dbt-resources` workflow [to break](https://github.com/ccao-data/data-architecture/actions/runs/26171833942/job/76991390028) when looking for the `dbt` executable, since it's installed via uv but #1032 changed the workflow to stop installing uv dependencies into the global environmment. This PR fixes that mistake.

To confirm the change works, I ran `cleanup_dbt_resources.sh` locally without activating the virtualenv first:

```bash
$ HEAD_REF=jeancochrane/install-python-deps-from-uv-lockfile ../.github/scripts/cleanup_dbt_resources.sh ci
Deleting the following schemas from Athena:

"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_ccao"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_census"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_default"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_external"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_location"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_model"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_open_data"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_pinval"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_proximity"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_qc"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_reporting"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_sale"
"z_ci_jeancochrane_install_python_deps_from_uv_lockfile_spatial"

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database z_ci_jeancochrane_install_python_deps_from_uv_lockfile_ccao not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database z_ci_jeancochrane_install_python_deps_from_uv_lockfile_census not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database z_ci_jeancochrane_install_python_deps_from_uv_lockfile_external not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database z_ci_jeancochrane_install_python_deps_from_uv_lockfile_location not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database z_ci_jeancochrane_install_python_deps_from_uv_lockfile_open_data not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database z_ci_jeancochrane_install_python_deps_from_uv_lockfile_pinval not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database z_ci_jeancochrane_install_python_deps_from_uv_lockfile_proximity not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database z_ci_jeancochrane_install_python_deps_from_uv_lockfile_qc not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database z_ci_jeancochrane_install_python_deps_from_uv_lockfile_sale not found.
Continuing execution due to expected 404 response.

An error occurred (EntityNotFoundException) when calling the DeleteDatabase operation: Database z_ci_jeancochrane_install_python_deps_from_uv_lockfile_spatial not found.
Continuing execution due to expected 404 response.

Done!
```