### PR TITLE
Remove mailing names and address associated with suppresion requests from address view

### DIFF
--- a/dbt/models/ccao/docs.md
+++ b/dbt/models/ccao/docs.md
@@ -78,6 +78,14 @@ aggregated or used for analyses, only provided in raw.
 **Primary Key**: `pin`, `tax_year`, `version`
 {% enddocs %}
 
+# hidename
+
+{% docs table_hidename %}
+Temporary table containing PINs associated with address suppresion requests.
+
+**Primary Key**: `pin`
+{% enddocs %}
+
 # hie
 
 {% docs table_hie %}
@@ -157,7 +165,7 @@ These are concatenated them with ','.
 GIS is currently updating data for the South Tri. These townships will be
 uploaded upon completion.
 
-Raw data is stored in 
+Raw data is stored in
 `O:\CCAODATA\zoning\data`
 
 **Primary Key**: `pin`

--- a/dbt/models/ccao/schema.yml
+++ b/dbt/models/ccao/schema.yml
@@ -78,6 +78,11 @@ sources:
 
       - name: hidename
         description: '{{ doc("table_hidename") }}'
+        data_tests:
+          - unique_combination_of_columns:
+              name: ccao_hidename_unique_by_pin
+              combination_of_columns:
+                - pin
 
       - name: hie
         description: '{{ doc("table_hie") }}'

--- a/dbt/models/ccao/schema.yml
+++ b/dbt/models/ccao/schema.yml
@@ -76,6 +76,9 @@ sources:
           - name: version
             description: In the past, models were not assigned alphanumeric IDs but rather PIN and year-level output was consecutively "versioned" by model run.
 
+      - name: hidename
+        description: '{{ doc("table_hidename") }}'
+
       - name: hie
         description: '{{ doc("table_hie") }}'
         tags:

--- a/dbt/models/default/default.vw_pin_address.sql
+++ b/dbt/models/default/default.vw_pin_address.sql
@@ -7,18 +7,24 @@
 -- on the Treasurer's website.
 WITH mail AS (
     SELECT
-        parid,
-        taxyr,
-        {{ concat_address(['mail1', 'mail2']) }} AS mail_address_name,
-        {{ concat_address(['maddr1', 'maddr2']) }} AS mail_address_full,
-        mcityname AS mail_address_city_name,
-        mstatecode AS mail_address_state,
-        NULLIF(mzip1, '00000') AS mail_address_zipcode_1,
-        NULLIF(mzip2, '0000') AS mail_address_zipcode_2,
-        mailseq = MAX(mailseq) OVER (PARTITION BY parid, taxyr) AS newest
-    FROM {{ source('iasworld', 'maildat') }}
-    WHERE cur = 'Y'
-        AND deactivat IS NULL
+        mail.parid,
+        mail.taxyr,
+        {{ concat_address(['mail.mail1', 'mail.mail2']) }}
+            AS mail_address_name,
+        {{ concat_address(['mail.maddr1', 'mail.maddr2']) }}
+            AS mail_address_full,
+        mail.mcityname AS mail_address_city_name,
+        mail.mstatecode AS mail_address_state,
+        NULLIF(mail.mzip1, '00000') AS mail_address_zipcode_1,
+        NULLIF(mail.mzip2, '0000') AS mail_address_zipcode_2,
+        mail.mailseq = MAX(mail.mailseq)
+            OVER (PARTITION BY mail.parid, mail.taxyr) AS newest,
+        hide.pin AS hide_pin
+    FROM {{ source('iasworld', 'maildat') }} AS mail
+    LEFT JOIN {{ source('ccao', 'hidename') }} AS hide
+        ON mail.parid = hide.pin
+    WHERE mail.cur = 'Y'
+        AND mail.deactivat IS NULL
 )
 
 SELECT
@@ -93,6 +99,7 @@ LEFT JOIN mail
     ON par.parid = mail.parid
     AND par.taxyr = mail.taxyr
     AND mail.newest
+    AND mail.hide_pin IS NULL
 WHERE par.cur = 'Y'
     AND par.deactivat IS NULL
     -- Remove any parcels with non-numeric characters

--- a/dbt/models/default/default.vw_pin_address.sql
+++ b/dbt/models/default/default.vw_pin_address.sql
@@ -99,6 +99,7 @@ LEFT JOIN mail
     ON par.parid = mail.parid
     AND par.taxyr = mail.taxyr
     AND mail.newest
+    -- Exclude mailing columns for PINs with suppression requests
     AND mail.hide_pin IS NULL
 WHERE par.cur = 'Y'
     AND par.deactivat IS NULL

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-hidename.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-hidename.R
@@ -10,5 +10,5 @@ output_bucket <- file.path(
   "ccao", "other", "hidename"
 )
 
-read_csv("") %>%
-  write_partitions_to_s3(output_bucket, is_spatial = FALSE, overwrite = TRUE)
+read_csv("O:/CCAODATA/data/hidename/hidename.csv") %>%
+  save_local_to_s3(output_bucket, is_spatial = FALSE, overwrite = TRUE)

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-hidename.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-hidename.R
@@ -1,7 +1,7 @@
+# Uploads a list of PINs for which to obscure mailing names and addresses.
+library(arrow)
 library(dplyr)
 library(readr)
-library(stringr)
-source("utils.R")
 
 # Declare output paths
 AWS_S3_WAREHOUSE_BUCKET <- Sys.getenv("AWS_S3_WAREHOUSE_BUCKET")
@@ -11,4 +11,4 @@ output_bucket <- file.path(
 )
 
 read_csv("O:/CCAODATA/data/hidename/hidename.csv") %>%
-  save_local_to_s3(output_bucket, is_spatial = FALSE, overwrite = TRUE)
+  write_parquet(file.path(output_bucket, "hidename.parquet"))

--- a/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-hidename.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/ccao/ccao-hidename.R
@@ -1,0 +1,14 @@
+library(dplyr)
+library(readr)
+library(stringr)
+source("utils.R")
+
+# Declare output paths
+AWS_S3_WAREHOUSE_BUCKET <- Sys.getenv("AWS_S3_WAREHOUSE_BUCKET")
+output_bucket <- file.path(
+  AWS_S3_WAREHOUSE_BUCKET,
+  "ccao", "other", "hidename"
+)
+
+read_csv("") %>%
+  write_partitions_to_s3(output_bucket, is_spatial = FALSE, overwrite = TRUE)


### PR DESCRIPTION
This PR creates a new table `ccao.hidename` which is fed by a list of PINs stored on the O drive. Any PIN from this list will not have any data from `iasworld.maildat` surfaced in `default.vw_pin_address`.

```sql
select mail_address_name is null as "mailing address is null",
	count() as rows,
	'new' as source
from z_ci_hidenames_default.vw_pin_address
group by mail_address_name is null
union all
select mail_address_name is null as "mailing address is null",
	count() as rows,
	'old' as source
from default.vw_pin_address
group by mail_address_name is null
```

| mailing_address_is_null | rows     | source |
|-------------------------|----------|--------|
| false                   | 48003634 | old    |
| true                    |  2667468 | old    |
| true                    |  2668055 | new    |
| false                   | 48003047 | new    |

the difference in null rows is 587, which is exactly what we expect:

```sql
select count()
from default.vw_pin_address vpa
	inner join ccao.hidename hide on vpa.pin = hide.pin
```

gives us 587.

```sql
with pins as (
	select pin
	from ccao.hidename
)
select vpa.*
from z_ci_hidenames_default.vw_pin_address as vpa
	inner join pins on vpa.pin = pins.pin
where mail_address_name is not null
```

returns no rows.