### PR TITLE
Fix divide-by-zero error in `qc.vw_report_town_close_res_edit.sql`

### DIFF
--- a/dbt/models/qc/qc.vw_report_town_close_res_edit.sql
+++ b/dbt/models/qc/qc.vw_report_town_close_res_edit.sql
@@ -103,7 +103,7 @@ SELECT
     ROUND(
         (
             (aprval.aprtot - aprval_prev.aprtot)
-            / CAST(aprval_prev.aprtot AS DOUBLE)
+            / NULLIF(CAST(aprval_prev.aprtot AS DOUBLE), 0)
         ),
         2
     ) AS aprtot_percent_change,
@@ -117,8 +117,10 @@ SELECT
                 (aprval.dwelval + aprval.aprland)
                 - (aprval_prev.dwelval + aprval_prev.aprland)
             )
-            / CAST(
-                (aprval_prev.dwelval + aprval_prev.aprland) AS DOUBLE
+            / NULLIF(
+                CAST(
+                    (aprval_prev.dwelval + aprval_prev.aprland) AS DOUBLE
+                ), 0
             )
         ),
         2


### PR DESCRIPTION
The percent change fields in our town close Res Edit view are currently subject to divide-by-zero errors, which fail silently in Athena and produce the values `Infinity`. This was causing Tableau to render all cells in the Res Edit workbook using scientific notation, and also causedExcel to raise file corruption errors when opening the workbook.

This PR updates all percent change fields in the Res Edit view to coerce them to nulls in cases where we would otherwise divide by zero.