### PR TITLE
Ensure town close QC views filter for `PARDAT` active parcels

### DIFF
--- a/dbt/models/qc/qc.vw_iasworld_asmt_all_joined_to_legdat.sql
+++ b/dbt/models/qc/qc.vw_iasworld_asmt_all_joined_to_legdat.sql
@@ -1,13 +1,20 @@
 SELECT
     asmt_all.*,
     legdat.user1 AS township_code
-FROM {{ source('iasworld', 'asmt_all') }} AS asmt_all
+-- Source PINs from PARDAT to filter out any records in ASMT that may represent
+-- deactivated parcels
+FROM {{ source('iasworld', 'pardat') }} AS pardat
+INNER JOIN {{ source('iasworld', 'asmt_all') }} AS asmt_all
+    ON pardat.parid = asmt_all.parid
+    AND pardat.taxyr = asmt_all.taxyr
+    AND asmt_all.rolltype != 'RR'
+    AND asmt_all.procname IN ('CCAOVALUE', 'CCAOFINAL', 'BORVALUE')
+    AND asmt_all.deactivat IS NULL
+    AND asmt_all.valclass IS NULL
 LEFT JOIN {{ source('iasworld', 'legdat') }} AS legdat
     ON asmt_all.taxyr = legdat.taxyr
     AND asmt_all.parid = legdat.parid
     AND legdat.cur = 'Y'
     AND legdat.deactivat IS NULL
-WHERE asmt_all.rolltype != 'RR'
-    AND asmt_all.procname IN ('CCAOVALUE', 'CCAOFINAL', 'BORVALUE')
-    AND asmt_all.deactivat IS NULL
-    AND asmt_all.valclass IS NULL
+WHERE pardat.cur = 'Y'
+    AND pardat.deactivat IS NULL

--- a/dbt/models/qc/qc.vw_iasworld_asmt_all_with_prior_year_values.sql
+++ b/dbt/models/qc/qc.vw_iasworld_asmt_all_with_prior_year_values.sql
@@ -25,7 +25,15 @@ SELECT
     asmt.valasm1,
     asmt.valasm2,
     asmt.valasm3
-FROM {{ source('iasworld', 'asmt_all') }} AS asmt
+-- Source PINs from PARDAT to filter out any records in ASMT that may represent
+-- deactivated parcels
+FROM {{ source('iasworld', 'pardat') }} AS pardat
+INNER JOIN {{ source('iasworld', 'asmt_all') }} AS asmt
+    ON pardat.parid = asmt.parid
+    AND pardat.taxyr = asmt.taxyr
+    AND asmt.cur = 'Y'
+    AND asmt.deactivat IS NULL
+    AND asmt.valclass IS NULL
 LEFT JOIN {{ source('iasworld', 'asmt_all') }} AS asmt_prev
     ON asmt.parid = asmt_prev.parid
     AND CAST(asmt.taxyr AS INT) = CAST(asmt_prev.taxyr AS INT) + 1
@@ -37,11 +45,6 @@ LEFT JOIN {{ source('iasworld', 'legdat') }} AS legdat
     AND asmt.parid = legdat.parid
     AND legdat.cur = 'Y'
     AND legdat.deactivat IS NULL
-LEFT JOIN {{ source('iasworld', 'pardat') }} AS pardat
-    ON asmt.taxyr = pardat.taxyr
-    AND asmt.parid = pardat.parid
-    AND pardat.cur = 'Y'
-    AND pardat.deactivat IS NULL
 LEFT JOIN {{ source('iasworld', 'owndat') }} AS owndat
     ON asmt.taxyr = owndat.taxyr
     AND asmt.parid = owndat.parid
@@ -54,6 +57,5 @@ LEFT JOIN {{ source('iasworld', 'aprval') }} AS aprval
     AND aprval.deactivat IS NULL
 LEFT JOIN {{ ref('ccao.aprval_reascd') }} AS reascd
     ON aprval.reascd = reascd.reascd
-WHERE asmt.cur = 'Y'
-    AND asmt.deactivat IS NULL
-    AND asmt.valclass IS NULL
+WHERE pardat.cur = 'Y'
+    AND pardat.deactivat IS NULL

--- a/dbt/models/qc/qc.vw_neg_asmt_value.sql
+++ b/dbt/models/qc/qc.vw_neg_asmt_value.sql
@@ -72,7 +72,10 @@ SELECT
     asmt.valasm1,
     asmt.valasm2,
     asmt.valasm3
-FROM (
+-- Source PINs from PARDAT to filter out any records in ASMT that may represent
+-- deactivated parcels
+FROM {{ source('iasworld', 'pardat') }} AS pardat
+INNER JOIN (
     -- This is intended to replicate the ASMT table since we don't
     -- actually have access to it and ASMT_ALL is just the union of
     -- ASMT and ASMT_HIST
@@ -82,10 +85,14 @@ FROM (
     SELECT *
     FROM {{ source('iasworld', 'asmt_hist') }}
 ) AS asmt
+    ON pardat.parid = asmt.parid
+    AND pardat.taxyr = asmt.taxyr
+    AND asmt.cur = 'Y'
+    AND asmt.deactivat IS NULL
 LEFT JOIN {{ source('iasworld', 'legdat') }} AS legdat
     ON asmt.taxyr = legdat.taxyr
     AND asmt.parid = legdat.parid
     AND legdat.cur = 'Y'
     AND legdat.deactivat IS NULL
-WHERE asmt.cur = 'Y'
-    AND asmt.deactivat IS NULL
+WHERE pardat.cur = 'Y'
+    AND pardat.deactivat IS NULL

--- a/dbt/models/qc/qc.vw_report_town_close_289s.sql
+++ b/dbt/models/qc/qc.vw_report_town_close_289s.sql
@@ -3,12 +3,19 @@ SELECT
     oby.taxyr,
     legdat.user1 AS township_code,
     oby.class
-FROM {{ source('iasworld', 'oby') }} AS oby
+-- Source PINs from PARDAT to filter out any records in subsequent tables that
+-- may represent deactivated parcels
+FROM {{ source('iasworld', 'pardat') }} AS pardat
+INNER JOIN {{ source('iasworld', 'oby') }} AS oby
+    ON pardat.parid = oby.parid
+    AND pardat.taxyr = oby.taxyr
+    AND oby.cur = 'Y'
+    AND oby.deactivat IS NULL
 LEFT JOIN {{ source('iasworld', 'legdat') }} AS legdat
     ON oby.parid = legdat.parid
     AND oby.taxyr = legdat.taxyr
     AND legdat.cur = 'Y'
     AND legdat.deactivat IS NULL
-WHERE oby.cur = 'Y'
-    AND oby.deactivat IS NULL
+WHERE pardat.cur = 'Y'
+    AND pardat.deactivat IS NULL
     AND oby.class = '289'

--- a/dbt/models/qc/qc.vw_report_town_close_ovrrcnlds_to_review.sql
+++ b/dbt/models/qc/qc.vw_report_town_close_ovrrcnlds_to_review.sql
@@ -92,7 +92,8 @@ SELECT
     calc.who,
     calc.wen
 FROM combined_calc AS calc
-LEFT JOIN {{ source('iasworld', 'pardat') }} AS pardat
+-- Inner join to PARDAT to filter out PINs that represent deactivated parcels
+INNER JOIN {{ source('iasworld', 'pardat') }} AS pardat
     ON calc.parid = pardat.parid
     AND calc.taxyr = pardat.taxyr
     AND pardat.cur = 'Y'

--- a/dbt/models/qc/qc.vw_report_town_close_prior_year_card_code_5s_oby.sql
+++ b/dbt/models/qc/qc.vw_report_town_close_prior_year_card_code_5s_oby.sql
@@ -1,5 +1,20 @@
+-- Filter OBY for only parcels that are active in PARDAT, to remove parcels
+-- that are deactivated but that remain active in OBY to support
+-- Clerk/Treasurer processes
+WITH oby AS (
+    SELECT oby.*
+    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    INNER JOIN {{ source('iasworld', 'oby') }} AS oby
+        ON pardat.parid = oby.parid
+        AND pardat.taxyr = oby.taxyr
+        AND oby.cur = 'Y'
+        AND oby.deactivat IS NULL
+    WHERE pardat.cur = 'Y'
+        AND pardat.deactivat IS NULL
+),
+
 -- Calculate YoY changes to occupancy percentages in OBY
-WITH oby_change AS (
+oby_change AS (
     SELECT
         oby_prev.parid,
         -- If there is a record for a card in the prior year but not in the
@@ -55,8 +70,8 @@ WITH oby_change AS (
     -- Select from the prior year of data as the base of the query so that we
     -- can preserve parcels that may have changed in the subsequent year
     -- such that they don't appear in OBY anymore
-    FROM {{ source('iasworld', 'oby') }} AS oby_prev
-    LEFT JOIN {{ source('iasworld', 'oby') }} AS oby
+    FROM oby AS oby_prev
+    LEFT JOIN oby
         ON oby_prev.parid = oby.parid
         AND oby_prev.card = oby.card
         AND oby_prev.lline = oby.lline


### PR DESCRIPTION
This PR is a follow-up PR for #1042 that expands the changes from that PR to cover our QC views, which also pull directly from affected tables (`ASMT`, `LEGDAT`, and `OWNDAT`).

Query to check how row counts will change:

<details>
<summary>Expand to see query</summary>

```sql
with asmt_all_joined_to_legdat_prod as (
    select
        'asmt_all_joined_to_legdat' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_iasworld_asmt_all_joined_to_legdat
),

asmt_all_joined_to_legdat_dev as (
    select
        'asmt_all_joined_to_legdat' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_iasworld_asmt_all_joined_to_legdat
),

asmt_all_with_prior_year_values_prod as (
    select
        'asmt_all_with_prior_year_values' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_iasworld_asmt_all_with_prior_year_values
),

asmt_all_with_prior_year_values_dev as (
    select
        'asmt_all_with_prior_year_values' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_iasworld_asmt_all_with_prior_year_values
),

neg_asmt_value_prod as (
    select
        'neg_asmt_value' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_neg_asmt_value
),

neg_asmt_value_dev as (
    select
        'neg_asmt_value' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_neg_asmt_value
),

town_close_neg_asmt_value_prod as (
    select
        'town_close_neg_asmt_value' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_neg_asmt_value
),

town_close_neg_asmt_value_dev as (
    select
        'town_close_neg_asmt_value' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_neg_asmt_value
),

ovrrcnlds_to_review_prod as (
    select
        'ovrrcnlds_to_review' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_ovrrcnlds_to_review
),

ovrrcnlds_to_review_dev as (
    select
        'ovrrcnlds_to_review' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_ovrrcnlds_to_review
),

t_289s_prod as (
    select
        '289s' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_289s
),

t_289s_dev as (
    select
        '289s' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_289s
),

improved_class_without_bldg_value_prod as (
    select
        'improved_class_without_bldg_value' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_improved_class_without_bldg_value
),

improved_class_without_bldg_value_dev as (
    select
        'improved_class_without_bldg_value' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_improved_class_without_bldg_value
),

res_multicodes_prod as (
    select
        'res_multicodes' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_res_multicodes
),

res_multicodes_dev as (
    select
        'res_multicodes' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_res_multicodes
),

t_500k_increase_1m_decrease_prod as (
    select
        '500k_increase_1m_decrease' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_500k_increase_1m_decrease
),

t_500k_increase_1m_decrease_dev as (
    select
        '500k_increase_1m_decrease' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_500k_increase_1m_decrease
),

vacant_class_with_bldg_value_prod as (
    select
        'vacant_class_with_bldg_value' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_vacant_class_with_bldg_value
),

vacant_class_with_bldg_value_dev as (
    select
        'vacant_class_with_bldg_value' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_vacant_class_with_bldg_value
),

t_0_value_prod as (
    select
        '0_value' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_0_value
),

t_0_value_dev as (
    select
        '0_value' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_0_value
),

t_0_land_value_prod as (
    select
        '0_land_value' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_0_land_value
),

t_0_land_value_dev as (
    select
        '0_land_value' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_0_land_value
),

class_does_not_equal_luc_prod as (
    select
        'class_does_not_equal_luc' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_class_does_not_equal_luc
),

class_does_not_equal_luc_dev as (
    select
        'class_does_not_equal_luc' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_class_does_not_equal_luc
),

prior_year_card_code_5s_dweldat_prod as (
    select
        'prior_year_card_code_5s_dweldat' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_prior_year_card_code_5s_dweldat
),

prior_year_card_code_5s_dweldat_dev as (
    select
        'prior_year_card_code_5s_dweldat' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_prior_year_card_code_5s_dweldat
),

prior_year_card_code_5s_comdat_prod as (
    select
        'prior_year_card_code_5s_comdat' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_prior_year_card_code_5s_comdat
),

prior_year_card_code_5s_comdat_dev as (
    select
        'prior_year_card_code_5s_comdat' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_prior_year_card_code_5s_comdat
),

prior_year_card_code_5s_oby_prod as (
    select
        'prior_year_card_code_5s_oby' as tablename,
        'prod' as env,
        count(*) as row_count
    from qc.vw_report_town_close_prior_year_card_code_5s_oby
),

prior_year_card_code_5s_oby_dev as (
    select
        'prior_year_card_code_5s_oby' as tablename,
        'dev' as env,
        count(*) as row_count
    from z_ci_jeancochrane_ensure_town_close_qc_views_filter_for_active_parcels_qc.vw_report_town_close_prior_year_card_code_5s_oby
)

select tablename, env, row_count
from (select * from asmt_all_joined_to_legdat_prod)
union (select * from asmt_all_joined_to_legdat_dev)
union (select * from asmt_all_with_prior_year_values_prod)
union (select * from asmt_all_with_prior_year_values_dev)
union (select * from neg_asmt_value_prod)
union (select * from neg_asmt_value_dev)
union (select * from town_close_neg_asmt_value_prod)
union (select * from town_close_neg_asmt_value_dev)
union (select * from ovrrcnlds_to_review_prod)
union (select * from ovrrcnlds_to_review_dev)
union (select * from t_289s_prod)
union (select * from t_289s_dev)
union (select * from improved_class_without_bldg_value_prod)
union (select * from improved_class_without_bldg_value_dev)
union (select * from res_multicodes_prod)
union (select * from res_multicodes_dev)
union (select * from t_500k_increase_1m_decrease_prod)
union (select * from t_500k_increase_1m_decrease_dev)
union (select * from vacant_class_with_bldg_value_prod)
union (select * from vacant_class_with_bldg_value_dev)
union (select * from t_0_value_prod)
union (select * from t_0_value_dev)
union (select * from t_0_land_value_prod)
union (select * from t_0_land_value_dev)
union (select * from class_does_not_equal_luc_prod)
union (select * from class_does_not_equal_luc_dev)
union (select * from prior_year_card_code_5s_dweldat_prod)
union (select * from prior_year_card_code_5s_dweldat_dev)
union (select * from prior_year_card_code_5s_comdat_prod)
union (select * from prior_year_card_code_5s_comdat_dev)
union (select * from prior_year_card_code_5s_oby_prod)
union (select * from prior_year_card_code_5s_oby_dev)
```

</details>

<details>
<summary>Expand to see results</summary>

| tablename | env | row_count |
| --- | --- | --- |
| `0_land_value` | dev | 6629 |
| `0_land_value` | prod | 6629 |
| `0_value` | prod | 1269 |
| `0_value` | dev | 1269 |
| `289s` | prod | 220 |
| `289s` | dev | 220 |
| `500k_increase_1m_decrease` | dev | 764976 |
| `500k_increase_1m_decrease` | prod | 764976 |
| asmt_all_with_prior_year_values | prod | 50785148 |
| asmt_all_with_prior_year_values | dev | 50780820 |
| asmt_all_joined_to_legdat | dev | 146827493 |
| asmt_all_joined_to_legdat | prod | 146827507 |
| `class_does_not_equal_luc` | dev | 910 |
| `class_does_not_equal_luc` | prod | 910 |
| `improved_class_without_bldg_value` | prod | 7306 |
| `improved_class_without_bldg_value` | dev | 7306 |
| `neg_asmt_value` | dev | 69514770 |
| `neg_asmt_value` | prod | 69519098 |
| `town_close_neg_asmt_value` | dev | 1732|
| `town_close_neg_asmt_value` | prod | 1732|
| `ovrrcnlds_to_review` | dev | 9981 |
| `ovrrcnlds_to_review` | prod | 9981 |
| `prior_year_card_code_5s_comdat` | dev | 268531 |
| `prior_year_card_code_5s_comdat` | prod | 268531 |
| `prior_year_card_code_5s_dweldat` | prod | 96059 |
| `prior_year_card_code_5s_dweldat` | dev | 96059 |
| `prior_year_card_code_5s_oby` | dev | 495409 |
| `prior_year_card_code_5s_oby` | prod | 495409 |
| `res_multicodes` | prod | 475015 |
| `res_multicodes` | dev | 475015 |
| `vacant_class_with_bldg_value` | dev | 423 |
| `vacant_class_with_bldg_value` | prod | 423 |

</details>

Only `qc.vw_neg_asmt_value`, `asmt_all_joined_to_legdat`, and `asmt_all_with_prior_year_values` exhibit any difference between dev and prod. This makes intuitive sense, because these are the only views that query for all PINs over all years; the other views filter for only PINs that are failing some form of QC check, so the sample of PINs for each of those views is much smaller, leading to a lower chance that any of the deactivated parcels might show up in those views.