### PR TITLE
Clean up `reporting.vw_assessment_roll_muni`

### DIFF
--- a/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
+++ b/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
@@ -44,7 +44,7 @@ trimmed_town_class AS (
     SELECT
         pardat.parid AS pin,
         pardat.taxyr AS year,
-        SUBSTR(pardat.class, 1, 1) AS major_class,
+        groups.reporting_class_code AS major_class,
         CASE
             WHEN
                 ARRAY_JOIN(vpl.combined_municipality_name, ', ') = ''
@@ -52,6 +52,9 @@ trimmed_town_class AS (
                 ARRAY_JOIN(vpl.combined_municipality_name, ', ')
         END AS municipality_name
     FROM {{ source('iasworld', 'pardat') }} AS pardat
+    -- Exclude classes without a reporting class
+    INNER JOIN {{ ref('ccao.class_dict') }} AS groups
+        ON REGEXP_REPLACE(pardat.class, '[^[:alnum:]]', '') = groups.class_code
     LEFT JOIN {{ ref('reporting.vw_pin_value_long') }} AS pins
         ON pardat.parid = pins.pin
         AND pardat.taxyr = pins.year

--- a/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
+++ b/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
@@ -21,7 +21,7 @@ WITH stages AS (
 We need to make sure iasworld.pardat and iasworld.asmt_all are aligned before we
 use them as numerator and denominator to calculate the percentage of a
 municpality that has been valued. */
-denominator AS (
+active_pins AS (
     SELECT DISTINCT
         asmt_all.parid AS pin,
         asmt_all.taxyr AS year
@@ -48,13 +48,13 @@ and iasworld.asmt_all, respectively) and are data errors - not emblematic of
 what portion of a municipality has actually progressed through an assessment
 stage.
 
-It does NOT remove PINs from the most recent year of
-reporting.vw_pin_township_class since we expect differences based on how
-iasworld.asmt_all is populated through the year as the assessment cycle
-progresses. This means data errors caused by differences between iasworld.pardat
-and iasworld.asmt_all won't be addressed in the most recent year. Unfortunately,
-we can't know what those errors are (or if they even exist) until
-iasworld.asmt_all has at least one fully complete stage for a given year.
+It does NOT remove PINs from the most recent year of iasworld.pardat since we
+expect differences based on how iasworld.asmt_all is populated through the year
+as the assessment cycle progresses. This means data errors caused by differences
+between iasworld.pardat and iasworld.asmt_all won't be addressed in the most
+recent year. Unfortunately, we can't know what those errors are (or if they even
+exist) until iasworld.asmt_all has at least one fully complete stage for a given
+year.
 
 Starting in 2020 a small number of PINs are present in iasworld.asmt_all for
 one or two but not all three stages of assessment when we would expect all three
@@ -79,9 +79,9 @@ trimmed_town_class AS (
     -- Exclude classes without a reporting class
     INNER JOIN {{ ref('ccao.class_dict') }} AS groups
         ON REGEXP_REPLACE(pardat.class, '[^[:alnum:]]', '') = groups.class_code
-    LEFT JOIN denominator
-        ON pardat.parid = denominator.pin
-        AND pardat.taxyr = denominator.year
+    LEFT JOIN active_pins
+        ON pardat.parid = active_pins.pin
+        AND pardat.taxyr = active_pins.year
     LEFT JOIN {{ ref('location.vw_pin10_location') }} AS vpl
         ON SUBSTR(pardat.parid, 1, 10) = vpl.pin10
         AND CASE
@@ -103,7 +103,7 @@ trimmed_town_class AS (
         -- We use the denominator CTE to align pardat and asmt_all except for
         -- the current year
         AND (
-            denominator.pin IS NOT NULL
+            active_pins.pin IS NOT NULL
             OR pardat.taxyr
             = (SELECT MAX(taxyr) FROM {{ source('iasworld', 'pardat') }})
         )
@@ -111,8 +111,8 @@ trimmed_town_class AS (
 ),
 
 /* Calculate the denominator for the pct_pin_w_value_in_group column.
-reporting.vw_pin_township_class serves as the universe of yearly PINs we expect
-to see in reporting.vw_pin_value_long. */
+iasworld.pardat serves as the universe of yearly PINs we expect
+to see in iasworld.asmt_all. */
 pin_counts AS (
     SELECT
         vptc.municipality_name,

--- a/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
+++ b/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
@@ -60,7 +60,19 @@ trimmed_town_class AS (
         AND pardat.taxyr = pins.year
     LEFT JOIN {{ ref('location.vw_pin10_location') }} AS vpl
         ON SUBSTR(pardat.parid, 1, 10) = vpl.pin10
-        AND pardat.taxyr = vpl.year
+        AND CASE
+            WHEN
+                pardat.taxyr
+                > (
+                    SELECT MAX(year)
+                    FROM {{ ref('location.vw_pin10_location') }}
+                )
+                THEN (
+                    SELECT MAX(year)
+                    FROM {{ ref('location.vw_pin10_location') }}
+                )
+            ELSE pardat.taxyr
+        END = vpl.year
     WHERE pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
         AND pardat.class NOT IN ('999')

--- a/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
+++ b/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
@@ -41,21 +41,31 @@ pct_pin_w_value_in_group ends up being less than 1 when it should equal 1.
 16-07-219-029-1032 missing a mailed value but having CCAO and BOR certified
 values in 2021 is an example. */
 trimmed_town_class AS (
-    SELECT vptc.*
-    FROM {{ ref('reporting.vw_pin_township_class') }} AS vptc
-    LEFT JOIN
-        (
-            SELECT DISTINCT
-                pin,
-                year
-            FROM {{ ref('reporting.vw_pin_value_long') }}
+    SELECT
+        pardat.parid AS pin,
+        pardat.taxyr AS year,
+        SUBSTR(pardat.class, 1, 1) AS major_class,
+        CASE
+            WHEN
+                ARRAY_JOIN(vpl.combined_municipality_name, ', ') = ''
+                THEN NULL ELSE
+                ARRAY_JOIN(vpl.combined_municipality_name, ', ')
+        END AS municipality_name
+    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    LEFT JOIN {{ ref('reporting.vw_pin_value_long') }} AS pins
+        ON pardat.parid = pins.pin
+        AND pardat.taxyr = pins.year
+    LEFT JOIN {{ ref('location.vw_pin10_location') }} AS vpl
+        ON SUBSTR(pardat.parid, 1, 10) = vpl.pin10
+        AND pardat.taxyr = vpl.year
+    WHERE pardat.cur = 'Y'
+        AND pardat.deactivat IS NULL
+        AND pardat.class NOT IN ('999')
+        AND (
+            pins.pin IS NOT NULL
+            OR pardat.taxyr
+            = (SELECT MAX(taxyr) FROM {{ source('iasworld', 'pardat') }})
         )
-            AS pins
-        ON vptc.pin = pins.pin
-        AND vptc.year = pins.year
-    WHERE pins.pin IS NOT NULL
-        OR vptc.year
-        = (SELECT MAX(year) FROM {{ ref('reporting.vw_pin_township_class') }})
 
 ),
 

--- a/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
+++ b/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
@@ -17,6 +17,25 @@ WITH stages AS (
 
 ),
 
+pins AS (
+    SELECT DISTINCT
+        asmt_all.parid AS pin,
+        asmt_all.taxyr AS year
+    FROM {{ source('iasworld', 'asmt_all') }} AS asmt_all
+    INNER JOIN {{ source('iasworld', 'pardat') }} AS par
+        ON asmt_all.parid = par.parid
+        AND asmt_all.taxyr = par.taxyr
+        AND par.cur = 'Y'
+        AND par.deactivat IS NULL
+    INNER JOIN {{ ref('ccao.class_dict') }} AS class_dict
+        ON asmt_all.class = class_dict.class_code
+    WHERE asmt_all.rolltype != 'RR'
+        AND asmt_all.deactivat IS NULL
+        AND asmt_all.valclass IS NULL -- Class 999 are test pins
+        AND asmt_all.class NOT IN ('999')
+        AND asmt_all.procname IN ('CCAOVALUE', 'CCAOFINAL', 'BORVALUE')
+),
+
 /* This CTE removes historical PINs in reporting.vw_pin_township_class that are
 not in reporting.vw_pin_value_long. We do this to make sure the samples we
 derive the numerator and denominator from for pct_pin_w_value_in_group are the
@@ -55,12 +74,7 @@ trimmed_town_class AS (
     -- Exclude classes without a reporting class
     INNER JOIN {{ ref('ccao.class_dict') }} AS groups
         ON REGEXP_REPLACE(pardat.class, '[^[:alnum:]]', '') = groups.class_code
-    LEFT JOIN (
-        SELECT DISTINCT
-            pin,
-            year
-        FROM {{ ref('reporting.vw_pin_value_long') }}
-    ) AS pins
+    LEFT JOIN pins
         ON pardat.parid = pins.pin
         AND pardat.taxyr = pins.year
     LEFT JOIN {{ ref('location.vw_pin10_location') }} AS vpl

--- a/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
+++ b/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
@@ -35,8 +35,8 @@ denominator AS (
         ON asmt_all.class = class_dict.class_code
     WHERE asmt_all.rolltype != 'RR'
         AND asmt_all.deactivat IS NULL
-        AND asmt_all.valclass IS NULL -- Class 999 are test pins
-        AND asmt_all.class NOT IN ('999')
+        AND asmt_all.valclass IS NULL
+        AND asmt_all.class NOT IN ('999') -- Class 999 are test pins
         AND asmt_all.procname IN ('CCAOVALUE', 'CCAOFINAL', 'BORVALUE')
 ),
 

--- a/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
+++ b/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
@@ -55,7 +55,12 @@ trimmed_town_class AS (
     -- Exclude classes without a reporting class
     INNER JOIN {{ ref('ccao.class_dict') }} AS groups
         ON REGEXP_REPLACE(pardat.class, '[^[:alnum:]]', '') = groups.class_code
-    LEFT JOIN {{ ref('reporting.vw_pin_value_long') }} AS pins
+    LEFT JOIN (
+        SELECT DISTINCT
+            pin,
+            year
+        FROM {{ ref('reporting.vw_pin_value_long') }}
+    ) AS pins
         ON pardat.parid = pins.pin
         AND pardat.taxyr = pins.year
     LEFT JOIN {{ ref('location.vw_pin10_location') }} AS vpl

--- a/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
+++ b/dbt/models/reporting/reporting.vw_assessment_roll_muni.sql
@@ -17,7 +17,11 @@ WITH stages AS (
 
 ),
 
-pins AS (
+/* This CTE creates a limiting universe of PINs by year from iasworld.asmt_all.
+We need to make sure iasworld.pardat and iasworld.asmt_all are aligned before we
+use them as numerator and denominator to calculate the percentage of a
+municpality that has been valued. */
+denominator AS (
     SELECT DISTINCT
         asmt_all.parid AS pin,
         asmt_all.taxyr AS year
@@ -36,21 +40,21 @@ pins AS (
         AND asmt_all.procname IN ('CCAOVALUE', 'CCAOFINAL', 'BORVALUE')
 ),
 
-/* This CTE removes historical PINs in reporting.vw_pin_township_class that are
-not in reporting.vw_pin_value_long. We do this to make sure the samples we
-derive the numerator and denominator from for pct_pin_w_value_in_group are the
-same. These differences are inherent in the tables that feed these views
-(iasworld.pardat and iasworld.asmt_all, respectively) and are data errors - not
-emblematic of what portion of a municipality has actually progressed through an
-assessment stage.
+/* This CTE removes historical PINs in iasworld.pardat that are not in
+iasworld.asmt_all. We do this to make sure the samples we derive the numerator
+and denominator from for pct_pin_w_value_in_group are the same. These
+differences are inherent in the tables that feed these views (iasworld.pardat
+and iasworld.asmt_all, respectively) and are data errors - not emblematic of
+what portion of a municipality has actually progressed through an assessment
+stage.
 
 It does NOT remove PINs from the most recent year of
 reporting.vw_pin_township_class since we expect differences based on how
 iasworld.asmt_all is populated through the year as the assessment cycle
 progresses. This means data errors caused by differences between iasworld.pardat
 and iasworld.asmt_all won't be addressed in the most recent year. Unfortunately,
-we can't know what those errors are (or if they even exist) until asmt_all has
-at least one fully complete stage for a given year.
+we can't know what those errors are (or if they even exist) until
+iasworld.asmt_all has at least one fully complete stage for a given year.
 
 Starting in 2020 a small number of PINs are present in iasworld.asmt_all for
 one or two but not all three stages of assessment when we would expect all three
@@ -70,13 +74,14 @@ trimmed_town_class AS (
                 THEN NULL ELSE
                 ARRAY_JOIN(vpl.combined_municipality_name, ', ')
         END AS municipality_name
+    -- Start with pardat to make sure we only have currently active PINs
     FROM {{ source('iasworld', 'pardat') }} AS pardat
     -- Exclude classes without a reporting class
     INNER JOIN {{ ref('ccao.class_dict') }} AS groups
         ON REGEXP_REPLACE(pardat.class, '[^[:alnum:]]', '') = groups.class_code
-    LEFT JOIN pins
-        ON pardat.parid = pins.pin
-        AND pardat.taxyr = pins.year
+    LEFT JOIN denominator
+        ON pardat.parid = denominator.pin
+        AND pardat.taxyr = denominator.year
     LEFT JOIN {{ ref('location.vw_pin10_location') }} AS vpl
         ON SUBSTR(pardat.parid, 1, 10) = vpl.pin10
         AND CASE
@@ -95,8 +100,10 @@ trimmed_town_class AS (
     WHERE pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
         AND pardat.class NOT IN ('999')
+        -- We use the denominator CTE to align pardat and asmt_all except for
+        -- the current year
         AND (
-            pins.pin IS NOT NULL
+            denominator.pin IS NOT NULL
             OR pardat.taxyr
             = (SELECT MAX(taxyr) FROM {{ source('iasworld', 'pardat') }})
         )


### PR DESCRIPTION
`reporting.vw_assessment_roll_muni` has gotten too cumbersome to be useful. It's slow time-to-query and heavy scanning are the product of using other views that do a lot more work than necessary. I've stripped those views out for the most part and tried to depend on iasworld tables wherever possible. 

The goal of this PR is to speed up the view while returning exactly the same data as before. Below we do see some small mismatches between medians for the new and old views in the skimr output, but that is merely an artifact of how SQL calculates medians.

old time and data scanned to count all rows:

<img width="1263" height="358" alt="image" src="https://github.com/user-attachments/assets/1462436c-b338-49ec-826a-08f201fe92fa" />

new:

<img width="1263" height="358" alt="image" src="https://github.com/user-attachments/assets/1a16bc51-d924-49ed-b251-aeb10841fb06" />

querying everything for 2018 and later - old:

<img width="1196" height="65" alt="image" src="https://github.com/user-attachments/assets/18f9462f-7261-4156-a9d2-d3f04f6e3183" />

new:

<img width="1196" height="65" alt="image" src="https://github.com/user-attachments/assets/2c8bdf2d-9f9b-4771-bff5-49827b4dcac1" />


<details>

<summary>skimr comparison for tables (2018-2026)</summary>

| skim_variable            | source | n_missing | complete_rate     | charactermin | charactermax | characterempty | charactern_unique | characterwhitespace | numericmean       | numericsd         | numericp0 | numericp25           | numericp50         | numericp75        | numericp100 |
|--------------------------|--------|-----------|-------------------|--------------|--------------|----------------|-------------------|---------------------|-------------------|-------------------|-----------|----------------------|--------------------|-------------------|-------------|
| year                     | new    |         0 |               1.0 |            4 |            4 |              0 |                 9 |                   0 |                   |                   |           |                      |                    |                   |             |
| year                     | old    |         0 |               1.0 |            4 |            4 |              0 |                 9 |                   0 |                   |                   |           |                      |                    |                   |             |
| stage                    | new    |         0 |               1.0 |            6 |           18 |              0 |                 3 |                   0 |                   |                   |           |                      |                    |                   |             |
| stage                    | old    |         0 |               1.0 |            6 |           18 |              0 |                 3 |                   0 |                   |                   |           |                      |                    |                   |             |
| municipality             | new    |         0 |               1.0 |           13 |           32 |              0 |               134 |                   0 |                   |                   |           |                      |                    |                   |             |
| municipality             | old    |         0 |               1.0 |           13 |           32 |              0 |               134 |                   0 |                   |                   |           |                      |                    |                   |             |
| class                    | new    |         0 |               1.0 |            1 |            2 |              0 |                12 |                   0 |                   |                   |           |                      |                    |                   |             |
| class                    | old    |         0 |               1.0 |            1 |            2 |              0 |                12 |                   0 |                   |                   |           |                      |                    |                   |             |
| stage_num                | new    |         0 |               1.0 |              |              |                |                   |                     |               2.0 | 0.816510296528653 |         1 |                  1.0 |                2.0 |               3.0 |           3 |
| stage_num                | old    |         0 |               1.0 |              |              |                |                   |                     |               2.0 | 0.816510296528653 |         1 |                  1.0 |                2.0 |               3.0 |           3 |
| num_pin_w_value          | new    |         0 |               1.0 |              |              |                |                   |                     |  1481.62927501176 |   21020.204986055 |         0 |                  4.0 |               41.0 |             210.0 |      733524 |
| num_pin_w_value          | old    |         0 |               1.0 |              |              |                |                   |                     |  1481.62927501176 |   21020.204986055 |         0 |                  4.0 |               41.0 |             210.0 |      733524 |
| num_pin_total_in_group   | new    |         0 |               1.0 |              |              |                |                   |                     |  1655.39679500101 |   22284.781705703 |         1 |                  8.0 |               62.0 |             246.0 |      733524 |
| num_pin_total_in_group   | old    |         0 |               1.0 |              |              |                |                   |                     |  1655.39679500101 |   22284.781705703 |         1 |                  8.0 |               62.0 |             246.0 |      733524 |
| pct_pin_w_value_in_group | new    |         0 |               1.0 |              |              |                |                   |                     | 0.893439147581848 | 0.307620490916825 |         0 |                  1.0 |                1.0 |               1.0 |           1 |
| pct_pin_w_value_in_group | old    |         0 |               1.0 |              |              |                |                   |                     | 0.893439147581848 | 0.307620490916825 |         0 |                  1.0 |                1.0 |               1.0 |           1 |
| bldg_sum                 | new    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  54768063.2140902 |  654986741.704423 |         0 |               2102.0 |           645166.0 |         9205643.0 | 19677882638 |
| bldg_sum                 | old    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  54768063.2140902 |  654986741.704423 |         0 |               2102.0 |           645166.0 |         9205643.0 | 19677882638 |
| bldg_median              | new    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  71521.6401709722 |   270660.18336953 |         0 |                  0.0 |            14493.0 |           47446.0 |     7800367 |
| bldg_median              | old    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  71521.6745903791 |  270658.084733375 |         0 |                  0.0 |            14493.0 |           47444.5 |     7800367 |
| land_sum                 | new    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  15600790.2466349 |   163538130.17112 |         0 |              34365.0 |           566092.0 |         4371609.0 |  5734091159 |
| land_sum                 | old    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  15600790.2466349 |   163538130.17112 |         0 |              34365.0 |           566092.0 |         4371609.0 |  5734091159 |
| land_median              | new    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  33966.6249484459 |  101013.977722109 |         0 |                952.0 |             5643.0 |           25300.0 |     2450250 |
| land_median              | old    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  33966.9994750853 |  101014.268147195 |         0 |                952.0 |             5646.0 |           25300.0 |     2450250 |
| tot_sum                  | new    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  70368853.3131116 |  814852000.233411 |         0 |              88964.0 |          1444168.0 |        13632192.0 | 25411973797 |
| tot_sum                  | old    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  70368853.3131116 |  814852000.233411 |         0 |              88964.0 |          1444168.0 |        13632192.0 | 25411973797 |
| tot_median               | new    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  108253.898241536 |  341101.398724663 |         0 |               1700.5 |            23892.0 |           82059.0 |     8090158 |
| tot_median               | old    |      3095 | 0.896022307330511 |              |              |                |                   |                     |  108254.018484496 |   341098.64226458 |         0 |               1699.5 |            23890.0 |           82010.5 |     8090158 |
| delta_pct_av             | new    |      7294 | 0.754955318148223 |              |              |                |                   |                     |  12.6934289130507 |  1870.29978724078 |        -1 |  -0.0320640995861653 |                0.0 |               0.0 |      280335 |
| delta_pct_av             | old    |      7294 | 0.754955318148223 |              |              |                |                   |                     |  12.6934289130507 |  1870.29978724078 |        -1 |  -0.0320640995861653 |                0.0 |               0.0 |      280335 |
| phase_total_av           | new    |      3051 | 0.897500503930659 |              |              |                |                   |                     |  757487642.431181 |  4463326866.63214 |     31486 |           80215666.0 |        161068041.0 |       337302914.0 | 52890106168 |
| phase_total_av           | old    |      3051 | 0.897500503930659 |              |              |                |                   |                     |  757487642.431181 |  4463326866.63214 |     31486 |           80215666.0 |        161068041.0 |       337302914.0 | 52890106168 |
| phase_av_share           | new    |      3095 | 0.896022307330511 |              |              |                |                   |                     | 0.121855198530239 | 0.231781562420039 |         0 | 0.000544994393002296 | 0.0104775609734158 | 0.110912622682353 |           1 |
| phase_av_share           | old    |      3095 | 0.896022307330511 |              |              |                |                   |                     | 0.121855198530239 | 0.231781562420039 |         0 | 0.000544994393002296 | 0.0104775609734158 | 0.110912622682353 |           1 |

</details>

Including skimmr output [here](https://github.com/user-attachments/files/28971787/check-data-skimmed.xlsx) as well since this markdown table is a bit difficult to read.

