### PR TITLE
Revisit condo parking space hueristics

### DIFF
--- a/dbt/models/default/default.vw_pin_condo_char.sql
+++ b/dbt/models/default/default.vw_pin_condo_char.sql
@@ -325,10 +325,11 @@ SELECT DISTINCT
         -- If a unit's percent of the declaration is less than half of
         -- what it would be if all units had an equal share, AV limited
         OR (
+            -- We use 50 rather than .5 since iasworld stores ownership as
+            -- percentages rather than in decimal form
             filled.tiebldgpct < (50 / filled.building_pins)
             AND vph.oneyr_pri_board_tot BETWEEN 10 AND 5000
         )
-        OR vph.oneyr_pri_board_tot BETWEEN 10 AND 1000
         OR nonlivable.flag = 'negative pred'
     )
     AND (nonlivable.flag != 'questionable' OR nonlivable.flag IS NULL),
@@ -367,6 +368,8 @@ SELECT DISTINCT
         -- suggesting this is a low-value non-livable unit like a parking space.
         WHEN
             (
+                -- We use 50 rather than .5 since iasworld stores ownership as
+                -- percentages rather than in decimal form
                 filled.tiebldgpct < (50 / filled.building_pins)
                 AND vph.oneyr_pri_board_tot BETWEEN 10 AND 5000
             )

--- a/dbt/models/default/default.vw_pin_condo_char.sql
+++ b/dbt/models/default/default.vw_pin_condo_char.sql
@@ -291,12 +291,6 @@ SELECT DISTINCT
             OR SUBSTR(filled.unitno, 1, 3) = 'GAR'
             OR filled.note = 'PARKING/STORAGE/COMMON UNIT'
             OR filled.parking_pin = TRUE
-            -- If a unit's percent of the declaration is less than half of
-            -- what it would be if all units had an equal share, AV limited
-            OR (
-                filled.tiebldgpct < (50 / filled.building_pins)
-                AND vph.oneyr_pri_board_tot BETWEEN 10 AND 5000
-            )
             OR nonlivable.flag = 'negative pred'
         )
         AND (nonlivable.flag != 'questionable' OR nonlivable.flag IS NULL)
@@ -324,12 +318,6 @@ SELECT DISTINCT
         OR filled.parking_pin = TRUE
         -- If a unit's percent of the declaration is less than half of
         -- what it would be if all units had an equal share, AV limited
-        OR (
-            -- We use 50 rather than .5 since iasworld stores ownership as
-            -- percentages rather than in decimal form
-            filled.tiebldgpct < (50 / filled.building_pins)
-            AND vph.oneyr_pri_board_tot BETWEEN 10 AND 5000
-        )
         OR nonlivable.flag = 'negative pred'
     )
     AND (nonlivable.flag != 'questionable' OR nonlivable.flag IS NULL),
@@ -362,18 +350,6 @@ SELECT DISTINCT
             AND SUBSTR(filled.unitno, 1, 2) != 'PH'
         )
         OR SUBSTR(filled.unitno, 1, 3) = 'GAR' THEN 'unit number'
-        -- Unit's share of the building declaration (tiebldgpct) is less
-        -- than half of the equal-share threshold (50 / building_pins),
-        -- and the building has a plausible AV (between 10 and 5000),
-        -- suggesting this is a low-value non-livable unit like a parking space.
-        WHEN
-            (
-                -- We use 50 rather than .5 since iasworld stores ownership as
-                -- percentages rather than in decimal form
-                filled.tiebldgpct < (50 / filled.building_pins)
-                AND vph.oneyr_pri_board_tot BETWEEN 10 AND 5000
-            )
-            THEN 'declaration percent'
     END AS parking_space_flag_reason,
     COALESCE(vph.oneyr_pri_board_tot < 10, FALSE) AS is_common_area,
     COALESCE(nonlivable.flag = 'questionable', FALSE)

--- a/dbt/models/default/default.vw_pin_condo_char.sql
+++ b/dbt/models/default/default.vw_pin_condo_char.sql
@@ -316,8 +316,6 @@ SELECT DISTINCT
         OR SUBSTR(filled.unitno, 1, 3) = 'GAR'
         OR filled.note = 'PARKING/STORAGE/COMMON UNIT'
         OR filled.parking_pin = TRUE
-        -- If a unit's percent of the declaration is less than half of
-        -- what it would be if all units had an equal share, AV limited
         OR nonlivable.flag = 'negative pred'
     )
     AND (nonlivable.flag != 'questionable' OR nonlivable.flag IS NULL),

--- a/dbt/models/default/default.vw_pin_condo_char.sql
+++ b/dbt/models/default/default.vw_pin_condo_char.sql
@@ -297,7 +297,6 @@ SELECT DISTINCT
                 filled.tiebldgpct < (50 / filled.building_pins)
                 AND vph.oneyr_pri_board_tot BETWEEN 10 AND 5000
             )
-            OR vph.oneyr_pri_board_tot BETWEEN 10 AND 1000
             OR nonlivable.flag = 'negative pred'
         )
         AND (nonlivable.flag != 'questionable' OR nonlivable.flag IS NULL)

--- a/dbt/models/default/default.vw_pin_condo_char.sql
+++ b/dbt/models/default/default.vw_pin_condo_char.sql
@@ -333,31 +333,44 @@ SELECT DISTINCT
     )
     AND (nonlivable.flag != 'questionable' OR nonlivable.flag IS NULL),
     FALSE) AS is_parking_space,
+    -- Explains why a PIN was flagged as a parking space / non-unit.
+    -- NULL when the flag was overridden by human review ('questionable'),
+    -- or when the PIN is not flagged at all.
+    -- Note: priority order matters here — earlier WHENs take precedence.
     CASE
+        -- Human review determined this unit is actually livable despite
+        -- being flagged by automated detection; suppress the reason.
         WHEN nonlivable.flag = 'questionable' THEN NULL
+        -- Unit received a negative predicted AV in a prior model run,
+        -- indicating it was misclassified as livable.
         WHEN
             nonlivable.flag = 'negative pred'
             THEN 'model predicted negative value'
+        -- Valuations staff explicitly marked this PIN as a non-unit
+        -- (parking, storage, or common area) in the note field or
+        -- via the ccao.pin_condo_char.parking_pin lookup table.
         WHEN filled.note = 'PARKING/STORAGE/COMMON UNIT'
             OR filled.parking_pin = TRUE
             THEN 'identified by valuations as non-unit'
+        -- CDU code indicates a garage (GR) or parking space (PS).
         WHEN filled.cdu IN ('GR', 'PS') THEN 'cdu'
+        -- Unit number starts with 'P' (but not 'PH' for penthouse)
+        -- or starts with 'GAR', both conventions for parking/garage units.
         WHEN (
             SUBSTR(filled.unitno, 1, 1) = 'P'
             AND SUBSTR(filled.unitno, 1, 2) != 'PH'
         )
         OR SUBSTR(filled.unitno, 1, 3) = 'GAR' THEN 'unit number'
-        -- If a unit's percent of the declaration is less than half of what
-        -- it would be if all units had an equal share, AV limited
+        -- Unit's share of the building declaration (tiebldgpct) is less
+        -- than half of the equal-share threshold (50 / building_pins),
+        -- and the building has a plausible AV (between 10 and 5000),
+        -- suggesting this is a low-value non-livable unit like a parking space.
         WHEN
             (
                 filled.tiebldgpct < (50 / filled.building_pins)
                 AND vph.oneyr_pri_board_tot BETWEEN 10 AND 5000
             )
             THEN 'declaration percent'
-        WHEN
-            vph.oneyr_pri_board_tot BETWEEN 10 AND 1000
-            THEN 'prior value'
     END AS parking_space_flag_reason,
     COALESCE(vph.oneyr_pri_board_tot < 10, FALSE) AS is_common_area,
     COALESCE(nonlivable.flag = 'questionable', FALSE)

--- a/dbt/models/default/default.vw_pin_condo_char.sql
+++ b/dbt/models/default/default.vw_pin_condo_char.sql
@@ -330,19 +330,14 @@ SELECT DISTINCT
         -- Human review determined this unit is actually livable despite
         -- being flagged by automated detection; suppress the reason.
         WHEN nonlivable.flag = 'questionable' THEN NULL
-        -- Unit received a negative predicted AV in a prior model run,
-        -- indicating it was misclassified as livable.
-        WHEN
-            nonlivable.flag = 'negative pred'
-            THEN 'model predicted negative value'
+        -- CDU code indicates a garage (GR) or parking space (PS).
+        WHEN filled.cdu IN ('GR', 'PS') THEN 'cdu'
         -- Valuations staff explicitly marked this PIN as a non-unit
         -- (parking, storage, or common area) in the note field or
         -- via the ccao.pin_condo_char.parking_pin lookup table.
         WHEN filled.note = 'PARKING/STORAGE/COMMON UNIT'
             OR filled.parking_pin = TRUE
             THEN 'identified by valuations as non-unit'
-        -- CDU code indicates a garage (GR) or parking space (PS).
-        WHEN filled.cdu IN ('GR', 'PS') THEN 'cdu'
         -- Unit number starts with 'P' (but not 'PH' for penthouse)
         -- or starts with 'GAR', both conventions for parking/garage units.
         WHEN (
@@ -350,6 +345,11 @@ SELECT DISTINCT
             AND SUBSTR(filled.unitno, 1, 2) != 'PH'
         )
         OR SUBSTR(filled.unitno, 1, 3) = 'GAR' THEN 'unit number'
+        -- Unit received a negative predicted AV in a prior model run,
+        -- indicating it was misclassified as livable.
+        WHEN
+            nonlivable.flag = 'negative pred'
+            THEN 'model predicted negative value'
     END AS parking_space_flag_reason,
     COALESCE(vph.oneyr_pri_board_tot < 10, FALSE) AS is_common_area,
     COALESCE(nonlivable.flag = 'questionable', FALSE)

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1255,7 +1255,8 @@ AHSAP, see: <https://www.cookcountyassessor.com/affordable-housing>
 Building common area.
 
 Detected primarily through prior AV of less than $10. We do *not* use this
-column to determine the livable status of condo PINs for modelling purposes.
+column to determine the livable status of condo PINs for modelling purposes
+based on a dir from valuations.
 {% enddocs %}
 
 ## is_corner_lot
@@ -1269,7 +1270,13 @@ Corner lot indicator
 {% docs shared_column_is_parking_space %}
 Deeded parking/garage space or storage unit.
 
-Detected either by valuations, CDU, or unit number/proration rate heuristics.
+Determined by an order sensitive heuristic that uses the following sources:
+1. `ccao.pin_nonlivable` for "questionable" status
+2. CDU columns
+3. Note columns and a list of parking pins provided by valuations
+4. Address unit numbers
+
+either by valuations, CDU, or unit number/proration rate heuristics.
 Only applies to condo classes (299 and 399).
 {% enddocs %}
 

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1255,8 +1255,7 @@ AHSAP, see: <https://www.cookcountyassessor.com/affordable-housing>
 Building common area.
 
 Detected primarily through prior AV of less than $10. We do *not* use this
-column to determine the livable status of condo PINs for modelling purposes
-based on a dir from valuations.
+column to determine the livable status of condo PINs for modelling purposes.
 {% enddocs %}
 
 ## is_corner_lot

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1254,7 +1254,8 @@ AHSAP, see: <https://www.cookcountyassessor.com/affordable-housing>
 {% docs shared_column_is_common_area %}
 Building common area.
 
-Detected primarily through prior AV of less than $10.
+Detected primarily through prior AV of less than $10. We do *not* use this
+column to determine the livable status of condo PINs for modelling purposes.
 {% enddocs %}
 
 ## is_corner_lot

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1274,8 +1274,6 @@ Determined by an order-sensitive heuristic that uses the following sources:
 2. CDU columns
 3. Note columns and a list of parking pins provided by valuations
 4. Address unit numbers
-
-either by valuations, CDU, or unit number/proration rate heuristics.
 Only applies to condo classes (299 and 399).
 {% enddocs %}
 

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1269,7 +1269,7 @@ Corner lot indicator
 {% docs shared_column_is_parking_space %}
 Deeded parking/garage space or storage unit.
 
-Determined by an order sensitive heuristic that uses the following sources:
+Determined by an order-sensitive heuristic that uses the following sources:
 1. `ccao.pin_nonlivable` for "questionable" status
 2. CDU columns
 3. Note columns and a list of parking pins provided by valuations


### PR DESCRIPTION
Thanks to @Damonamajor we know the prior year AV parking space heuristics were working as intended, despite [some wonky outcomes](https://github.com/ccao-data/data-architecture/issues/1034#issue-4448619997). While it's nice to know that's the case, I think we've moved past the point where we it's wise to depend on these backward-looking rules to identify parking spaces.
- We no longer mail parking space values that align with this logic. We now determine parking space value entirely as a function of the value of the livable condo units they share a 10 digit pin with.
- This was one of the only ways for us to detect possible parking spaces and common areas back around 2018, but valuations has since gone through almost all the condo buildings in the county and updated CDU columns with 'GR' where appropriate. We do still use other rules to detect parking spaces that are more durable than value-based rules.
- This method has a habit of switching back and forth between `TRUE` and `FALSE` for `is_parking_space` as AVs change over time, clearly not a desired outcome.

<details>

<summary>Check to see which condo units are no longer marked as parking spaces</summary>

```r
changes <- dbGetQuery(conn = AWS_ATHENA_CONN_NOCTUA, "
select old.*
from z_ci_1034_revisit_condo_parking_space_hueristics_default.vw_pin_condo_char as new
	full outer join default.vw_pin_condo_char as old on new.pin = old.pin
	and new.year = old.year
where new.is_parking_space != old.is_parking_space
")

table(changes$year, changes$parking_space_flag_reason)
```

| year    | declaration percent prior | value |
|---------|---------------------------|-------|
|    2000 |                       186 |   144 |
|    2001 |                       181 |   115 |
|    2002 |                       181 |   129 |
|    2003 |                       170 |   117 |
|    2004 |                       181 |   187 |
|    2005 |                       167 |   304 |
|    2006 |                       160 |   126 |
|    2007 |                       160 |    74 |
|    2008 |                       168 |    26 |
|    2009 |                       185 |   153 |
|    2010 |                       203 |   188 |
|    2011 |                       202 |   130 |
|    2012 |                       200 |   145 |
|    2013 |                       221 |   137 |
|    2014 |                       199 |   226 |
|    2015 |                       200 |   347 |
|    2016 |                       159 |   133 |
|    2017 |                       156 |    78 |
|    2018 |                       133 |    49 |
|    2019 |                       120 |    19 |
|    2020 |                        99 |   117 |
|    2021 |                        96 |    20 |
|    2022 |                        97 |   325 |
|    2023 |                        89 |   326 |
|    2024 |                        83 |   347 |
|    2025 |                        53 |    94 |
|    2026 |                        76 |    62 |

</details>

<details>

<summary>Check to see why condo units are still being identified as parking spaces in new view</summary>

```sql
select distinct parking_space_flag_reason
from z_ci_1034_revisit_condo_parking_space_hueristics_default.vw_pin_condo_char
```

| parking_space_flag_reason            |
|--------------------------------------|
|                                      |
| model predicted negative value       |
| identified by valuations as non-unit |
| unit number                          |
| cdu                                  |

</details>
