### PR TITLE
Add new vetdis co-op excode to exemption views, and configure CI to run unit tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -53,12 +53,11 @@ jobs:
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_BIOME_LINT: false
+          VALIDATE_YAML: false
+          VALIDATE_YAML_PRETTIER: false
           # The natural language check slows down our velocity and is rarely
           # helpful
           VALIDATE_NATURAL_LANGUAGE: false
-          # We use yamllint for YAML linting so we don't need prettier
-          VALIDATE_YAML_PRETTIER: false
           # We have a separate workflow for pre-commit
           VALIDATE_PRE_COMMIT: false
           LINTER_RULES_PATH: /
-          YAML_CONFIG_FILE: .yamllint.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,11 @@ repos:
       - id: parsable-R
       - id: no-browser-statement
       - id: no-debug-statement
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        args: [--strict]
   - repo: local
     hooks:
       - id: check-sort-dbt-yaml-files

--- a/dbt/models/default/default.vw_pin_exe_long.sql
+++ b/dbt/models/default/default.vw_pin_exe_long.sql
@@ -27,7 +27,9 @@ WITH exe_raw AS (
                 det.excode IN ('DV1', 'C-DV1', 'DV0', 'C-DV0', 'DV-1')
                 THEN 'exe_vet_dis_lt50'
             WHEN det.excode IN ('DV2', 'C-DV2', 'DV-2') THEN 'exe_vet_dis_50_69'
-            WHEN det.excode IN ('DV3', 'DV3-M', 'DV-3') THEN 'exe_vet_dis_ge70'
+            WHEN
+                det.excode IN ('DV3', 'C-DV3', 'DV3-M', 'DV-3')
+                THEN 'exe_vet_dis_ge70'
             WHEN det.excode IN ('DV4', 'DV4-M', 'DV-4') THEN 'exe_vet_dis_100'
             WHEN det.excode = 'DV5' THEN 'exe_vet_dis_100_idor'
             WHEN

--- a/dbt/models/default/schema/default.vw_pin_exe_long.yml
+++ b/dbt/models/default/schema/default.vw_pin_exe_long.yml
@@ -135,6 +135,13 @@ unit_tests:
           - excode: 'HO'
             taxyr: '2026'
             cur: 'Y'
+      - input: source('iasworld', 'pardat')
+        rows:
+          # This table doesn't matter for the test, we just need it to ensure
+          # that the joins work
+          - parid: '01234567890000'
+            taxyr: '2026'
+            cur: 'Y'
     expect:
       rows:
         - pin: '01234567890000'

--- a/dbt/selectors.yml
+++ b/dbt/selectors.yml
@@ -23,8 +23,11 @@ selectors:
     description: Selector for running non-iasWorld data tests and unit tests
     definition:
       union:
-        - method: resource_type
-          value: test
+        - union:
+            - method: resource_type
+              value: test
+            - method: resource_type
+              value: unit_test
         - exclude:
           - method: tag
             value: data_test_iasworld
@@ -36,8 +39,11 @@ selectors:
       tests
     definition:
       intersection:
-        - method: resource_type
-          value: test
+        - union:
+            - method: resource_type
+              value: test
+            - method: resource_type
+              value: unit_test
         - union:
             - method: state
               value: new

--- a/dbt/selectors.yml
+++ b/dbt/selectors.yml
@@ -24,10 +24,10 @@ selectors:
     definition:
       union:
         - union:
-            - method: resource_type
-              value: test
-            - method: resource_type
-              value: unit_test
+          - method: resource_type
+            value: test
+          - method: resource_type
+            value: unit_test
         - exclude:
           - method: tag
             value: data_test_iasworld
@@ -40,16 +40,16 @@ selectors:
     definition:
       intersection:
         - union:
-            - method: resource_type
-              value: test
-            - method: resource_type
-              value: unit_test
+          - method: resource_type
+            value: test
+          - method: resource_type
+            value: unit_test
         - union:
-            - method: state
-              value: new
-            - method: state
-              value: modified
+          - method: state
+            value: new
+          - method: state
+            value: modified
         - exclude:
-            - method: tag
-              value: data_test_iasworld
-              indirect_selection: cautious
+          - method: tag
+            value: data_test_iasworld
+            indirect_selection: cautious

--- a/dbt/selectors.yml
+++ b/dbt/selectors.yml
@@ -4,34 +4,34 @@ selectors:
     definition:
       union:
         - intersection:
-          - method: resource_type
-            value: test
-          - method: tag
-            value: data_test_iasworld
-            # Only run tests that exclusively reference selected nodes. Useful
-            # for avoiding an edge case where a test whose base model is not
-            # selected can run because it has an argument that references a model
-            # that _is_ selected.
-            indirect_selection: cautious
+            - method: resource_type
+              value: test
+            - method: tag
+              value: data_test_iasworld
+              # Only run tests that exclusively reference selected nodes. Useful
+              # for avoiding an edge case where a test whose base model is not
+              # selected can run because it has an argument that references a model
+              # that _is_ selected.
+              indirect_selection: cautious
         - exclude:
-          - method: tag
-            value: data_test_iasworld_exclude_from_workbook
-          - method: resource_type
-            value: seed
+            - method: tag
+              value: data_test_iasworld_exclude_from_workbook
+            - method: resource_type
+              value: seed
 
   - name: select_data_test_non_iasworld
     description: Selector for running non-iasWorld data tests and unit tests
     definition:
       union:
         - union:
-          - method: resource_type
-            value: test
-          - method: resource_type
-            value: unit_test
+            - method: resource_type
+              value: test
+            - method: resource_type
+              value: unit_test
         - exclude:
-          - method: tag
-            value: data_test_iasworld
-            indirect_selection: cautious
+            - method: tag
+              value: data_test_iasworld
+              indirect_selection: cautious
 
   - name: select_data_test_new_or_modified_non_iasworld
     description: >
@@ -40,16 +40,16 @@ selectors:
     definition:
       intersection:
         - union:
-          - method: resource_type
-            value: test
-          - method: resource_type
-            value: unit_test
+            - method: resource_type
+              value: test
+            - method: resource_type
+              value: unit_test
         - union:
-          - method: state
-            value: new
-          - method: state
-            value: modified
+            - method: state
+              value: new
+            - method: state
+              value: modified
         - exclude:
-          - method: tag
-            value: data_test_iasworld
-            indirect_selection: cautious
+            - method: tag
+              value: data_test_iasworld
+              indirect_selection: cautious


### PR DESCRIPTION
This PR fixes two small issues I noticed this morning:

1. The not-null test on `default.vw_pin_exe_long.exemption_type` [has started failing](https://github.com/ccao-data/data-architecture/actions/runs/27954252551/job/82718483672#step:7:753) due to the presence of a valid exemption with excode `C-DV3`, indicating the co-op version of `exe_vet_dis_ge70`. This excode wasn't in the reference file our stakeholder sent over to us, but it seems legit, so I'm adding it as an acceptable excode to the `default.vw_pin_exe_long` view definition, which should resolve the failing test. If you'd prefer I confirm this with our stakeholder before proceeding, I'm happy to do that, too.
2. Our `build-and-test-dbt` CI workflow is not running unit tests, due to resource selection logic that only selects resources with the type `test` and not `unit_test`. This is visible when you run a specific unit test defined on `default.vw_pin_exe_long`: In #1042 we edited that view to add a dependency on `iasworld.pardat`, but did not add the corresponding table definition to the `default_vw_pin_exe_long_ranks_and_selects_properly_among_duplicates` unit test, causing the test to fail. This test should have failed on CI, but per [the workflow logs](https://github.com/ccao-data/data-architecture/actions/runs/26976790325/job/79605731887), it did not run.

Here is a command showing that `default_vw_pin_exe_long_ranks_and_selects_properly_among_duplicates` fails on the main branch:

```
$ dbt test --select default_vw_pin_exe_long_ranks_and_selects_properly_among_duplicates
...
17:11:00  Completed with 1 error, 0 partial successes, and 0 warnings:
17:11:00
17:11:00    Compilation Error in unit_test default_vw_pin_exe_long_ranks_and_selects_properly_among_duplicates (models/default/schema/default.vw_pin_exe_long.yml)
  Unit_Test 'unit_test.ccao_data_athena.default.vw_pin_exe_long.default_vw_pin_exe_long_ranks_and_selects_properly_among_duplicates' (models/default/schema/default.vw_pin_exe_long.yml) depends on a source named 'iasworld.pardat' which was not found
```

I also folded in one other change for a small issue that was annoying me: We now lint YAML files using a pre-commit hook, rather than super-linter. This makes it a lot easier to debug YAML linting failures, which I was running into while fixing our selector logic.

## Testing

Testing the fix for issue 1 above (missing co-op excode) is easy, since you can confirm that the version of `build-and-test-dbt` that ran as part of this PR is passing below ([logs here](https://github.com/ccao-data/data-architecture/actions/runs/27974248910/job/82787822518?pr=1053#step:9:66)).

Testing the fix for issue 2 (unit tests not running on CI) is harder, because we have no automated tests for it. To do so, I checked to confirm that the `default_vw_pin_exe_long_ranks_and_selects_properly_among_duplicates` test did not run as part of [the `build-and-test-dbt` workflow that ran](https://github.com/ccao-data/data-architecture/actions/runs/26976790325/job/79605731887) when #1042 got merged, which introduced the error that breaks that unit test; I then confirmed that this test is now running as part of the `build-and-test-dbt` workflow runs on this PR ([logs here](https://github.com/ccao-data/data-architecture/actions/runs/27974248910/job/82787822518?pr=1053#step:9:67)).

I also ran some local QC on the selector itself to confirm that the changes I made to the selectors that CI uses are correct, in that they are now returning unit tests, and unit tests are the only new tests they are returning:

<details>
<summary>Click to expand local QC commands</summary>

```bash
# Switch to the main branch; make edit to `default.vw_pin_exe_long` so that it counts
# as "new or modified" (not shown here)
$ git checkout master

# On the main branch: Run the data test selectors and confirm they exclude unit tests
# (neither command emits output)
$ dbt list --quiet --selector select_data_test_non_iasworld | grep unit_test
$ dbt list --quiet --selector select_data_test_new_or_modified_non_iasworld --defer --state master-cache | grep unit_test

# On the main branch: Record the number of results each selector returns
$ dbt list --quiet --selector select_data_test_non_iasworld | wc -l
352
$ dbt list --quiet --selector select_data_test_new_or_modified_non_iasworld --defer --state master-cache | wc -l
3

# Switch to bugfix branch
$ git checkout jeancochrane/add-coop-dv3-exemption-code-to-views

# On the bugfix branch: Run the data test selectors and confirm they exclude unit tests
$ dbt list --quiet --selector select_data_test_non_iasworld | grep unit_test
unit_test:ccao_data_athena.default_vw_pin_address_filters_extra_spaces_from_maildat
unit_test:ccao_data_athena.default_vw_pin_address_filters_invalid_pins
unit_test:ccao_data_athena.default_vw_pin_appeal_class_strips_non_alphanumerics
unit_test:ccao_data_athena.default_vw_pin_exe_long_ranks_and_selects_properly_among_duplicates
unit_test:ccao_data_athena.default_vw_pin_exempt_class_strips_non_alphanumerics
unit_test:ccao_data_athena.default_vw_pin_exempt_filters_invalid_pins
unit_test:ccao_data_athena.default_vw_pin_universe_class_strips_non_alphanumerics
unit_test:ccao_data_athena.default_vw_pin_universe_filters_invalid_pins
unit_test:ccao_data_athena.default_vw_pin_value_mailed_class_strips_non_alphanumerics
unit_test:ccao_data_athena.default_vw_pin_value_stage_name_matches_procname
unit_test:ccao_data_athena.location_crosswalk_year_fill_should_create_proper_fill_and_data_years
unit_test:ccao_data_athena.location_vw_pin10_location_fill_should_fill_missing_years
unit_test:ccao_data_athena.proximity_crosswalk_year_fill_should_create_proper_fill_and_data_years
unit_test:ccao_data_athena.proximity_vw_pin10_proximity_fill_should_fill_missing_years
unit_test:ccao_data_athena.sale_vw_outlier_produces_correct_outliers_and_reasons

$ dbt list --quiet --selector select_data_test_new_or_modified_non_iasworld --defer --state master-cache | grep unit_test
unit_test:ccao_data_athena.default_vw_pin_exe_long_ranks_and_selects_properly_among_duplicates

# On the bugfix branch: Record the number of results each selector returns,
# confirm it is the main branch number plus the new tests we grepped above
$ dbt list --quiet --selector select_data_test_non_iasworld | wc -l
367
$ dbt list --quiet --selector select_data_test_new_or_modified_non_iasworld --defer --state master-cache | wc -l
4
```

</details>