### PR TITLE
Add new veteran exemption code possibility

### DIFF
--- a/dbt/models/default/default.vw_pin_exe_long.sql
+++ b/dbt/models/default/default.vw_pin_exe_long.sql
@@ -26,8 +26,9 @@ WITH exe_raw AS (
             WHEN
                 det.excode IN ('DV1', 'C-DV1', 'DV0', 'C-DV0', 'DV-1')
                 THEN 'exe_vet_dis_lt50'
-            WHEN det.excode IN ('DV2', 'C-DV2', 'DV-2') THEN 'exe_vet_dis_50_69'
-            WHEN det.excode IN ('DV3', 'DV3-M', 'DV-3') THEN 'exe_vet_dis_ge70'
+            WHEN det.excode IN ('C-DV2', 'DV2', 'DV-2') THEN 'exe_vet_dis_50_69'
+            WHEN det.excode IN ('C-DV3', 'DV3', 'DV-3', 'DV3-M')
+                THEN 'exe_vet_dis_ge70'
             WHEN det.excode IN ('DV4', 'DV4-M', 'DV-4') THEN 'exe_vet_dis_100'
             WHEN det.excode = 'DV5' THEN 'exe_vet_dis_100_idor'
             WHEN


### PR DESCRIPTION
We've [got a new possible code](https://github.com/ccao-data/data-architecture/actions/runs/27954252551/job/82718483672) for `exe_vet_dis_ge70`, "Veterans with disabilities exemption for specially-adapted housing 70% or greater (35 ILCS 200/15-165)". It's a format we've seen for `exe_vet_dis_lt50` and `exe_vet_dis_50_69` so I don't think it's too surprising it showed up. Only real question is whether we'd like to anticipate it for `exe_vet_dis_100`.

```sql
select pin,
	year,
	exemption_code
from default.vw_pin_exe_long
where exemption_type is null
```

| pin            | year | exemption_code |
|----------------|------|----------------|
| 03194000060000 | 2024 | C-DV3          |

(PS, adding `exemption_code` to help debug was some real foresight 🧠)