### PR TITLE
Add missing source tables to unit test definitions

### DIFF
--- a/dbt/models/default/schema/default.vw_pin_address.yml
+++ b/dbt/models/default/schema/default.vw_pin_address.yml
@@ -85,6 +85,8 @@ unit_tests:
     description: view should filter out extra spaces from maildat
     model: default.vw_pin_address
     given:
+      # This is the only table that matters; everything else is just necessary
+      # to build the view properly
       - input: source("iasworld", "maildat")
         rows:
           - parid: "00000000000000"
@@ -104,6 +106,8 @@ unit_tests:
           - {parid: "00000000000000", taxyr: "2024", cur: "Y", deactivat: null}
       - input: source("iasworld", "owndat")
         rows: *bad-address-pin-row
+      - input: source("ccao", "hidename")
+        rows: []
     expect:
       rows:
         - {mail_address_name: "FOO BAR BAZ", mail_address_full: "123 S MAIN ST"}
@@ -111,6 +115,8 @@ unit_tests:
     description: view should filter for only 14-digit numeric PINs
     model: default.vw_pin_address
     given:
+      # This is the only table that matters; everything else is just necessary
+      # to build the view properly
       - input: source("iasworld", "pardat")
         rows:
           # `parid` is the important column here, and all other columns are
@@ -127,6 +133,8 @@ unit_tests:
         rows: *invalid-pin-rows
       - input: source("iasworld", "maildat")
         rows: *invalid-pin-rows
+      - input: source("ccao", "hidename")
+        rows: []
     expect:
       rows:
         - {pin: "00000000000000"}

--- a/dbt/models/default/schema/default.vw_pin_value.yml
+++ b/dbt/models/default/schema/default.vw_pin_value.yml
@@ -250,6 +250,9 @@ unit_tests:
       - input: ref("ccao.vw_time_util")
         rows:
           - {date_today: "2024-01-01"}
+      - input: source("iasworld", "pardat")
+        rows:
+          - {parid: "123", taxyr: "2024", cur: "Y"}
     expect:
       rows:
         - {mailed_class: "211A"}
@@ -287,6 +290,13 @@ unit_tests:
           # reference to the current year could become out of date with this
           # test
           - {date_today: "2024-01-01"}
+      - input: source("iasworld", "pardat")
+        rows:
+          - {parid: "pre-mailed", taxyr: "2024", cur: "Y"}
+          - {parid: "mailed", taxyr: "2024", cur: "Y"}
+          - {parid: "pre-certified", taxyr: "2024", cur: "Y"}
+          - {parid: "ccao-certified", taxyr: "2024", cur: "Y"}
+          - {parid: "bor-certified", taxyr: "2024", cur: "Y"}
     expect:
       rows:
         - {stage_name: "PRE-MAILED"}


### PR DESCRIPTION
A number of our unit tests [errored out during our weekly data integrity tests](https://github.com/ccao-data/data-architecture/actions/runs/28790835189/job/85368746947#step:7:788) because their test definitions were missing some source tables that are required to build the underlying view. Here's an example error:

```
Unit_Test 'unit_test.ccao_data_athena.default.vw_pin_address.default_vw_pin_address_filters_extra_spaces_from_maildat' (models/default/schema/default.vw_pin_address.yml) depends on a source named 'ccao.hidename' which was not found
```

These errors are only just now getting surfaced because our CI workflows were not properly running unit tests until https://github.com/ccao-data/data-architecture/pull/1053 landed last week. Yesterday's `test-dbt-models` run was the first scheduled run since that PR landed.

This PR tweaks the failing unit tests to ensure that all source tables for the underlying views are properly configured in the test definition.

See the [`build-and-test-dbt` workflow logs](https://github.com/ccao-data/data-architecture/actions/runs/28899307049/job/85733338814) for proof that these tests pass now.