### PR TITLE
Increase open data refresh cadence

### DIFF
--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -3,7 +3,7 @@ exposures:
     label: Appeals
     type: dashboard
     tags:
-      - monthly
+      - semimonthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Appeals/y282-6ig3
     depends_on:
       - ref('open_data.vw_appeal')
@@ -55,7 +55,7 @@ exposures:
     label: Parcel Addresses
     type: dashboard
     tags:
-      - monthly
+      - semimonthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Parcel-Addresses/3723-97qp
     depends_on:
       - ref('open_data.vw_parcel_address')
@@ -106,7 +106,7 @@ exposures:
     label: Parcel Sales
     type: dashboard
     tags:
-      - monthly
+      - semimonthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Parcel-Sales/wvhk-k5uv
     depends_on:
       - ref('open_data.vw_parcel_sale')
@@ -152,7 +152,7 @@ exposures:
     label: Parcel Universe (Current Year Only)
     type: dashboard
     tags:
-      - monthly
+      - semimonthly
     url: https://datacatalog.cookcountyil.gov/dataset/Assessor-Parcel-Universe-Current-Year-/pabr-t5kh
     depends_on:
       - ref('open_data.vw_parcel_universe_current')
@@ -176,7 +176,7 @@ exposures:
     label: Parcel Universe (Historic)
     type: dashboard
     tags:
-      - monthly
+      - semimonthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Parcel-Universe/nj4t-kc8j
     depends_on:
       - ref('open_data.vw_parcel_universe_historical')
@@ -200,7 +200,7 @@ exposures:
     label: Permits
     type: dashboard
     tags:
-      - monthly
+      - semimonthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Permits/6yjf-dfxs
     depends_on:
       - ref('open_data.vw_permit')
@@ -223,7 +223,7 @@ exposures:
     label: Property Tax-Exempt Parcels
     type: dashboard
     tags:
-      - monthly
+      - semimonthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Property-Tax-Exempt-Parcels/vgzx-68gb
     depends_on:
       - ref('open_data.vw_property_tax_exempt_parcel')
@@ -249,7 +249,7 @@ exposures:
     type: dashboard
     tags:
       - type_condo
-      - monthly
+      - semimonthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Residential-Condominium-Unit-Characteri/3r7i-mrz4
     depends_on:
       - ref('open_data.vw_res_condo_unit_char')
@@ -276,7 +276,7 @@ exposures:
     type: dashboard
     tags:
       - type_res
-      - monthly
+      - semimonthly
     url: https://datacatalog.cookcountyil.gov/Property-Taxation/Assessor-Single-and-Multi-Family-Improvement-Chara/x54s-btds
     depends_on:
       - ref('open_data.vw_sf_mf_improvement_char')


### PR DESCRIPTION
This PR moves all open data assets that were previously on a monthly update cadence to a semimonthly cadence, per an offline conversation. I will update the metadata for the open data assets once this PR is merged.