### PR TITLE
Fix permits open data asset date filtering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
     hooks:
       - id: check-sort-dbt-yaml-files
         name: check-sort-dbt-yaml-files
-        entry: python3 dbt/scripts/check_sort_dbt_yaml_files.py
+        entry: python dbt/scripts/check_sort_dbt_yaml_files.py
         language: system
         types_or: [yaml, markdown]
         files: ^dbt/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
     hooks:
       - id: check-sort-dbt-yaml-files
         name: check-sort-dbt-yaml-files
-        entry: python dbt/scripts/check_sort_dbt_yaml_files.py
+        entry: python3 dbt/scripts/check_sort_dbt_yaml_files.py
         language: system
         types_or: [yaml, markdown]
         files: ^dbt/

--- a/dbt/models/open_data/exposures.yml
+++ b/dbt/models/open_data/exposures.yml
@@ -214,7 +214,7 @@ exposures:
         - pin
         - permit_number
         - date_issued
-      years_active: 1
+      years_active: 5
     description: |
       Building permits organized by PIN, with extra metadata recorded by CCAO
       permit specialists during the permit processing workflow.


### PR DESCRIPTION
We currently only refresh the most current year of the permits asset on the open data portal, defined as the year the permit was issued. Using this field to determine which rows need to be refreshed or uploaded can lead to permits that were issued for prior years but submitted more recently to be missed. This PR adjusts our upload script to look back through permits with a date issued within the last 5 years (rather than 1) to help alleviate this issue.

I can't really test this workflow with the new value since the `years_active` field is only used for scheduled runs, but it's been working without issue for a while now and we can wait till 8/1 to see if this upload goes as planned (I _could_ force it locally, but that wouldn't really be testing the same thing).