### PR TITLE
Upgrade R pre-commit hooks

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -2,6 +2,7 @@ linters: linters_with_defaults(
     object_length_linter = NULL,
     object_name_linter = NULL,
     object_usage_linter = NULL,
-    return_linter = NULL
+    return_linter = NULL,
+    pipe_consistency_linter = pipe_consistency_linter(c("auto"))
   )
 encoding: "UTF-8"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       # Formatter
       - id: ruff-format
   - repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.3.9014
+    rev: 2e05db3fea9db1e0a8e3c84540219c7e0a0915ff # v0.4.3.9030
     hooks:
       - id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]

--- a/etl/scripts-ccao-data-raw-us-east-1/spatial/spatial-kriging_surfaces.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/spatial/spatial-kriging_surfaces.R
@@ -48,8 +48,6 @@ ohare_noise$geometry <- st_as_sfc(ohare_noise$geometry, crs = 3435)
 ohare_noise <- st_as_sf(ohare_noise)
 
 
-
-
 ohare_contour <- dbGetQuery(
   conn = AWS_ATHENA_CONN_NOCTUA,
   "SELECT airport, ST_GeomFromBinary(geometry) as geometry
@@ -60,7 +58,6 @@ ohare_contour$geometry <- st_as_sfc(ohare_contour$geometry)
 ohare_contour <- st_as_sf(ohare_contour)
 ohare_contour <- st_set_crs(ohare_contour, 4326)
 ohare_contour <- st_transform(ohare_contour, 3435)
-
 
 
 # Check we read correctly:
@@ -133,7 +130,6 @@ airport_clean <- airport %>%
   summarize(noise = mean(noise, na.rm = TRUE))
 
 
-
 # Create new dataset with Airports included:
 ohare <- c(
   site = "ohare",
@@ -153,7 +149,6 @@ aps <- st_set_crs(aps, 4326)
 aps <- st_transform(aps, 3435)
 
 airport_boost <- rbind(airport_clean, aps)
-
 
 
 # Create new dataset with boundaries as quiet (50!)
@@ -190,7 +185,6 @@ airport_extra_boost <- airport_extra_boost %>%
   slice(-c(57, 66))
 
 
-
 # Add coordinates explicitly:
 airport_clean$X <- st_coordinates(st_as_sf(airport_clean))[, 1]
 airport_clean$Y <- st_coordinates(airport_clean)[, 2]
@@ -209,9 +203,7 @@ raster_mdw <- stars::st_as_stars(midway_bbox, dx = 1000)
 rasters <- stars::st_mosaic(raster_ohare, raster_mdw)
 
 
-
 ## PART 2: BUILD SURFACES AND TEST HOW GOOD THEY ARE ====================
-
 
 
 plot_surface <- function(data) {
@@ -719,8 +711,6 @@ airport_final <- unique(airport_final)
 airport_final <- mutate(airport_final, noise = as.numeric(noise))
 
 
-
-
 # Create surface for it:
 v <- variogram(noise ~ 1, airport_final, cutoff = 200000, width = 500)
 
@@ -803,7 +793,6 @@ lapply(years_low, spatial_join_raster_pin)
 lapply(years, spatial_join_raster_pin)
 
 
-
 # Same code as above but for new year:
 year <- "2021"
 raster_location <- str_c("output/kriging_surfaces/rasters/", "omp_19.tif")
@@ -813,7 +802,6 @@ print("read raster")
 
 parcel_query_string <- str_c("Select pin10, x_3435, y_3435 FROM spatial.parcel
   Where year = ", "'", year, "'")
-
 
 
 parcels <- dbGetQuery(
@@ -850,7 +838,6 @@ write.csv(parcels_spj, file_name)
 print("wrote")
 
 
-
 # Calculate aggregate stats of parcels by DNL:
 ag_stats_parcels_21 <- parcels_spj %>%
   mutate(sound_bin = cut(noise,
@@ -876,7 +863,6 @@ ag_stats_parcels_21 <- cbind(ag_stats_parcels_21, DNL) %>%
   select(DNL, count, percent)
 
 write.csv(ag_stats_parcels_21, "exposure_DNL_21.csv")
-
 
 
 # Reading:

--- a/etl/scripts-ccao-data-raw-us-east-1/spatial/spatial-kriging_surfaces.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/spatial/spatial-kriging_surfaces.R
@@ -482,7 +482,6 @@ krige_tune_hyper <- function(data,
     print(i)
 
 
-
     out <- compute_krige_rmse(data,
       target_var,
       formula_list[i],
@@ -749,7 +748,6 @@ spatial_join_raster_pin <- function(year) {
   print(year)
 
 
-
   # raster_location <- str_c("output/kriging_surfaces/rasters/", year, ".tif") # nolint
   # raster_file <- read_stars(raster_location) # nolint
   ind <- as.numeric(year) - 2009
@@ -761,7 +759,6 @@ spatial_join_raster_pin <- function(year) {
 
   parcel_query_string <- str_c("Select pin10, x_3435, y_3435 FROM spatial.parcel
     Where year = ", "'", year, "'")
-
 
 
   parcels <- dbGetQuery(

--- a/etl/scripts-ccao-data-raw-us-east-1/spatial/spatial-school.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/spatial/spatial-school.R
@@ -290,7 +290,6 @@ pwalk(sources_list, function(...) {
 file_path <- "//gisemcv1.ccounty.com/ArchiveServices"
 
 crossing(
-
   # Paths for all relevant geodatabases
   data.frame("path" = list.files(file_path, full.names = TRUE)) %>%
     filter(

--- a/etl/scripts-ccao-data-raw-us-east-1/spatial/spatial-tax.R
+++ b/etl/scripts-ccao-data-raw-us-east-1/spatial/spatial-tax.R
@@ -19,7 +19,6 @@ file_path <- "//gisemcv1.ccounty.com/ArchiveServices"
 
 # Tax districts
 crossing(
-
   # Paths for all relevant geodatabases
   data.frame("path" = list.files(file_path, full.names = TRUE)) %>%
     filter(

--- a/etl/scripts-ccao-data-warehouse-us-east-1/census/census-acs.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/census/census-acs.R
@@ -101,7 +101,8 @@ all_combos <- expand.grid(
 # Function to loop through rows in all_combos, grab census data,
 # and write it to a parquet file on S3 if it doesn't already exist
 pull_and_write_acs <- function(
-    s3_bucket_uri, survey, folder, geography, year, tables = census_tables) {
+  s3_bucket_uri, survey, folder, geography, year, tables = census_tables
+) {
   remote_file <- file.path(
     s3_bucket_uri, survey,
     paste0("geography=", folder),

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-access.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-access.R
@@ -146,8 +146,6 @@ walk(remote_files_park_warehouse, function(x) {
 })
 
 
-
-
 ##### INDUSTRIAL CORRIDOR #####
 remote_file_indc_raw <- file.path(
   input_bucket, "industrial_corridor", "2013.geojson"

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-ccao-township.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-ccao-township.R
@@ -25,7 +25,6 @@ remote_file_town_warehouse <- file.path(
 )
 
 
-
 if (!aws.s3::object_exists(remote_file_town_warehouse)) {
   tmp_file_town <- tempfile(fileext = ".geojson")
   aws.s3::save_object(remote_file_town_raw, file = tmp_file_town)

--- a/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-school.R
+++ b/etl/scripts-ccao-data-warehouse-us-east-1/spatial/spatial-school.R
@@ -36,7 +36,8 @@ census_district_files_df <- aws.s3::get_bucket_df(
 
 # Clean up and merge non-CPS district files from different years
 process_census_district_file <- function(
-    s3_bucket_uri, file_year, uri, dist_type) {
+  s3_bucket_uri, file_year, uri, dist_type
+) {
   # Download S3 files to local temp dir if they don't exist
   tmp_file_local <- file.path(
     school_tmp_dir,
@@ -120,7 +121,8 @@ county_district_files_df <- aws.s3::get_bucket_df(
 
 # Clean up and merge non-CPS district files from different years
 process_county_district_file <- function(
-    s3_bucket_uri, file_year, uri, dist_type) {
+  s3_bucket_uri, file_year, uri, dist_type
+) {
   # Download S3 files to local temp dir if they don't exist
   tmp_file_local <- file.path(
     school_tmp_dir,

--- a/etl/utils.R
+++ b/etl/utils.R
@@ -93,7 +93,8 @@ write_partitions_to_s3 <- function(df,
 
 
 standardize_expand_geo <- function(
-    spatial_df, make_valid = FALSE, polygon = TRUE) {
+  spatial_df, make_valid = FALSE, polygon = TRUE
+) {
   return(
     spatial_df %>%
       st_transform(4326) %>%
@@ -121,11 +122,12 @@ standardize_expand_geo <- function(
 }
 
 county_gdb_to_s3 <- function(
-    s3_bucket_uri,
-    dir_name,
-    file_path,
-    layer,
-    overwrite = FALSE) {
+  s3_bucket_uri,
+  dir_name,
+  file_path,
+  layer,
+  overwrite = FALSE
+) {
   remote_file <- file.path(
     s3_bucket_uri,
     dir_name,


### PR DESCRIPTION
Now that our server and laptops are running R 4.6, we need to update our R pre-commit hooks to the latest version.

I'm also taking this opportunity to start pinning our pre-commit dependencies to immutable releases or commit hashes, for better security.