### PR TITLE
Adjust dbt docs and models to handle new CofE hearing type

### DIFF
--- a/dbt/models/open_data/open_data.vw_appeal.sql
+++ b/dbt/models/open_data/open_data.vw_appeal.sql
@@ -18,8 +18,16 @@ SELECT
     CASE WHEN hearing_type = '1' THEN 'Assessor recommendation'
         WHEN hearing_type = '2' THEN 'Certificate of correction'
         WHEN hearing_type = 'A' THEN 'Current year appeal'
-        WHEN hearing_type = 'C' THEN 'Current appeal & certificate of error'
-        WHEN hearing_type = 'E' THEN 'Certificate of error only'
+        WHEN
+            hearing_type = 'C'
+            THEN 'Current year appeal & prior year(s) certificate of error'
+        WHEN hearing_type = 'D' THEN 'Certificate of error only'
+        WHEN
+            hearing_type = 'E' AND year >= '2026'
+            THEN 'Determinations for C and D records'
+        WHEN
+            hearing_type = 'E' AND year <= '2025'
+            THEN 'Certificate of error only'
         WHEN
             hearing_type = 'F'
             THEN 'Smartfile exemption certificate of error filing'

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -242,8 +242,9 @@ Possible values for this variable are:
 - `1` = Assessor recommendation
 - `2` = Certificate of correction
 - `A` = Current year appeal
-- `C` = Current appeal & certificate of error
-- `E` = Certificate of error only
+- `C` = Current year appeal & prior year(s) certificate of error
+- `D` = ***2026 and later:*** Certificate of error only
+- `E` = ***2026 and later:*** Determinations for C and D records | ***2025 and earlier:*** Certificate of error only
 - `F` = Smartfile exemption certificate of error filing
 - `O` = Omitted assessment
 - `R` = Re-review
@@ -1530,7 +1531,7 @@ Type of valuation model run. Possible values are:
 - `baseline`: A model run that we use to compare alternative model runs
   (i.e. `candidate` runs) in a given assessment year. The baseline model run
   usually has the same features and parameters as the prior assessment year,
-  but with updated data for the current assessment year. 
+  but with updated data for the current assessment year.
 - `candidate`: A model run that we are evaluating as a potential `final` run
   for an assessment year. We compare this type of model run against the
   `baseline` model run to find one winning model. Winners get retagged as


### PR DESCRIPTION
This PR updates the descriptions for `iasworld.htpar.heartyp` which was recently changed. It also updates the open data appeals view to incorporate this change, though that view shouldn't actually include `heartyp = D` or `heartyp = E`. That asset should be updated if we accept the new description I've included for `heartyp = C`.

<img width="761" height="150" alt="image" src="https://github.com/user-attachments/assets/7089cccb-f810-4531-91e7-81c0452aa74a" />

I'm totally open to changing how this information is presented.