### PR TITLE
Refine stage-level class for ratio stats view

### DIFF
--- a/dbt/models/reporting/reporting.ratio_stats_input.sql
+++ b/dbt/models/reporting/reporting.ratio_stats_input.sql
@@ -78,4 +78,5 @@ WHERE NOT vwps.is_multisale
     AND NOT vwps.sale_filter_less_than_10k
     AND NOT vwps.sale_filter_same_sale_within_365
     AND cls.modeling_group IS NOT NULL
+    -- hug
     AND ps.pin IS NULL

--- a/dbt/models/reporting/reporting.ratio_stats_input.sql
+++ b/dbt/models/reporting/reporting.ratio_stats_input.sql
@@ -67,7 +67,6 @@ LEFT JOIN {{ source('spatial', 'township') }} AS towns
 INNER JOIN all_values AS av
     ON vwps.pin = av.pin
     AND CAST(vwps.year AS INT) = CAST(av.year AS INT) - 1
-    AND av.total > 0
 LEFT JOIN {{ ref('ccao.class_dict') }} AS cls
     ON av.class = cls.class_code
 -- Grab parking spaces and join them to aggregate stats for removal
@@ -81,3 +80,4 @@ WHERE NOT vwps.is_multisale
     AND NOT vwps.sale_filter_same_sale_within_365
     AND cls.modeling_group IS NOT NULL
     AND ps.pin IS NULL
+    AND av.total > 0

--- a/dbt/models/reporting/reporting.ratio_stats_input.sql
+++ b/dbt/models/reporting/reporting.ratio_stats_input.sql
@@ -78,5 +78,4 @@ WHERE NOT vwps.is_multisale
     AND NOT vwps.sale_filter_less_than_10k
     AND NOT vwps.sale_filter_same_sale_within_365
     AND cls.modeling_group IS NOT NULL
-    -- hug
     AND ps.pin IS NULL

--- a/dbt/models/reporting/reporting.ratio_stats_input.sql
+++ b/dbt/models/reporting/reporting.ratio_stats_input.sql
@@ -67,7 +67,8 @@ LEFT JOIN {{ source('spatial', 'township') }} AS towns
 INNER JOIN all_values AS av
     ON vwps.pin = av.pin
     AND CAST(vwps.year AS INT) = CAST(av.year AS INT) - 1
-    --AND av.total > 0
+    -- Remove NULL and zero FMVs
+    AND av.total > 0
 LEFT JOIN {{ ref('ccao.class_dict') }} AS cls
     ON av.class = cls.class_code
 -- Grab parking spaces and join them to aggregate stats for removal

--- a/dbt/models/reporting/reporting.ratio_stats_input.sql
+++ b/dbt/models/reporting/reporting.ratio_stats_input.sql
@@ -51,6 +51,7 @@ SELECT
     vwps.pin,
     av.year,
     vwps.year AS sale_year,
+    av.class,
     cls.modeling_group AS property_group,
     av.assessment_stage,
     towns.triad_code AS triad,

--- a/dbt/models/reporting/reporting.ratio_stats_input.sql
+++ b/dbt/models/reporting/reporting.ratio_stats_input.sql
@@ -51,22 +51,23 @@ SELECT
     vwps.pin,
     av.year,
     vwps.year AS sale_year,
-    towns.property_group,
+    cls.modeling_group AS property_group,
     av.assessment_stage,
     towns.triad_code AS triad,
-    towns.township_code,
+    vwps.township_code,
     av.total AS fmv,
     vwps.sale_price,
     av.total / vwps.sale_price AS ratio
 FROM {{ ref('default.vw_pin_sale') }} AS vwps
-LEFT JOIN {{ ref('reporting.vw_pin_township_class') }} AS towns
-    ON vwps.pin = towns.pin
-    AND vwps.year = towns.year
+LEFT JOIN {{ source('spatial', 'township') }} AS towns
+    ON vwps.township_code = towns.township_code
     -- Join sales so that values for a given year can be compared to a
     -- complete set of sales from the previous year
 INNER JOIN all_values AS av
     ON vwps.pin = av.pin
     AND CAST(vwps.year AS INT) = CAST(av.year AS INT) - 1
+LEFT JOIN {{ ref('ccao.class_dict') }} AS cls
+    ON av.class = cls.class_code
 -- Grab parking spaces and join them to aggregate stats for removal
 LEFT JOIN {{ ref('default.vw_pin_condo_char') }} AS ps
     ON av.pin = ps.pin
@@ -76,5 +77,5 @@ WHERE NOT vwps.is_multisale
     AND NOT vwps.sale_filter_deed_type
     AND NOT vwps.sale_filter_less_than_10k
     AND NOT vwps.sale_filter_same_sale_within_365
-    AND towns.property_group IS NOT NULL
+    AND cls.modeling_group IS NOT NULL
     AND ps.pin IS NULL

--- a/dbt/models/reporting/reporting.ratio_stats_input.sql
+++ b/dbt/models/reporting/reporting.ratio_stats_input.sql
@@ -66,6 +66,7 @@ LEFT JOIN {{ source('spatial', 'township') }} AS towns
 INNER JOIN all_values AS av
     ON vwps.pin = av.pin
     AND CAST(vwps.year AS INT) = CAST(av.year AS INT) - 1
+    AND av.total > 0
 LEFT JOIN {{ ref('ccao.class_dict') }} AS cls
     ON av.class = cls.class_code
 -- Grab parking spaces and join them to aggregate stats for removal

--- a/dbt/models/reporting/reporting.ratio_stats_input.sql
+++ b/dbt/models/reporting/reporting.ratio_stats_input.sql
@@ -67,6 +67,7 @@ LEFT JOIN {{ source('spatial', 'township') }} AS towns
 INNER JOIN all_values AS av
     ON vwps.pin = av.pin
     AND CAST(vwps.year AS INT) = CAST(av.year AS INT) - 1
+    --AND av.total > 0
 LEFT JOIN {{ ref('ccao.class_dict') }} AS cls
     ON av.class = cls.class_code
 -- Grab parking spaces and join them to aggregate stats for removal
@@ -80,4 +81,3 @@ WHERE NOT vwps.is_multisale
     AND NOT vwps.sale_filter_same_sale_within_365
     AND cls.modeling_group IS NOT NULL
     AND ps.pin IS NULL
-    AND av.total > 0

--- a/dbt/models/reporting/reporting.ratio_stats_input.sql
+++ b/dbt/models/reporting/reporting.ratio_stats_input.sql
@@ -51,7 +51,6 @@ SELECT
     vwps.pin,
     av.year,
     vwps.year AS sale_year,
-    av.class,
     cls.modeling_group AS property_group,
     av.assessment_stage,
     towns.triad_code AS triad,

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -34,9 +34,17 @@ models:
     data_tests:
       - expression_is_true:
           name: reporting_ratio_stats_metrics_are_sensible
-          # pre-mailed values exhibit variance that makes applying the same prb
-          # constraints as other assessment stages trigger a test failure too
-          # often to be helpful
+          # There are two important nuances regarding the PRB condition:
+          #
+          #   1. Pre-mailed values exhibit variance that makes applying the same
+          #      PRB constraints as other assessment stages trigger a test
+          #      failure too often to be helpful, so we exclude pre-mailed
+          #      values from the condition
+          #   2. There is no theoretical limit to PRB, but we set an arbitrary
+          #      error threshold at +-2 because we want to catch anomalous
+          #      values. We may need to extend this range in the future if we
+          #      see valid PRBs lower than the lower bound, or higher than the
+          #      upper bound
           expression: |
             cod >= 0
             AND prd >= 0

--- a/dbt/models/reporting/schema.yml
+++ b/dbt/models/reporting/schema.yml
@@ -40,7 +40,7 @@ models:
           expression: |
             cod >= 0
             AND prd >= 0
-            AND (prb BETWEEN -1 AND 1 OR assessment_stage = 'pre-mailed')
+            AND (prb BETWEEN -2 AND 2 OR assessment_stage = 'pre-mailed')
             AND mki >= 0
             AND triad IS NOT NULL
             AND geography_type IS NOT NULL


### PR DESCRIPTION
Edit: well, this didn't end up fixing our PRBs. I was hoping the extreme ones were the results of our 0 ratios, but I guess that wasn't the case. [`reporting.ratio_stats`](https://github.com/ccao-data/data-architecture/blob/658011dbe6f99219a3f27c59228815753c96b7f6/dbt/models/reporting/reporting.ratio_stats.py#L208) was filtering these out from the calculations anyway. I'm not entirely convinced there's a strong mathematical reason to set thresholds of -1 and 1 for our prb being "sensible", though. It's quite possible with extreme outliers PRB can achieve these values since it isn't bounded like PRD is. I've increased these thresholds for now so they stop failing. I do think this PR still adds some valuable increases in resolution for our ratio stats, nonetheless.

I realize the queries and output below are convoluted, so don't hesitate to ask for clarification. @ccao-jardine the second query is the one you're probably most interested in.

We're getting some weird PRB values due to ratios with values of zero. I believe this is a product of FMVs that are zero in our input data. This was primarily the product of parcels switching classes between assessment stages and becoming exempt. Our table was not catching these changes since it didn't resolve assessment-stage-level classes. These zero FMVs screw can screw up our reporting and shouldn't be part of calculations.

After these changes, we're still seeing 20 parcels with modeling classes in 2026 with zero FMV for the pre-mailed stage. I've included them below, but removed them from the actual output of the table.

One last thing to note: there will no longer be rows in this feeder table that have null values for FMV in the modeling stage.

<details>
<summary>Check to make sure all rows that have been removed are not in a modeling group or have zero FMV:</summary>

```sql
-- Grab the rows that are no longer in the table
with removed as (
	select pin,
		year,
		assessment_stage,
		-- Check if any PINs in the old table are missing from the new one not
		-- not because of class but because they have 0 FMV
		fmv = 0 as zero_fmv
	from reporting.ratio_stats_input
	-- The new table is kicking all of these null FMVs out.
	where fmv is not null
	except
	select pin,
		year,
		assessment_stage,
		fmv = 0 as zero_fmv
	from z_ci_test_market_tracker_year_reporting.ratio_stats_input
) 
-- Count the rows that have been removed by class and modeling group
select vpvl.class,
	cls.modeling_group,
	zero_fmv,
	count(*) as sales
from removed as rmv
	left join reporting.vw_pin_value_long as vpvl on rmv.pin = vpvl.pin
	and rmv.year = vpvl.year
	and rmv.assessment_stage = lower(vpvl.stage_name)
	left join ccao.class_dict as cls on vpvl.class = cls.class_code
group by vpvl.class,
	cls.modeling_group,
	zero_fmv
```

| class | modeling_group | zero_fmv | sales |
|-------|----------------|----------|-------|
| 100   |                | false    |   920 |
| 190   |                | false    |     2 |
| 200   |                | false    |     3 |
| 201   |                | false    |    40 |
| 205   | SF             | true     |     2 |
| 213   |                | false    |     7 |
| 241   |                | false    |    54 |
| 290   |                | false    |     3 |
| 297   |                | false    |   229 |
| 315   |                | false    |    43 |
| 318   |                | false    |     3 |
| 391   |                | false    |     6 |
| 517   |                | false    |     3 |
| 590   |                | false    |     6 |
| 593   |                | false    |     3 |
| 597   |                | false    |     3 |
| 599   |                | false    |    12 |
| EX    |                | false    |     1 |
| EX    |                | true     |   536 |

</details>

<details>
<summary>Click to see a list of all pins with zero FMV despite being in a modeling group:</summary>

Note: We have to remove the av.total > 0 filter from the table to see these rows.

```sql
select rsi.pin,
	rsi.year,
	towns.township_name,
	rsi.class,
	rsi.fmv,
	rsi.sale_year,
	rsi.sale_price
from z_ci_test_market_tracker_year_reporting.ratio_stats_input as rsi
	-- Join on town names
	left join spatial.township as towns on rsi.township_code = towns.township_code
where fmv = 0
```

| pin            | year | township_name | class | fmv | sale_year | sale_price |
|----------------|------|---------------|-------|-----|-----------|------------|
| 25223190160000 | 2026 | Hyde Park     |   207 |   0 |      2025 |     230000 |
| 20243110230000 | 2026 | Hyde Park     |   204 |   0 |      2025 |     430000 |
| 20113190280000 | 2026 | Hyde Park     |   211 |   0 |      2025 |    1560000 |
| 20111160030000 | 2026 | Hyde Park     |   209 |   0 |      2025 |    1150000 |
| 20223030310000 | 2026 | Hyde Park     |   211 |   0 |      2025 |      72000 |
| 20272040250000 | 2026 | Hyde Park     |   205 |   0 |      2025 |      27501 |
| 20151190260000 | 2026 | Hyde Park     |   211 |   0 |      2025 |    1016500 |
| 20222300330000 | 2026 | Hyde Park     |   211 |   0 |      2025 |      30000 |
| 20033220070000 | 2026 | Hyde Park     |   211 |   0 |      2025 |      45000 |
| 20111100230000 | 2026 | Hyde Park     |   206 |   0 |      2025 |    1300000 |
| 26182110500000 | 2026 | Hyde Park     |   207 |   0 |      2025 |      60000 |
| 20103110180000 | 2026 | Hyde Park     |   211 |   0 |      2025 |      50000 |
| 20234120470000 | 2026 | Hyde Park     |   211 |   0 |      2025 |      60000 |
| 25294040630000 | 2026 | Calumet       |   205 |   0 |      2025 |     215000 |
| 25223140190000 | 2026 | Hyde Park     |   207 |   0 |      2025 |      26382 |
| 25293050500000 | 2026 | Calumet       |   202 |   0 |      2025 |     240000 |
| 25223190150000 | 2026 | Hyde Park     |   207 |   0 |      2025 |     230000 |
| 25104060400000 | 2026 | Hyde Park     |   206 |   0 |      2025 |      60000 |
| 25294110490000 | 2026 | Calumet       |   205 |   0 |      2025 |     185000 |
| 20272140240000 | 2026 | Hyde Park     |   205 |   0 |      2025 |      61000 |
</details>

<details>
<summary>There were a lot of rows for the modeling stage with no FMV that no longer make it into the new table:</summary>

```sql
select assessment_stage,
	count(*)
from reporting.ratio_stats_input
where fmv is null
group by assessment_stage
```

| assessment_stage | col1  |
|------------------|-------|
| model            | 54120 |

</details>

<details>
<summary>Make sure there aren't any drastic differnces between reporting groups across the new and old tables:</summary>

```sql
with hugs as (
	select distinct 'new' as source,
		year,
		assessment_stage,
		geography_id
	from z_ci_test_market_tracker_year_reporting.ratio_stats
	union all
	select distinct 'old' as source,
		year,
		assessment_stage,
		geography_id
	from reporting.ratio_stats
)
select source,
	count(*) as rows
from hugs
group by source
```

| source | rows |
|--------|------|
| new    |  884 |
| old    |  882 |

</details>