### PR TITLE
Address docs drift by removing some stale columns

### DIFF
--- a/dbt/models/default/schema/default.vw_pin_sale.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale.yml
@@ -82,7 +82,7 @@ models:
           this being 0.
       - name: mydec_line_9_other_change
         description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
-      - name: mydec_line_9_other_description
+      - name: mydec_line_9_other_change_description
         description: This field describes the work done from mydec_line_9_other_change.
       - name: nbhd
         description: '{{ doc("shared_column_nbhd_code") }}'
@@ -92,8 +92,6 @@ models:
         description: '{{ doc("shared_column_outlier_reason") }}'
       - name: pin
         description: '{{ doc("shared_column_pin") }}'
-      - name: requires_field_check
-        description: '{{ doc("shared_column_requires_field_check") }}'
       - name: review_has_characteristic_change
         description: '{{ doc("shared_column_has_characteristic_change") }}'
       - name: review_has_class_change

--- a/dbt/models/default/schema/default.vw_pin_sale_combined.yml
+++ b/dbt/models/default/schema/default.vw_pin_sale_combined.yml
@@ -51,7 +51,7 @@ models:
           this being 0.
       - name: mydec_line_9_other_change
         description: Binary indicator on the ptax-203 form. A subsection of a question about significant physical changes to the property.
-      - name: mydec_line_9_other_description
+      - name: mydec_line_9_other_change_description
         description: This field describes the work done from mydec_line_9_other_change.
       - name: nbhd
         description: '{{ doc("shared_column_nbhd_code") }}'

--- a/dbt/models/iasworld/schema/iasworld.htagnt.yml
+++ b/dbt/models/iasworld/schema/iasworld.htagnt.yml
@@ -68,7 +68,7 @@ sources:
           - name: loaded_at
             description: '{{ doc("shared_column_loaded_at") }}'
           - name: name1
-            description: Name line 1
+            description: '{{ doc("shared_column_agent_name") }}'
           - name: name1_companyname
             description: Agent 1 company name
           - name: name1_firstname

--- a/dbt/models/iasworld/schema/iasworld.htpar.yml
+++ b/dbt/models/iasworld/schema/iasworld.htpar.yml
@@ -132,8 +132,6 @@ sources:
             description: '{{ doc("shared_column_loaded_at") }}'
           - name: loc
             description: Location code
-          - name: name1
-            description: '{{ doc("shared_column_agent_name") }}'
           - name: notcdate
             description: Date of notice from previous hearing level
           - name: noticedate

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -240,8 +240,8 @@ models:
         description: '{{ doc("shared_column_year") }}'
       - name: run_id
         description: '{{ doc("shared_column_run_id") }}'
-      - name: triad_name
-        description: '{{ doc("shared_column_triad_name") }}'
+      - name: triad_code
+        description: '{{ doc("shared_column_triad_code") }}'
       - name: type
         description: Model type (residential or condo)
       - name: is_final
@@ -583,12 +583,6 @@ models:
       - &other_ihs_avg_year_index
         name: other_ihs_avg_year_index
         description: '{{ doc("shared_column_ihs_avg_year_index") }}'
-      - &other_ari
-        name: other_ari
-        description: '{{ doc("shared_column_ari") }}'
-      - &other_dci
-        name: other_dci
-        description: '{{ doc("shared_column_dci") }}'
       - &other_school_district_elementary_avg_rating
         name: other_school_district_elementary_avg_rating
         description: '{{ doc("shared_column_school_district_elementary_avg_rating") }}'
@@ -837,8 +831,6 @@ models:
       - *meta_triad_name
       - *meta_year
       - *other_ihs_avg_year_index
-      - *other_dci
-      - *other_ari
       - *other_school_district_elementary_avg_rating
       - *other_school_district_secondary_avg_rating
       - *other_tax_bill_amount_total
@@ -1105,8 +1097,6 @@ models:
       - *meta_triad_name
       - *meta_year
       - *other_ihs_avg_year_index
-      - *other_dci
-      - *other_ari
       - *other_school_district_elementary_avg_rating
       - *other_school_district_secondary_avg_rating
       - *other_tax_bill_amount_total

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -580,6 +580,12 @@ models:
       - &nearest_neighbor_3_pin10
         name: nearest_neighbor_3_pin10
         description: '{{ doc("column_nearest_neighbor_pin10") }}'
+      - &other_affordability_risk_index
+        name: other_affordability_risk_index
+        description: '{{ doc("shared_column_ari") }}'
+      - &other_distressed_community_index
+        name: other_distressed_community_index
+        description: '{{ doc("shared_column_dci") }}'
       - &other_ihs_avg_year_index
         name: other_ihs_avg_year_index
         description: '{{ doc("shared_column_ihs_avg_year_index") }}'
@@ -830,6 +836,8 @@ models:
       - *meta_triad_code
       - *meta_triad_name
       - *meta_year
+      - *other_affordability_risk_index
+      - *other_distressed_community_index
       - *other_ihs_avg_year_index
       - *other_school_district_elementary_avg_rating
       - *other_school_district_secondary_avg_rating
@@ -1096,6 +1104,8 @@ models:
       - *meta_triad_code
       - *meta_triad_name
       - *meta_year
+      - *other_affordability_risk_index
+      - *other_distressed_community_index
       - *other_ihs_avg_year_index
       - *other_school_district_elementary_avg_rating
       - *other_school_district_secondary_avg_rating

--- a/dbt/models/other/schema.yml
+++ b/dbt/models/other/schema.yml
@@ -50,6 +50,9 @@ sources:
 
       - name: dci
         description: '{{ doc("table_dci") }}'
+        columns:
+          - name: dci
+            description: '{{ doc("shared_column_dci") }}'
         data_tests:
           - unique_combination_of_columns:
               name: other_dci_unique_by_year_and_geoid
@@ -61,6 +64,9 @@ sources:
 
       - name: ari
         description: '{{ doc("table_ari") }}'
+        columns:
+          - name: ari_score
+            description: '{{ doc("shared_column_ari") }}'
         data_tests:
           - unique_combination_of_columns:
               name: other_ari_unique_by_geoid_and_year

--- a/dbt/models/sale/columns.md
+++ b/dbt/models/sale/columns.md
@@ -1,4 +1,16 @@
+## earliest_data_ingest
+
+{% docs column_earliest_data_ingest %}
+Date of earliest sale used in validation.
+
+This range is inclusive of the rolling window period used for calculating
+statistical groups. In other words, if the earliest sale to-be-flagged is
+2013-12-01 and the rolling window period is 9 months, then the earliest sale
+*used* (i.e. the `earliest_data_ingest`) would be 2013-03-01.
+{% enddocs %}
+
 ## group_id
+
 {% docs column_group_id %}
 Group string used as a unique identifier.
 
@@ -9,23 +21,128 @@ Typically a combination of a:
 {% enddocs %}
 
 ## group_size
+
 {% docs column_group_size %}
 Count of sales/properties in the group.
-This is the population within which price statistics (e.g., standard deviation) are calculated.
+
+This is the population within which price statistics (e.g., standard deviation)
+are calculated.
+{% enddocs %}
+
+## housing_market_class_codes
+
+{% docs column_housing_market_class_codes %}
+List of class codes that define each housing market type
+{% enddocs %}
+
+## iso_forest_cols
+
+{% docs column_iso_forest_cols %}
+Columns used as features in the isolation forest model
+{% enddocs %}
+
+## latest_data_ingest
+
+{% docs column_latest_data_ingest %}
+Date of latest sale used in validation
 {% enddocs %}
 
 ## min_group_thresh
+
 {% docs column_min_group_thresh %}
 Minimum number of sales required for statistical flagging.
 
-If a group’s `group_size` is below this threshold, the sale is not flagged (set to “Not outlier”).  
-**Caveat:** Sales with certain PTAX-203 line-10 items marked may still be classified as outliers.
+If a group’s `group_size` is below this threshold, the sale is not flagged
+(set to “Not outlier”).
+
+**Caveat:** Sales with certain PTAX-203 line-10 items marked may still be
+classified as outliers.
+{% enddocs %}
+
+## raw_price_threshold
+
+{% docs column_raw_price_threshold %}
+Upper bound price beyond which all sales are flagged as outliers
+{% enddocs %}
+
+## requires_field_check
+
+{% docs column_requires_field_check %}
+Analyst determination on whether we need to send someone from the office out
+to collect further information.
+
+True in this column suggests that the analyst believes there has been completed
+work on the home.
 {% enddocs %}
 
 ## rolling_window
+
 {% docs column_rolling_window %}
 Rolling window period used to compute grouping statistics for sale flagging.
 
 Defined as *N* months prior, **inclusive of the month of the sale**.  
 As of Sep 2024, this is approximately 12 months (sale month + prior 11 months).
+{% enddocs %}
+
+## run_filter
+
+{% docs column_run_filter %}
+Filters that defined the sales that this run considered for flagging, e.g.
+housing market type and/or triad
+{% enddocs %}
+
+## sales_flagged
+
+{% docs column_sales_flagged %}
+Total number of sales flagged.
+
+Inclusive of both sales flagged as outliers *and* sales flagged as non-outliers.
+{% enddocs %}
+
+## sales_to_write_filter
+
+{% docs column_sales_to_write_filter %}
+Optional filter that determines which sales to write.
+
+Any sales that match `run_filter` but not this filter will still get flagged,
+but those flags will not get written to the database.
+{% enddocs %}
+
+## short_term_owner_threshold
+
+{% docs column_short_term_owner_threshold %}
+Properties with a significant price change and multiple sales within this time
+duration (in days) are flagged
+{% enddocs %}
+
+## standard_deviation_bounds
+
+{% docs column_standard_deviation_bounds %}
+Boundaries for standard deviation flagging.
+
+Sales with prices beyond these boundaries are flagged.
+
+There are two types of bounds:
+
+- `standard_bounds`: The default bounds
+- `ptax_bounds`: Bounds used specifically for sales that have a PTAX-203 flag,
+  typically a narrower range than `standard_bounds` because these sales are
+  more likely to be outliers
+{% enddocs %}
+
+## stat_groups
+
+{% docs column_stat_groups %}
+Groups used to calculate flagging statistics (std. dev.), keyed by triad name
+and housing market type (res or condo)
+{% enddocs %}
+
+## time_frame
+
+{% docs column_time_frame %}
+Start and end dates for the window of sales to flag.
+
+In contrast to `earliest_data_ingest`, which includes sales that are not up for
+flagging but are necessary to construct the rolling window, this date range
+only includes sales that are up for flagging.
 {% enddocs %}

--- a/dbt/models/sale/columns.md
+++ b/dbt/models/sale/columns.md
@@ -25,8 +25,8 @@ Typically a combination of a:
 {% docs column_group_size %}
 Count of sales/properties in the group.
 
-This is the population within which price statistics (e.g., standard deviation)
-are calculated.
+This is the number of observations in a population within which price statistics
+(e.g., standard deviation) are calculated.
 {% enddocs %}
 
 ## housing_market_class_codes
@@ -44,7 +44,7 @@ Columns used as features in the isolation forest model
 ## latest_data_ingest
 
 {% docs column_latest_data_ingest %}
-Date of latest sale used in validation
+Date of the latest sale pulled by the ingest query
 {% enddocs %}
 
 ## min_group_thresh
@@ -62,7 +62,8 @@ classified as outliers.
 ## raw_price_threshold
 
 {% docs column_raw_price_threshold %}
-Upper bound price beyond which all sales are flagged as outliers
+Upper bound price beyond which all sales are flagged as outliers, independent
+of any standard deviation or group size thresholds
 {% enddocs %}
 
 ## requires_field_check
@@ -111,8 +112,11 @@ but those flags will not get written to the database.
 ## short_term_owner_threshold
 
 {% docs column_short_term_owner_threshold %}
-Properties with a significant price change and multiple sales within this time
-duration (in days) are flagged
+Threshold that determines the number of days since a property's previous sale at
+which the seller is considered to be a "short-term owner".
+
+Sales under this threshold receive the "Short-term owner" characteristic reason
+in one of the `sv_outlier_reason` fields.
 {% enddocs %}
 
 ## standard_deviation_bounds

--- a/dbt/models/sale/schema.yml
+++ b/dbt/models/sale/schema.yml
@@ -9,7 +9,7 @@ sources:
         columns:
           - name: group
             description: '{{ doc("column_group_id") }}'
-          - name: meta_sale_document_number
+          - name: meta_sale_document_num
             description: '{{ doc("shared_column_document_number") }}'
           - name: ptax_flag_original
             description: |
@@ -66,7 +66,7 @@ sources:
           - name: loaded_at
             description: The time at which the data warehouse transformation script ran that produced the data.
           - name: requires_field_check
-            description: '{{ doc("shared_column_requires_field_check") }}'
+            description: '{{ doc("column_requires_field_check") }}'
           - name: source_file
             description: Name of the excel file the data was ingested from.
           - name: work_drawer
@@ -114,12 +114,16 @@ sources:
         columns:
           - name: group
             description: '{{ doc("column_group_id") }}'
+          - name: group_mean
+            description: Mean sale price of the group, in logged dollars
           - name: group_size
             description: '{{ doc("column_group_size") }}'
-          - name: mean_price
-            description: Mean price of the group, in FMV
-          - name: mean_price_per_sqft
-            description: Mean price per sqft (of building) of the group, in FMV
+          - name: group_sqft_mean
+            description: Mean building square footage of the group, logged
+          - name: group_sqft_std
+            description: Standard deviation of logged building square footage of the group
+          - name: group_std
+            description: Standard deviation of sale price of the group, in logged dollars
           - name: run_id
             description: '{{ doc("shared_column_sv_run_id") }}'
 
@@ -136,51 +140,36 @@ sources:
                 description: parameter is unique by run_id
 
         columns:
-          - name: condo_stat_groups
-            description: |
-              Groups used to calculate flagging statistics (std. dev.)
-              for condominium (class 299, 399) properties
-          - name: dev_bounds
-            description: |
-              Boundaries for standard deviation flagging.
-
-              Sales with prices beyond these boundaries are flagged.
           - name: earliest_data_ingest
-            description: |
-              Date of earliest sale used in validation.
-
-              This inclusive of the rolling window period used for
-              calculating statistical groups. In other words, if the earliest
-              sale to-be-flagged is 2013-12-01 and the rolling window period
-              is 9 months, then the earliest sale *used* would be 2013-03-01
+            description: '{{ doc("column_earliest_data_ingest") }}'
+          - name: housing_market_class_codes
+            description: '{{ doc("column_housing_market_class_codes") }}'
           - name: iso_forest_cols
-            description: Columns used as features in the isolation forest model
+            description: '{{ doc("column_iso_forest_cols") }}'
           - name: latest_data_ingest
-            description: Date of latest sale used in validation
+            description: '{{ doc("column_latest_data_ingest") }}'
           - name: min_group_thresh
             description: '{{ doc("column_min_group_thresh") }}'
-          - name: ptax_sd
-            description: |
-              Boundaries for standard deviation flagging in combination
-              with a PTAX-203 flag
-          - name: res_stat_groups
-            description: |
-              Groups used to calculate flagging statistics (std. dev.)
-              for residential (class 2) properties
+          - name: raw_price_threshold
+            description: '{{ doc("column_raw_price_threshold") }}'
           - name: rolling_window
             description: '{{ doc("column_rolling_window") }}'
+          - name: run_filter
+            description: '{{ doc("column_run_filter") }}'
           - name: run_id
             description: '{{ doc("shared_column_sv_run_id") }}'
           - name: sales_flagged
-            description: |
-              Total number of sales flagged.
-
-              Inclusive of both sales flagged as outliers *and* sales
-              flagged as non-outliers
+            description: '{{ doc("column_sales_flagged") }}'
+          - name: sales_to_write_filter
+            description: '{{ doc("column_sales_to_write_filter") }}'
           - name: short_term_owner_threshold
-            description: |
-              Properties with a significant price change and multiple
-              sales within this time duration (in days) are flagged
+            description: '{{ doc("column_short_term_owner_threshold") }}'
+          - name: standard_deviation_bounds
+            description: '{{ doc("column_standard_deviation_bounds") }}'
+          - name: stat_groups
+            description: '{{ doc("column_stat_groups") }}'
+          - name: time_frame
+            description: '{{ doc("column_time_frame") }}'
 
 
       - name: metadata

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1550,22 +1550,6 @@ Type of valuation model run. Possible values are:
 
 # Other
 
-## ari
-
-{% docs shared_column_ari %}
-Illinois Housing Development Authority's Affordability Risk Index.
-
-It is unclear of IHDA's data timeline. Year currently refers to final year of census data used.
-{% enddocs %}
-
-## dci
-
-{% docs shared_column_dci %}
-Distressed Communities Index from the Economic Innovation Group.
-
-Unit of observations is ZIP Code. Year refers to year of final year of census data used.
-{% enddocs %}
-
 ## ihs_avg_year_index
 
 {% docs shared_column_ihs_avg_year_index %}
@@ -1888,15 +1872,6 @@ Possible values for this variable are:
   finding no problems with the sale
 - Null: The sale has not been evaluated by our sales validation algorithm or by
   an analyst reviewer
-{% enddocs %}
-
-## requires_field_check
-
-{% docs shared_column_requires_field_check %}
-Analyst determination on whether we need to send someone
-from the office out to collect further information. True
-in this column suggests that the analyst believes there
-has been completed work on the home.
 {% enddocs %}
 
 ## review_json

--- a/dbt/models/shared_columns.md
+++ b/dbt/models/shared_columns.md
@@ -1550,6 +1550,22 @@ Type of valuation model run. Possible values are:
 
 # Other
 
+## ari
+
+{% docs shared_column_ari %}
+Illinois Housing Development Authority's Affordability Risk Index.
+
+It is unclear of IHDA's data timeline. Year currently refers to final year of census data used.
+{% enddocs %}
+
+## dci
+
+{% docs shared_column_dci %}
+Distressed Communities Index from the Economic Innovation Group.
+
+Unit of observations is ZIP Code. Year refers to year of final year of census data used.
+{% enddocs %}
+
 ## ihs_avg_year_index
 
 {% docs shared_column_ihs_avg_year_index %}


### PR DESCRIPTION
The schema definitions in our data catalog include a few "stale" columns that were removed from the model or source but never updated in the docs. This PR cleans out those columns to keep our docs up-to-date.

While I was auditing our docs, I also took a moment to clean up the docs for the `sale.parameter` table, which was missing a number of columns.

Full list of columns that I removed:

| Node                                  | Columns missing from DB                                            |
|---------------------------------------|--------------------------------------------------------------------|
| `model.default.vw_pin_sale`           | Removed `requires_field_check`, renamed `mydec_line_9_other_description` ➡️ `mydec_line_9_other_change_description`           |
| `model.default.vw_pin_sale_combined`  | Renamed renamed `mydec_line_9_other_description` ➡️ `mydec_line_9_other_change_description`                                   |
| `model.model.final_model`             | Renamed `triad_name` ➡️ `triad_code`                                                       |
| `model.model.vw_card_res_input`       | Renamed `other_ari` ➡️ `other_affordability_risk_index`, `other_dci` ➡️ `other_distressed_communities_index`                                           |
| `model.model.vw_pin_condo_input`      | Renamed `other_ari` ➡️ `other_affordability_risk_index`, `other_dci` ➡️ `other_distressed_communities_index`                                             |
| `model.model.vw_pin_shared_input`     | Renamed `other_ari` ➡️ `other_affordability_risk_index`, `other_dci` ➡️ `other_distressed_communities_index`                                             |
| `source.iasworld.htpar`               | Removed `name1` (defined on `htagnt`, not `htpar`)                                                             |
| `source.sale.flag`                    | Renamed `meta_sale_document_number` ➡️ `meta_sale_document_num`                                        |
| `source.sale.group_mean`              | Renamed `mean_price` ➡️ `group_mean`, removed `mean_price_per_sqft`                                |
| `source.sale.parameter`               | Removed/renamed `condo_stat_groups`, `dev_bounds`, `ptax_sd`, and `res_stat_groups`    |

Closes #1086.