### PR TITLE
Switch from z_score to 100% increase in land values for qc dashboard

### DIFF
--- a/dbt/models/qc/qc.vw_report_res_land.sql
+++ b/dbt/models/qc/qc.vw_report_res_land.sql
@@ -187,7 +187,7 @@ SELECT
             CASE WHEN code IN ('500', '600', 'EX')
                     THEN '🔍 Check: Review land codes 500, 600, and EX'
             END,
-            CASE WHEN land_av_pct_diff_zscore > 2
+            CASE WHEN land_av_pct_diff >= 100
                     THEN '🔍 Check: Review big increases in land AV'
             END,
             CASE WHEN land_sf_zscore > 2

--- a/dbt/models/qc/qc.vw_report_res_land.sql
+++ b/dbt/models/qc/qc.vw_report_res_land.sql
@@ -188,7 +188,7 @@ SELECT
                     THEN '🔍 Check: Review land codes 500, 600, and EX'
             END,
             CASE WHEN land_av_pct_diff >= 100
-                    THEN '🔍 Check: Review big increases in land AV'
+                    THEN '🔍 Check: Review big increases in land AV (>100%)'
             END,
             CASE WHEN land_sf_zscore > 2
                     THEN '🔍 Check: Review values for PINs with'


### PR DESCRIPTION
I did some testing, and I think it's just better to use a straight forward 100% increase in land value rather than the z-score. Z-scores are calculated based on a central mean value. In the case of orland park, an outlier % increase of 4357800 meant that the central value was 136%. The standard deviation is also high (22049) since it is based on the mean in it's formula.

<img width="220" height="62" alt="image" src="https://github.com/user-attachments/assets/1b997306-0777-4490-ac6e-d918ba7ad3d1" />


I don't see the need to take out the z_score although I'm happy to, since it may be useful in the future.

Here's the query that I came to this conclusion with

```
SELECT
    COUNT(*)                    AS n,
    AVG(land_av_pct_diff)       AS mean_pct,
    STDDEV(land_av_pct_diff)    AS stddev_pct,
    MIN(land_av_pct_diff)       AS min_pct,
    MAX(land_av_pct_diff)       AS max_pct
FROM vw_report_res_land
WHERE township_name = 'Orland'
    AND year = '2026'
```

That outlier is PIN `27312090240000` which switched from vacant land to res class in 2026.

Counts of the updated oultier will be between 1 - 1431 based on the township. 10 townships have 0 outliers.

```
SELECT
    township_name,
    COUNT(DISTINCT pin) AS pin_count
FROM qc.vw_report_res_land
WHERE land_av_pct_diff > 100
    AND year = '2026'
GROUP BY township_name
ORDER BY pin_count DESC
```

Another option would be the 1% of largest increases. At the end of the day, I think it's probably best to just ask the stakeholder, but they haven't responded yet.