### PR TITLE
Bump year threshold for `model.assessment_card` not-null test

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -35,6 +35,11 @@ vars:
   # but can also be use to select specific time frames for testing
   data_test_iasworld_year_end: 2030
 
+  # Current modeling year, for the purposes of running data tests. This filter
+  # helps ensure we are testing the integrity of our model artifacts during
+  # modeling season, while ignoring old data problems that we can't control
+  data_test_model_current_assessment_year: 2027
+
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 models:

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -14,7 +14,7 @@ sources:
                   config:
                     where: >
                       meta_class != '299'
-                      AND year >= '2027'
+                      AND year >= '{{ var("data_test_model_current_assessment_year") }}'
         data_tests:
           - unique_combination_of_columns:
               name: model_assessment_card_unique_pin_card_year_run
@@ -546,7 +546,7 @@ models:
                 where: >
                   meta_nbhd_code != '99999'
                   AND SUBSTR(meta_class, 1, 1) = '2'
-                  AND meta_year >= '2026'
+                  AND meta_year >= '{{ var("data_test_model_current_assessment_year") }}'
           - expression_is_true:
               name: model_vw_pin_shared_input_meta_township_code_matches_meta_tax_code
               expression: = SUBSTR(meta_tax_code, 1, 2)

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -14,7 +14,7 @@ sources:
                   config:
                     where: >
                       meta_class != '299'
-                      AND year >= '2026'
+                      AND year >= '2027'
         data_tests:
           - unique_combination_of_columns:
               name: model_assessment_card_unique_pin_card_year_run


### PR DESCRIPTION
The `model_assessment_card_meta_card_num_not_null` test keeps failing because of a couple of PINs that changed from non-regression to regression classes in the 2025 data after modeling. Now every time we run a new model using 2025 data, we add a few new failing rows to this test. See [this week's data integrity test run](https://github.com/ccao-data/data-architecture/actions/runs/32023217039/job/95367048270#step:7:796) for an example.

As I see it, we have three options for how to address this:

1. Ignore it and hope that someone finally fixes those PINs in the 2025 data (our approach so far)
    - Pro: No work required from us
    - Con: Our data integrity tests are constantly failing, which pollutes the signal of the test failure; it's been many month sisnce we reported this issue and I'm starting to lose faith that it will get fixed
2. Bump the threshold for the number of rows that have to fail the condition for the overall test to fail
    - Pro: Minimal change
    - Con: Dilutes the signal of the test, i.e. if we do genuinely encounter a problematic PIN we may miss it; also, we'll just have to bump the threshold yet again after enough model runs
3. Bump the year condition for the test, so we only fail on 2027 runs
    - Pro: Minimal change that still preserves the important signal for the test (i.e. catching null cards in next year's model run)
    - Con: If we introduce a problem into the pipeline that starts producing null cards, we won't catch it until we switch to 2027 modeling, which will be some months from now

This PR implements option 3 because I think that's the approach that best preserves the signal of the test while requiring a minimal amount of work. I'm open to pushback on that choice, though!

While bumping the year threshold, we also take the opportunity to factor this threshold out into a central variable that we can use for other model artifact tests. See the companion PR https://github.com/ccao-data/model-res-avm/pull/548 for a docs change that will remind us to increment this value at the appropriate time.