### PR TITLE
Create tableau dashboard based on iasworld tests

### DIFF
--- a/dbt/macros/generate_iasworld_qc_test_view.sql
+++ b/dbt/macros/generate_iasworld_qc_test_view.sql
@@ -68,17 +68,20 @@
             '{{ test.description }}' as test_description,
             '{{ test.category }}' as test_category,
             {% if test.additional_select_columns -%}
-                map(
-                    array[
-                        {%- for col_name in test.additional_select_columns -%}
-                            '{{ col_name }}'{{ ", " if not loop.last }}
-                        {%- endfor %}
-                    ],
-                    array[
-                        {%- for col_name in test.additional_select_columns -%}
-                            cast({{ col_name }} as varchar) {{- ", " if not loop.last }}
-                        {%- endfor %}
-                    ]
+                map_filter(
+                    map(
+                        array[
+                            {%- for col_name in test.additional_select_columns -%}
+                                '{{ col_name }}'{{ ", " if not loop.last }}
+                            {%- endfor %}
+                        ],
+                        array[
+                            {%- for col_name in test.additional_select_columns -%}
+                                cast({{ col_name }} as varchar) {{- ", " if not loop.last }}
+                            {%- endfor %}
+                        ]
+                    ),
+                    (k, v) -> v IS NOT NULL
                 ) as additional_columns
             {%- else -%} cast(null as map(varchar, varchar)) as additional_columns
             {%- endif %}

--- a/dbt/macros/generate_iasworld_qc_test_view.sql
+++ b/dbt/macros/generate_iasworld_qc_test_view.sql
@@ -1,0 +1,140 @@
+{#-
+    Generate a QC report view that runs a set of boolean "tests" against a
+    base query and returns one row per (record, failing test) pair. We use
+    the resulting views to power iasWorld QC.
+
+    Args:
+        base_query: A SQL SELECT statement (as a string) that returns the
+            identifying columns plus any additional columns referenced by
+            the `condition` or `additional_select_columns` attributes of the
+            `tests` argument. Source tables that don't include a required
+            identifying column (usually `card` or `lline`) should return
+            `CAST(NULL AS <type>) AS <column_name>` for that column to conform
+            to the expected shape. Required identifying columns include:
+                - parid: varchar
+                - taxyr: varchar
+                - card: decimal
+                - lline: decimal
+                - township_code: varchar
+                - class: varchar
+                - who: varchar
+                - wen: varchar
+        tests: A list of dicts, each with keys:
+            - name: A unique, descriptive slug for the test
+            - description: A human-readable description of what the test checks
+            - category: A category slug used to group related tests
+            - condition: A SQL boolean expression, evaluated against
+                `base_query`, that is TRUE when the record passes the test
+                and FALSE when it fails
+            - additional_select_columns (optional): A list of column names
+                from `base_query` to include in the output as a map of column
+                name -> stringified value for records that fail the test
+
+    Returns:
+        A query that selects one row per record per failing test.
+-#}
+{% macro generate_iasworld_qc_test_view(base_query, tests) %}
+    {% do _validate_iasworld_qc_tests(tests, exceptions.raise_compiler_error) %}
+    with
+        base as ({{ base_query }}),
+
+        test_result as (
+            select
+                *,
+                -- noqa: disable=layout.indent
+                {% for test in tests %}
+                    not ({{ test.condition }}) as {{ test.name }}
+                    {{- "," if not loop.last }}
+                {% endfor %}
+            -- noqa: enable=layout.indent
+            from base
+            where
+                taxyr
+                between '{{ var("data_test_iasworld_year_start") }}'
+                and '{{ var("data_test_iasworld_year_end") }}'
+        )
+
+    {% for test in tests %}
+        select
+            parid,
+            taxyr,
+            card,
+            lline,
+            township_code,
+            class,
+            who,
+            wen,
+            '{{ test.name }}' as test_name,
+            '{{ test.description }}' as test_description,
+            '{{ test.category }}' as test_category,
+            {% if test.additional_select_columns -%}
+                map(
+                    array[
+                        {%- for col_name in test.additional_select_columns -%}
+                            '{{ col_name }}'{{ ", " if not loop.last }}
+                        {%- endfor %}
+                    ],
+                    array[
+                        {%- for col_name in test.additional_select_columns -%}
+                            cast({{ col_name }} as varchar) {{- ", " if not loop.last }}
+                        {%- endfor %}
+                    ]
+                ) as additional_columns
+            {%- else -%} cast(null as map(varchar, varchar)) as additional_columns
+            {%- endif %}
+        from test_result
+        where {{ test.name }} {{ "UNION ALL" if not loop.last }}
+    {% endfor %}
+{% endmacro %}
+
+{#-
+    Validate that `tests` is a list of dicts, each containing the keys
+    required by `generate_iasworld_qc_test_view`. Raises a compiler error
+    (via `raise_error_func`) on the first validation failure it finds.
+
+    Args:
+        tests: The `tests` argument passed to `generate_iasworld_qc_test_view`
+        raise_error_func: A function to call with an error message when
+            validation fails. Takes `exceptions.raise_compiler_error` in
+            production, and a mock in unit tests so that the error can be
+            returned for equality comparison instead of raised
+-#}
+{% macro _validate_iasworld_qc_tests(tests, raise_error_func) %}
+    {%- set required_keys = ["name", "description", "category", "condition"] -%}
+    {%- if tests is not iterable or tests is mapping or tests is string -%}
+        {{-
+            return(
+                raise_error_func('"tests" argument must be a list, got: ' ~ tests)
+            )
+        -}}
+    {%- endif -%}
+    {%- for test in tests -%}
+        {%- if test is not mapping -%}
+            {{-
+                return(
+                    raise_error_func(
+                        'Each element of "tests" must be an object/dict,'
+                        ~ " got: "
+                        ~ test
+                    )
+                )
+            -}}
+        {%- endif -%}
+        {%- for key in required_keys -%}
+            {%- if key not in test -%}
+                {{-
+                    return(
+                        raise_error_func(
+                            'Missing required "'
+                            ~ key
+                            ~ '" key in test'
+                            ~ " config: "
+                            ~ test
+                        )
+                    )
+                -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endfor -%}
+    {{ return(none) }}
+{% endmacro %}

--- a/dbt/macros/generate_iasworld_qc_test_view.sql
+++ b/dbt/macros/generate_iasworld_qc_test_view.sql
@@ -77,11 +77,13 @@
                         ],
                         array[
                             {%- for col_name in test.additional_select_columns -%}
-                                cast({{ col_name }} as varchar) {{- ", " if not loop.last }}
+                                cast(
+                                    {{ col_name }} as varchar
+                                ) {{- ", " if not loop.last }}
                             {%- endfor %}
                         ]
                     ),
-                    (k, v) -> v IS NOT NULL
+                    (k, v) -> v is not null
                 ) as additional_columns
             {%- else -%} cast(null as map(varchar, varchar)) as additional_columns
             {%- endif %}

--- a/dbt/macros/tests/test_all.sql
+++ b/dbt/macros/tests/test_all.sql
@@ -6,4 +6,5 @@
     {% do test_generate_alias_name() %}
     {% do test_format_additional_select_columns() %}
     {% do test_insert_hyphens() %}
+    {% do test_generate_iasworld_qc_test_view() %}
 {% endmacro %}

--- a/dbt/macros/tests/test_all.sql
+++ b/dbt/macros/tests/test_all.sql
@@ -6,5 +6,4 @@
     {% do test_generate_alias_name() %}
     {% do test_format_additional_select_columns() %}
     {% do test_insert_hyphens() %}
-    {% do test_generate_iasworld_qc_test_view() %}
 {% endmacro %}

--- a/dbt/macros/tests/test_generate_iasworld_qc_test_view.sql
+++ b/dbt/macros/tests/test_generate_iasworld_qc_test_view.sql
@@ -1,0 +1,66 @@
+{% macro test_generate_iasworld_qc_test_view() %}
+    {% do test_validate_iasworld_qc_tests_not_a_list() %}
+    {% do test_validate_iasworld_qc_tests_element_not_a_dict() %}
+    {% do test_validate_iasworld_qc_tests_missing_required_key() %}
+    {% do test_validate_iasworld_qc_tests_valid() %}
+{% endmacro %}
+
+{% macro test_validate_iasworld_qc_tests_not_a_list() %}
+    {{
+        assert_equals(
+            "test_validate_iasworld_qc_tests_not_a_list",
+            _validate_iasworld_qc_tests({"name": "foo"}, mock_raise_compiler_error),
+            "\"tests\" argument must be a list, got: {'name': 'foo'}",
+        )
+    }}
+{% endmacro %}
+
+{% macro test_validate_iasworld_qc_tests_element_not_a_dict() %}
+    {{
+        assert_equals(
+            "test_validate_iasworld_qc_tests_element_not_a_dict",
+            _validate_iasworld_qc_tests(["foo"], mock_raise_compiler_error),
+            'Each element of "tests" must be an object/dict, got: foo',
+        )
+    }}
+{% endmacro %}
+
+{% macro test_validate_iasworld_qc_tests_missing_required_key() %}
+    {{
+        assert_equals(
+            "test_validate_iasworld_qc_tests_missing_required_key",
+            _validate_iasworld_qc_tests(
+                [
+                    {
+                        "name": "foo",
+                        "description": "bar",
+                        "category": "baz",
+                    }
+                ],
+                mock_raise_compiler_error,
+            ),
+            "Missing required \"condition\" key in test config: {'name':"
+            ~ " 'foo', 'description': 'bar', 'category': 'baz'}",
+        )
+    }}
+{% endmacro %}
+
+{% macro test_validate_iasworld_qc_tests_valid() %}
+    {{
+        assert_equals(
+            "test_validate_iasworld_qc_tests_valid",
+            _validate_iasworld_qc_tests(
+                [
+                    {
+                        "name": "foo",
+                        "description": "bar",
+                        "category": "baz",
+                        "condition": "1 = 1",
+                    }
+                ],
+                mock_raise_compiler_error,
+            ),
+            none,
+        )
+    }}
+{% endmacro %}

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -185,7 +185,12 @@ sources:
                     AND model.taxyr = external_model.taxyr
                     AND external_model.cur = 'Y'
                     AND external_model.deactivat IS NULL
-                  config: *unique-conditions
+                  config:
+                    where: |
+                      CAST(taxyr AS int) BETWEEN {{ var('data_test_iasworld_year_start') }} AND {{ var('data_test_iasworld_year_end') }}
+                      AND cur = 'Y'
+                      AND deactivat IS NULL
+                      AND nbhd NOT LIKE '%999'
                   meta:
                     category: relationships
                     description: nbhd code first 2 digits should match legdat.user1 (township code)

--- a/dbt/models/iasworld/schema/iasworld.pardat.yml
+++ b/dbt/models/iasworld/schema/iasworld.pardat.yml
@@ -185,12 +185,7 @@ sources:
                     AND model.taxyr = external_model.taxyr
                     AND external_model.cur = 'Y'
                     AND external_model.deactivat IS NULL
-                  config:
-                    where: |
-                      CAST(taxyr AS int) BETWEEN {{ var('data_test_iasworld_year_start') }} AND {{ var('data_test_iasworld_year_end') }}
-                      AND cur = 'Y'
-                      AND deactivat IS NULL
-                      AND nbhd NOT LIKE '%999'
+                  config: *unique-conditions
                   meta:
                     category: relationships
                     description: nbhd code first 2 digits should match legdat.user1 (township code)

--- a/dbt/models/qc/docs.md
+++ b/dbt/models/qc/docs.md
@@ -205,8 +205,8 @@ This view is not currently in use in any QC workflows.
 # vw_report_iasworld_test_pardat
 
 {% docs view_vw_report_iasworld_test_pardat %}
-Aggregates iasworld.pardat data tests as a queryable view, with one row
-per PIN failing a given test.
+Aggregates test failures, stemming from iasworld pardat. Each observation is a failure
+based on unique PIN, year, and failing test combinations.
 {% enddocs %}
 
 # vw_report_res_land

--- a/dbt/models/qc/docs.md
+++ b/dbt/models/qc/docs.md
@@ -207,6 +207,9 @@ This view is not currently in use in any QC workflows.
 {% docs view_vw_report_iasworld_test_all %}
 Combines test failures from all iasworld test views. Each observation is a failure
 based on unique PIN, year, and failing test combinations.
+
+**Primary Key**: `parid`, `taxyr`, `test_name`
+
 {% enddocs %}
 
 # vw_report_iasworld_test_owndat
@@ -214,6 +217,9 @@ based on unique PIN, year, and failing test combinations.
 {% docs view_vw_report_iasworld_test_owndat %}
 Aggregates test failures, stemming from iasworld owndat. Each observation is a failure
 based on unique PIN, year, and failing test combinations.
+
+**Primary Key**: `parid`, `taxyr`, `test_name`
+
 {% enddocs %}
 
 # vw_report_iasworld_test_pardat
@@ -221,6 +227,9 @@ based on unique PIN, year, and failing test combinations.
 {% docs view_vw_report_iasworld_test_pardat %}
 Aggregates test failures, stemming from iasworld pardat. Each observation is a failure
 based on unique PIN, year, and failing test combinations.
+
+**Primary Key**: `parid`, `taxyr`, `test_name`
+
 {% enddocs %}
 
 # vw_report_res_land

--- a/dbt/models/qc/docs.md
+++ b/dbt/models/qc/docs.md
@@ -202,6 +202,13 @@ classes.
 This view is not currently in use in any QC workflows.
 {% enddocs %}
 
+# vw_report_iasworld_test_pardat
+
+{% docs view_vw_report_iasworld_test_pardat %}
+Aggregates iasworld.pardat data tests as a queryable view, with one row
+per PIN failing a given test.
+{% enddocs %}
+
 # vw_report_res_land
 
 {% docs view_vw_report_res_land %}

--- a/dbt/models/qc/docs.md
+++ b/dbt/models/qc/docs.md
@@ -202,6 +202,20 @@ classes.
 This view is not currently in use in any QC workflows.
 {% enddocs %}
 
+# vw_report_iasworld_test_all
+
+{% docs view_vw_report_iasworld_test_all %}
+Combines test failures from all iasworld test views. Each observation is a failure
+based on unique PIN, year, and failing test combinations.
+{% enddocs %}
+
+# vw_report_iasworld_test_owndat
+
+{% docs view_vw_report_iasworld_test_owndat %}
+Aggregates test failures, stemming from iasworld owndat. Each observation is a failure
+based on unique PIN, year, and failing test combinations.
+{% enddocs %}
+
 # vw_report_iasworld_test_pardat
 
 {% docs view_vw_report_iasworld_test_pardat %}

--- a/dbt/models/qc/qc.vw_report_iasworld_test_all.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_all.sql
@@ -1,3 +1,9 @@
-SELECT *, 'pardat' AS source_table FROM {{ ref('qc.vw_report_iasworld_test_pardat') }}
+SELECT
+    *,
+    'pardat' AS source_table
+FROM {{ ref('qc.vw_report_iasworld_test_pardat') }}
 UNION ALL
-SELECT *, 'owndat' AS source_table FROM {{ ref('qc.vw_report_iasworld_test_owndat') }}
+SELECT
+    *,
+    'owndat' AS source_table
+FROM {{ ref('qc.vw_report_iasworld_test_owndat') }}

--- a/dbt/models/qc/qc.vw_report_iasworld_test_all.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_all.sql
@@ -1,0 +1,3 @@
+SELECT * FROM {{ ref('qc.vw_report_iasworld_test_pardat') }}
+UNION ALL
+SELECT * FROM {{ ref('qc.vw_report_iasworld_test_owndat') }}

--- a/dbt/models/qc/qc.vw_report_iasworld_test_all.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_all.sql
@@ -1,3 +1,3 @@
-SELECT * FROM {{ ref('qc.vw_report_iasworld_test_pardat') }}
+SELECT *, 'pardat' AS source_table FROM {{ ref('qc.vw_report_iasworld_test_pardat') }}
 UNION ALL
-SELECT * FROM {{ ref('qc.vw_report_iasworld_test_owndat') }}
+SELECT *, 'owndat' AS source_table FROM {{ ref('qc.vw_report_iasworld_test_owndat') }}

--- a/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
@@ -40,7 +40,7 @@
     },
     {
         "name": "iasworld_owndat_address_columns_no_extra_whitespace",
-        "description": "own1, own2, addr1-5, and other address columns should have no leading or trailing whitespace",
+        "description": "address columns should not have whitespace",
         "category": "column_values",
         "condition": "NOT (" ~ whitespace_parts | join(" OR ") ~ ")",
         "additional_select_columns": whitespace_cols
@@ -72,24 +72,10 @@
         LAG(owndat.seq)
             OVER (PARTITION BY owndat.parid, owndat.taxyr ORDER BY owndat.seq)
             AS prev_seq,
-        owndat.own1,
-        owndat.own2,
-        owndat.addr1,
-        owndat.addr2,
-        owndat.addr3,
-        owndat.addr4,
-        owndat.addr5,
-        owndat.adrpre,
-        owndat.adrdir,
-        owndat.adrstr,
-        owndat.adrsuf,
-        owndat.unitdesc,
-        owndat.unitno,
-        owndat.cityname,
-        owndat.statecode,
-        owndat.zip1,
-        owndat.zip2,
-        owndat.user27,
+        {% for col in whitespace_cols %}
+        CASE WHEN owndat.{{ col }} LIKE '% ' OR owndat.{{ col }} LIKE ' %'
+            THEN owndat.{{ col }} END AS {{ col }},
+        {% endfor %}
         COUNT(*)
             OVER (PARTITION BY owndat.parid, owndat.taxyr)
             AS num_duplicates

--- a/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
@@ -42,7 +42,7 @@
     {
         "name": "iasworld_owndat_unique_by_parid_taxyr",
         "description": "owndat should be unique by parid and taxyr",
-        "category": "duplicate_rows",
+        "category": "duplicate_records",
         "condition": "num_duplicates = 1",
         "additional_select_columns": ["num_duplicates"]
     }

--- a/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
@@ -72,7 +72,7 @@
         COUNT(*)
             OVER (PARTITION BY owndat.parid, owndat.taxyr)
             AS num_duplicates
-    FROM iasworld.owndat AS owndat
+    FROM {{ source('iasworld', 'owndat') }} AS owndat
     LEFT JOIN iasworld.legdat AS legdat
         ON owndat.parid = legdat.parid
         AND owndat.taxyr = legdat.taxyr

--- a/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
@@ -22,7 +22,7 @@
     {
         "name": "iasworld_owndat_parid_not_null",
         "description": "parid should not be null",
-        "category": "incorrect_values",
+        "category": "missing_values",
         "condition": "parid IS NOT NULL"
     },
     {

--- a/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
@@ -49,7 +49,7 @@
             OVER (PARTITION BY owndat.parid, owndat.taxyr)
             AS num_duplicates
     FROM {{ source('iasworld', 'owndat') }} AS owndat
-    LEFT JOIN iasworld.legdat AS legdat
+    LEFT JOIN {{ source('iasworld', 'legdat') }} AS legdat
         ON owndat.parid = legdat.parid
         AND owndat.taxyr = legdat.taxyr
         AND legdat.cur = 'Y'

--- a/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
@@ -78,14 +78,11 @@
         AND owndat.taxyr = legdat.taxyr
         AND legdat.cur = 'Y'
         AND legdat.deactivat IS NULL
-    INNER JOIN (
-        SELECT DISTINCT parid, taxyr
-        FROM iasworld.pardat
-        WHERE cur = 'Y'
-            AND deactivat IS NULL
-    ) AS pardat_parids
-        ON owndat.parid = pardat_parids.parid
-        AND owndat.taxyr = pardat_parids.taxyr
+    INNER JOIN {{ source('iasworld', 'pardat') }} AS pardat
+        ON owndat.parid = pardat.parid
+        AND owndat.taxyr = pardat.taxyr
+        AND pardat.cur = 'Y'
+        AND pardat.deactivat IS NULL
     WHERE owndat.cur = 'Y'
         AND owndat.deactivat IS NULL
 {% endset %}

--- a/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
@@ -1,0 +1,111 @@
+{%- set whitespace_cols = [
+    "own1", "own2", "addr1", "addr2", "addr3", "addr4", "addr5",
+    "adrpre", "adrdir", "adrstr", "adrsuf", "unitdesc", "unitno",
+    "cityname", "statecode", "zip1", "zip2", "user27"
+] -%}
+
+{%- set whitespace_parts = [] -%}
+{%- for col in whitespace_cols -%}
+    {%- do whitespace_parts.append(
+        "(" ~ col ~ " LIKE '% ' OR " ~ col ~ " LIKE ' %')"
+    ) -%}
+{%- endfor -%}
+
+{%- set tests = [
+    {
+        "name": "iasworld_owndat_cur_in_accepted_values",
+        "description": 'cur should be "Y" or "D"',
+        "category": "incorrect_values",
+        "condition": "cur IN ('Y', 'D')",
+        "additional_select_columns": ["cur"]
+    },
+    {
+        "name": "iasworld_owndat_parid_in_pardat_parid",
+        "description": "parid should be in pardat",
+        "category": "parid",
+        "condition": "pardat_parid IS NOT NULL"
+    },
+    {
+        "name": "iasworld_owndat_parid_not_null",
+        "description": "parid should not be null",
+        "category": "incorrect_values",
+        "condition": "parid IS NOT NULL"
+    },
+    {
+        "name": "iasworld_owndat_seq_all_sequential_exist",
+        "description": "seq should be sequential",
+        "category": "incorrect_values",
+        "condition": "seq = prev_seq + 1",
+        "additional_select_columns": ["seq", "prev_seq"]
+    },
+    {
+        "name": "iasworld_owndat_address_columns_no_extra_whitespace",
+        "description": "own1, own2, addr1-5, and other address columns should have no leading or trailing whitespace",
+        "category": "column_values",
+        "condition": "NOT (" ~ whitespace_parts | join(" OR ") ~ ")",
+        "additional_select_columns": whitespace_cols
+    },
+    {
+        "name": "iasworld_owndat_unique_by_parid_taxyr",
+        "description": "owndat should be unique by parid and taxyr",
+        "category": "duplicate_rows",
+        "condition": "num_duplicates = 1",
+        "additional_select_columns": ["num_duplicates"]
+    }
+] -%}
+
+{%- set base_query %}
+    SELECT
+        -- Identifying columns
+        owndat.parid,
+        owndat.taxyr,
+        CAST(NULL AS INTEGER) AS card,
+        CAST(NULL AS INTEGER) AS lline,
+        legdat.user1 AS township_code,
+        CAST(NULL AS VARCHAR) AS class,
+        owndat.who,
+        owndat.wen,
+        -- Columns to test
+        owndat.cur,
+        pardat_parids.parid AS pardat_parid,
+        owndat.seq,
+        LAG(owndat.seq)
+            OVER (PARTITION BY owndat.parid, owndat.taxyr ORDER BY owndat.seq)
+            AS prev_seq,
+        owndat.own1,
+        owndat.own2,
+        owndat.addr1,
+        owndat.addr2,
+        owndat.addr3,
+        owndat.addr4,
+        owndat.addr5,
+        owndat.adrpre,
+        owndat.adrdir,
+        owndat.adrstr,
+        owndat.adrsuf,
+        owndat.unitdesc,
+        owndat.unitno,
+        owndat.cityname,
+        owndat.statecode,
+        owndat.zip1,
+        owndat.zip2,
+        owndat.user27,
+        COUNT(*)
+            OVER (PARTITION BY owndat.parid, owndat.taxyr)
+            AS num_duplicates
+    FROM iasworld.owndat AS owndat
+    LEFT JOIN iasworld.legdat AS legdat
+        ON owndat.parid = legdat.parid
+        AND owndat.taxyr = legdat.taxyr
+        AND legdat.cur = 'Y'
+        AND legdat.deactivat IS NULL
+    LEFT JOIN (
+        SELECT DISTINCT parid
+        FROM iasworld.pardat
+    ) AS pardat_parids
+        ON owndat.parid = pardat_parids.parid
+    WHERE owndat.cur = 'Y'
+        AND owndat.deactivat IS NULL
+{% endset %}
+
+{{ generate_iasworld_qc_test_view(base_query, tests) }}

--- a/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
@@ -20,12 +20,6 @@
         "additional_select_columns": ["cur"]
     },
     {
-        "name": "iasworld_owndat_parid_in_pardat_parid",
-        "description": "parid should be in pardat",
-        "category": "parid",
-        "condition": "pardat_parid IS NOT NULL"
-    },
-    {
         "name": "iasworld_owndat_parid_not_null",
         "description": "parid should not be null",
         "category": "incorrect_values",
@@ -67,7 +61,6 @@
         owndat.wen,
         -- Columns to test
         owndat.cur,
-        pardat_parids.parid AS pardat_parid,
         owndat.seq,
         LAG(owndat.seq)
             OVER (PARTITION BY owndat.parid, owndat.taxyr ORDER BY owndat.seq)
@@ -85,11 +78,14 @@
         AND owndat.taxyr = legdat.taxyr
         AND legdat.cur = 'Y'
         AND legdat.deactivat IS NULL
-    LEFT JOIN (
-        SELECT DISTINCT parid
+    INNER JOIN (
+        SELECT DISTINCT parid, taxyr
         FROM iasworld.pardat
+        WHERE cur = 'Y'
+            AND deactivat IS NULL
     ) AS pardat_parids
         ON owndat.parid = pardat_parids.parid
+        AND owndat.taxyr = pardat_parids.taxyr
     WHERE owndat.cur = 'Y'
         AND owndat.deactivat IS NULL
 {% endset %}

--- a/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_owndat.sql
@@ -1,16 +1,3 @@
-{%- set whitespace_cols = [
-    "own1", "own2", "addr1", "addr2", "addr3", "addr4", "addr5",
-    "adrpre", "adrdir", "adrstr", "adrsuf", "unitdesc", "unitno",
-    "cityname", "statecode", "zip1", "zip2", "user27"
-] -%}
-
-{%- set whitespace_parts = [] -%}
-{%- for col in whitespace_cols -%}
-    {%- do whitespace_parts.append(
-        "(" ~ col ~ " LIKE '% ' OR " ~ col ~ " LIKE ' %')"
-    ) -%}
-{%- endfor -%}
-
 {%- set tests = [
     {
         "name": "iasworld_owndat_cur_in_accepted_values",
@@ -31,13 +18,6 @@
         "category": "incorrect_values",
         "condition": "seq = prev_seq + 1",
         "additional_select_columns": ["seq", "prev_seq"]
-    },
-    {
-        "name": "iasworld_owndat_address_columns_no_extra_whitespace",
-        "description": "address columns should not have whitespace",
-        "category": "column_values",
-        "condition": "NOT (" ~ whitespace_parts | join(" OR ") ~ ")",
-        "additional_select_columns": whitespace_cols
     },
     {
         "name": "iasworld_owndat_unique_by_parid_taxyr",
@@ -65,10 +45,6 @@
         LAG(owndat.seq)
             OVER (PARTITION BY owndat.parid, owndat.taxyr ORDER BY owndat.seq)
             AS prev_seq,
-        {% for col in whitespace_cols %}
-        CASE WHEN owndat.{{ col }} LIKE '% ' OR owndat.{{ col }} LIKE ' %'
-            THEN owndat.{{ col }} END AS {{ col }},
-        {% endfor %}
         COUNT(*)
             OVER (PARTITION BY owndat.parid, owndat.taxyr)
             AS num_duplicates

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -143,7 +143,6 @@ iasworld_pardat_nbhd_matches_legdat_township AS (
         AND {{ var('data_test_iasworld_year_end') }}
         AND pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
-        AND pardat.nbhd NOT LIKE '%999'
 ),
 
 iasworld_pardat_nbhd_matches_spatial_town_nbhd AS (

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -17,7 +17,7 @@
         "name": "iasworld_pardat_class_in_ccao_class_dict",
         "description": "class_code should be valid",
         "category": "class_mismatch_or_issue",
-        "condition": "class_dict_class IS NOT NULL OR class IN ('EX', 'RR') OR REGEXP_LIKE(class, '[0-9]{3}[A|B]')"
+        "condition": "class_dict_class IS NOT NULL OR class IN ('EX', 'RR') OR REGEXP_LIKE(class, '[0-9]{3}[A|B]')",
         "additional_select_columns": ["class"]
     },
     {

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -24,8 +24,8 @@ pardat_seq AS (
         wen
     FROM {{ source('iasworld', 'pardat') }}
     WHERE CAST(taxyr AS INT) BETWEEN
-            {{ var('data_test_iasworld_year_start') }}
-            AND {{ var('data_test_iasworld_year_end') }}
+        {{ var('data_test_iasworld_year_start') }}
+        AND {{ var('data_test_iasworld_year_end') }}
         AND cur = 'Y'
         AND deactivat IS NULL
 ),
@@ -53,8 +53,8 @@ iasworld_pardat_adrno_length_lte_5 AS (
         AND pardat.taxyr = legdat.taxyr
     WHERE NOT (LENGTH(CAST(pardat.adrno AS VARCHAR)) <= 5)
         AND CAST(pardat.taxyr AS INT) BETWEEN
-            {{ var('data_test_iasworld_year_start') }}
-            AND {{ var('data_test_iasworld_year_end') }}
+        {{ var('data_test_iasworld_year_start') }}
+        AND {{ var('data_test_iasworld_year_end') }}
         AND pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
 ),
@@ -82,8 +82,8 @@ iasworld_pardat_class_equals_luc AS (
         AND pardat.taxyr = legdat.taxyr
     WHERE NOT (pardat.class = pardat.luc)
         AND CAST(pardat.taxyr AS INT) BETWEEN
-            {{ var('data_test_iasworld_year_start') }}
-            AND {{ var('data_test_iasworld_year_end') }}
+        {{ var('data_test_iasworld_year_start') }}
+        AND {{ var('data_test_iasworld_year_end') }}
         AND pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
 ),
@@ -111,8 +111,8 @@ iasworld_pardat_cur_in_accepted_values AS (
         AND pardat.taxyr = legdat.taxyr
     WHERE pardat.cur NOT IN ('Y', 'D')
         AND CAST(pardat.taxyr AS INT) BETWEEN
-            {{ var('data_test_iasworld_year_start') }}
-            AND {{ var('data_test_iasworld_year_end') }}
+        {{ var('data_test_iasworld_year_start') }}
+        AND {{ var('data_test_iasworld_year_end') }}
 ),
 
 iasworld_pardat_nbhd_matches_legdat_township AS (
@@ -139,8 +139,8 @@ iasworld_pardat_nbhd_matches_legdat_township AS (
         AND pardat.taxyr = legdat.taxyr
         AND SUBSTR(pardat.nbhd, 1, 2) != legdat.township_code
     WHERE CAST(pardat.taxyr AS INT) BETWEEN
-            {{ var('data_test_iasworld_year_start') }}
-            AND {{ var('data_test_iasworld_year_end') }}
+        {{ var('data_test_iasworld_year_start') }}
+        AND {{ var('data_test_iasworld_year_end') }}
         AND pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
         AND pardat.nbhd NOT LIKE '%999'
@@ -171,8 +171,8 @@ iasworld_pardat_nbhd_matches_spatial_town_nbhd AS (
         ON pardat.nbhd = distinct_town_nbhd.town_nbhd
     WHERE distinct_town_nbhd.town_nbhd IS NULL
         AND CAST(pardat.taxyr AS INT) BETWEEN
-            {{ var('data_test_iasworld_year_start') }}
-            AND {{ var('data_test_iasworld_year_end') }}
+        {{ var('data_test_iasworld_year_start') }}
+        AND {{ var('data_test_iasworld_year_end') }}
         AND pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
         AND pardat.nbhd NOT LIKE '%999'
@@ -227,11 +227,14 @@ iasworld_pardat_unique_by_parid_taxyr AS (
         ON pardat.parid = legdat.parid
         AND pardat.taxyr = legdat.taxyr
     INNER JOIN (
-        SELECT parid, taxyr, COUNT(*) AS num_dupes
+        SELECT
+            parid,
+            taxyr,
+            COUNT(*) AS num_dupes
         FROM {{ source('iasworld', 'pardat') }}
         WHERE CAST(taxyr AS INT) BETWEEN
-                {{ var('data_test_iasworld_year_start') }}
-                AND {{ var('data_test_iasworld_year_end') }}
+            {{ var('data_test_iasworld_year_start') }}
+            AND {{ var('data_test_iasworld_year_end') }}
             AND cur = 'Y'
             AND deactivat IS NULL
         GROUP BY parid, taxyr
@@ -240,8 +243,8 @@ iasworld_pardat_unique_by_parid_taxyr AS (
         ON pardat.parid = dupe_counts.parid
         AND pardat.taxyr = dupe_counts.taxyr
     WHERE CAST(pardat.taxyr AS INT) BETWEEN
-            {{ var('data_test_iasworld_year_start') }}
-            AND {{ var('data_test_iasworld_year_end') }}
+        {{ var('data_test_iasworld_year_start') }}
+        AND {{ var('data_test_iasworld_year_end') }}
         AND pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
 )

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -13,6 +13,16 @@ distinct_town_nbhd AS (
     FROM {{ source('spatial', 'neighborhood') }}
 ),
 
+pardat AS (
+    SELECT *
+    FROM {{ source('iasworld', 'pardat') }}
+    WHERE CAST(taxyr AS INT) BETWEEN
+        {{ var('data_test_iasworld_year_start') }}
+        AND {{ var('data_test_iasworld_year_end') }}
+        AND cur = 'Y'
+        AND deactivat IS NULL
+),
+
 pardat_seq AS (
     SELECT
         parid,
@@ -22,12 +32,7 @@ pardat_seq AS (
         LAG(seq) OVER (PARTITION BY parid, taxyr ORDER BY seq) AS prev_seq,
         who,
         wen
-    FROM {{ source('iasworld', 'pardat') }}
-    WHERE CAST(taxyr AS INT) BETWEEN
-        {{ var('data_test_iasworld_year_start') }}
-        AND {{ var('data_test_iasworld_year_end') }}
-        AND cur = 'Y'
-        AND deactivat IS NULL
+    FROM pardat
 ),
 
 iasworld_pardat_adrno_length_lte_5 AS (
@@ -47,16 +52,11 @@ iasworld_pardat_adrno_length_lte_5 AS (
             ARRAY['adrno'],
             ARRAY[CAST(pardat.adrno AS VARCHAR)]
         ) AS additional_fields
-    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    FROM pardat
     LEFT JOIN legdat_townships AS legdat
         ON pardat.parid = legdat.parid
         AND pardat.taxyr = legdat.taxyr
     WHERE NOT (LENGTH(CAST(pardat.adrno AS VARCHAR)) <= 5)
-        AND CAST(pardat.taxyr AS INT) BETWEEN
-        {{ var('data_test_iasworld_year_start') }}
-        AND {{ var('data_test_iasworld_year_end') }}
-        AND pardat.cur = 'Y'
-        AND pardat.deactivat IS NULL
 ),
 
 iasworld_pardat_class_equals_luc AS (
@@ -76,16 +76,11 @@ iasworld_pardat_class_equals_luc AS (
             ARRAY['luc'],
             ARRAY[pardat.luc]
         ) AS additional_fields
-    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    FROM pardat
     LEFT JOIN legdat_townships AS legdat
         ON pardat.parid = legdat.parid
         AND pardat.taxyr = legdat.taxyr
     WHERE NOT (pardat.class = pardat.luc)
-        AND CAST(pardat.taxyr AS INT) BETWEEN
-        {{ var('data_test_iasworld_year_start') }}
-        AND {{ var('data_test_iasworld_year_end') }}
-        AND pardat.cur = 'Y'
-        AND pardat.deactivat IS NULL
 ),
 
 iasworld_pardat_cur_in_accepted_values AS (
@@ -133,16 +128,11 @@ iasworld_pardat_nbhd_matches_legdat_township AS (
             ARRAY['nbhd'],
             ARRAY[pardat.nbhd]
         ) AS additional_fields
-    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    FROM pardat
     INNER JOIN legdat_townships AS legdat
         ON pardat.parid = legdat.parid
         AND pardat.taxyr = legdat.taxyr
         AND SUBSTR(pardat.nbhd, 1, 2) != legdat.township_code
-    WHERE CAST(pardat.taxyr AS INT) BETWEEN
-        {{ var('data_test_iasworld_year_start') }}
-        AND {{ var('data_test_iasworld_year_end') }}
-        AND pardat.cur = 'Y'
-        AND pardat.deactivat IS NULL
 ),
 
 iasworld_pardat_nbhd_matches_spatial_town_nbhd AS (
@@ -162,18 +152,13 @@ iasworld_pardat_nbhd_matches_spatial_town_nbhd AS (
             ARRAY['nbhd'],
             ARRAY[pardat.nbhd]
         ) AS additional_fields
-    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    FROM pardat
     LEFT JOIN legdat_townships AS legdat
         ON pardat.parid = legdat.parid
         AND pardat.taxyr = legdat.taxyr
     LEFT JOIN distinct_town_nbhd
         ON pardat.nbhd = distinct_town_nbhd.town_nbhd
     WHERE distinct_town_nbhd.town_nbhd IS NULL
-        AND CAST(pardat.taxyr AS INT) BETWEEN
-        {{ var('data_test_iasworld_year_start') }}
-        AND {{ var('data_test_iasworld_year_end') }}
-        AND pardat.cur = 'Y'
-        AND pardat.deactivat IS NULL
         AND pardat.nbhd NOT LIKE '%999'
 ),
 
@@ -221,7 +206,7 @@ iasworld_pardat_unique_by_parid_taxyr AS (
             ARRAY['num_duplicates'],
             ARRAY[CAST(dupe_counts.num_dupes AS VARCHAR)]
         ) AS additional_fields
-    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    FROM pardat
     LEFT JOIN legdat_townships AS legdat
         ON pardat.parid = legdat.parid
         AND pardat.taxyr = legdat.taxyr
@@ -230,22 +215,12 @@ iasworld_pardat_unique_by_parid_taxyr AS (
             parid,
             taxyr,
             COUNT(*) AS num_dupes
-        FROM {{ source('iasworld', 'pardat') }}
-        WHERE CAST(taxyr AS INT) BETWEEN
-            {{ var('data_test_iasworld_year_start') }}
-            AND {{ var('data_test_iasworld_year_end') }}
-            AND cur = 'Y'
-            AND deactivat IS NULL
+        FROM pardat
         GROUP BY parid, taxyr
         HAVING COUNT(*) > 1
     ) AS dupe_counts
         ON pardat.parid = dupe_counts.parid
         AND pardat.taxyr = dupe_counts.taxyr
-    WHERE CAST(pardat.taxyr AS INT) BETWEEN
-        {{ var('data_test_iasworld_year_start') }}
-        AND {{ var('data_test_iasworld_year_end') }}
-        AND pardat.cur = 'Y'
-        AND pardat.deactivat IS NULL
 )
 
 SELECT * FROM iasworld_pardat_adrno_length_lte_5

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -44,7 +44,7 @@
     {
         "name": "iasworld_pardat_unique_by_parid_taxyr",
         "description": "pardat should be unique by parid and taxyr",
-        "category": "duplicate_rows",
+        "category": "duplicate_records",
         "condition": "num_duplicates = 1",
         "additional_select_columns": ["num_duplicates"]
     }

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -133,6 +133,7 @@ iasworld_pardat_nbhd_matches_legdat_township AS (
         ON pardat.parid = legdat.parid
         AND pardat.taxyr = legdat.taxyr
         AND SUBSTR(pardat.nbhd, 1, 2) != legdat.township_code
+    WHERE pardat.nbhd NOT LIKE '%999'
 ),
 
 iasworld_pardat_nbhd_matches_spatial_town_nbhd AS (

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -14,6 +14,12 @@
         "additional_select_columns": ["luc"]
     },
     {
+        "name": "iasworld_pardat_class_in_ccao_class_dict",
+        "description": "class_code should be valid",
+        "category": "class_mismatch_or_issue",
+        "condition": "class_dict_class IS NOT NULL"
+    },
+    {
         "name": "iasworld_pardat_cur_in_accepted_values",
         "description": 'cur should be "Y" or "D"',
         "category": "incorrect_values",
@@ -67,6 +73,7 @@
         pardat.cur,
         pardat.nbhd,
         nbhd.town_nbhd,
+        class_dict.class_code AS class_dict_class,
         pardat.seq,
         LAG(pardat.seq)
             OVER (PARTITION BY pardat.parid, pardat.taxyr ORDER BY pardat.seq)
@@ -74,8 +81,8 @@
         COUNT(*)
             OVER (PARTITION BY pardat.parid, pardat.taxyr)
             AS num_duplicates
-    FROM iasworld.pardat AS pardat
-    LEFT JOIN iasworld.legdat AS legdat
+    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    LEFT JOIN {{ source('iasworld', 'legdat') }} AS legdat
         ON pardat.parid = legdat.parid
         AND pardat.taxyr = legdat.taxyr
         AND legdat.cur = 'Y'
@@ -85,6 +92,11 @@
         FROM {{ source('spatial', 'neighborhood') }}
     ) AS nbhd
         ON pardat.nbhd = nbhd.town_nbhd
+    LEFT JOIN (
+        SELECT DISTINCT class_code
+        FROM {{ ref('ccao', 'class_dict') }}
+    ) AS class_dict
+        ON pardat.class = class_dict.class_code
     WHERE pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
 {% endset %}

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -94,7 +94,7 @@
         ON pardat.nbhd = nbhd.town_nbhd
     LEFT JOIN (
         SELECT DISTINCT class_code
-        FROM {{ ref('ccao', 'class_dict') }}
+        FROM {{ ref('ccao.class_dict') }}
     ) AS class_dict
         ON pardat.class = class_dict.class_code
     WHERE pardat.cur = 'Y'

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -17,7 +17,7 @@
         "name": "iasworld_pardat_class_in_ccao_class_dict",
         "description": "class_code should be valid",
         "category": "class_mismatch_or_issue",
-        "condition": "class_dict_class IS NOT NULL",
+        "condition": "class_dict_class IS NOT NULL OR class IN ('EX', 'RR') OR REGEXP_LIKE(class, '[0-9]{3}[A|B]')",
         "additional_select_columns": ["class"]
     },
     {

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -17,7 +17,8 @@
         "name": "iasworld_pardat_class_in_ccao_class_dict",
         "description": "class_code should be valid",
         "category": "class_mismatch_or_issue",
-        "condition": "class_dict_class IS NOT NULL"
+        "condition": "class_dict_class IS NOT NULL",
+        "additional_select_columns": ["class"]
     },
     {
         "name": "iasworld_pardat_cur_in_accepted_values",

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -17,7 +17,7 @@
         "name": "iasworld_pardat_class_in_ccao_class_dict",
         "description": "class_code should be valid",
         "category": "class_mismatch_or_issue",
-        "condition": "class_dict_class IS NOT NULL,
+        "condition": "class_dict_class IS NOT NULL",
         "additional_select_columns": ["class"]
     },
     {

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -143,6 +143,7 @@ iasworld_pardat_nbhd_matches_legdat_township AS (
             AND {{ var('data_test_iasworld_year_end') }}
         AND pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
+        AND pardat.nbhd NOT LIKE '%999'
 ),
 
 iasworld_pardat_nbhd_matches_spatial_town_nbhd AS (

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -17,7 +17,7 @@
         "name": "iasworld_pardat_class_in_ccao_class_dict",
         "description": "class_code should be valid",
         "category": "class_mismatch_or_issue",
-        "condition": "class_dict_class IS NOT NULL OR class IN ('EX', 'RR') OR REGEXP_LIKE(class, '[0-9]{3}[A|B]')",
+        "condition": "class_dict_class IS NOT NULL,
         "additional_select_columns": ["class"]
     },
     {

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -1,238 +1,92 @@
-WITH legdat_townships AS (
+{%- set tests = [
+    {
+        "name": "iasworld_pardat_adrno_length_lte_5",
+        "description": "adrno should be <= 5 characters long",
+        "category": "column_length",
+        "condition": "length(adrno) <= 5",
+        "additional_select_columns": ["adrno"]
+    },
+    {
+        "name": "iasworld_pardat_class_equals_luc",
+        "description": "class should be the same as luc",
+        "category": "class_mismatch_or_issue",
+        "condition": "class = luc",
+        "additional_select_columns": ["luc"]
+    },
+    {
+        "name": "iasworld_pardat_cur_in_accepted_values",
+        "description": 'cur should be "Y" or "D"',
+        "category": "incorrect_values",
+        "condition": "cur IN ('Y', 'D')",
+        "additional_select_columns": ["cur"]
+    },
+    {
+        "name": "iasworld_pardat_nbhd_matches_legdat_township",
+        "description": "nbhd code first 2 digits should match legdat.user1 (township code)",
+        "category": "relationships",
+        "condition": "SUBSTR(nbhd, 1, 2) = township_code",
+        "additional_select_columns": ["nbhd"]
+    },
+    {
+        "name": "iasworld_pardat_nbhd_matches_spatial_town_nbhd",
+        "description": "nbhd code not valid",
+        "category": "relationships",
+        "condition": "town_nbhd IS NOT NULL OR nbhd LIKE '%999'",
+        "additional_select_columns": ["nbhd"]
+    },
+    {
+        "name": "iasworld_pardat_seq_all_sequential_exist",
+        "description": "seq should be sequential",
+        "category": "incorrect_values",
+        "condition": "seq = prev_seq + 1",
+        "additional_select_columns": ["seq", "prev_seq"]
+    },
+    {
+        "name": "iasworld_pardat_unique_by_parid_taxyr",
+        "description": "pardat should be unique by parid and taxyr",
+        "category": "duplicate_rows",
+        "condition": "num_duplicates = 1",
+        "additional_select_columns": ["num_duplicates"]
+    }
+] -%}
+
+{%- set base_query %}
     SELECT
-        parid,
-        taxyr,
-        user1 AS township_code
-    FROM {{ source('iasworld', 'legdat') }}
-    WHERE cur = 'Y'
-        AND deactivat IS NULL
-),
-
-distinct_town_nbhd AS (
-    SELECT DISTINCT town_nbhd
-    FROM {{ source('spatial', 'neighborhood') }}
-),
-
-pardat AS (
-    SELECT *
-    FROM {{ source('iasworld', 'pardat') }}
-    WHERE CAST(taxyr AS INT) BETWEEN
-        {{ var('data_test_iasworld_year_start') }}
-        AND {{ var('data_test_iasworld_year_end') }}
-        AND cur = 'Y'
-        AND deactivat IS NULL
-),
-
-pardat_seq AS (
-    SELECT
-        parid,
-        taxyr,
-        class,
-        seq,
-        LAG(seq) OVER (PARTITION BY parid, taxyr ORDER BY seq) AS prev_seq,
-        who,
-        wen
-    FROM pardat
-),
-
-iasworld_pardat_adrno_length_lte_5 AS (
-    SELECT
-        'iasworld_pardat_adrno_length_lte_5' AS test_name,
-        'adrno should be <= 5 characters long' AS test_description,
-        'column_length' AS test_category,
-        pardat.taxyr,
+        -- Identifying columns
         pardat.parid,
+        pardat.taxyr,
         CAST(NULL AS INTEGER) AS card,
         CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
+        legdat.user1 AS township_code,
         pardat.class,
         pardat.who,
         pardat.wen,
-        MAP(
-            ARRAY['adrno'],
-            ARRAY[CAST(pardat.adrno AS VARCHAR)]
-        ) AS additional_fields
-    FROM pardat
-    LEFT JOIN legdat_townships AS legdat
+        -- Columns to test
+        CAST(pardat.adrno AS VARCHAR) AS adrno,
+        pardat.luc,
+        pardat.cur,
+        pardat.nbhd,
+        nbhd.town_nbhd,
+        pardat.seq,
+        LAG(pardat.seq)
+            OVER (PARTITION BY pardat.parid, pardat.taxyr ORDER BY pardat.seq)
+            AS prev_seq,
+        COUNT(*)
+            OVER (PARTITION BY pardat.parid, pardat.taxyr)
+            AS num_duplicates
+    FROM iasworld.pardat AS pardat
+    LEFT JOIN iasworld.legdat AS legdat
         ON pardat.parid = legdat.parid
         AND pardat.taxyr = legdat.taxyr
-    WHERE NOT (LENGTH(CAST(pardat.adrno AS VARCHAR)) <= 5)
-),
+        AND legdat.cur = 'Y'
+        AND legdat.deactivat IS NULL
+    LEFT JOIN (
+        SELECT DISTINCT town_nbhd
+        FROM {{ source('spatial', 'neighborhood') }}
+    ) AS nbhd
+        ON pardat.nbhd = nbhd.town_nbhd
+    WHERE pardat.cur = 'Y'
+        AND pardat.deactivat IS NULL
+{% endset %}
 
-iasworld_pardat_class_equals_luc AS (
-    SELECT
-        'iasworld_pardat_class_equals_luc' AS test_name,
-        'class should be the same as luc' AS test_description,
-        'class_mismatch_or_issue' AS test_category,
-        pardat.taxyr,
-        pardat.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat.class,
-        pardat.who,
-        pardat.wen,
-        MAP(
-            ARRAY['luc'],
-            ARRAY[pardat.luc]
-        ) AS additional_fields
-    FROM pardat
-    LEFT JOIN legdat_townships AS legdat
-        ON pardat.parid = legdat.parid
-        AND pardat.taxyr = legdat.taxyr
-    WHERE NOT (pardat.class = pardat.luc)
-),
-
-iasworld_pardat_cur_in_accepted_values AS (
-    SELECT
-        'iasworld_pardat_cur_in_accepted_values' AS test_name,
-        'cur should be ''Y'' or ''D''' AS test_description,
-        CAST(NULL AS VARCHAR) AS test_category,
-        pardat.taxyr,
-        pardat.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat.class,
-        pardat.who,
-        pardat.wen,
-        MAP(
-            ARRAY['cur'],
-            ARRAY[pardat.cur]
-        ) AS additional_fields
-    FROM {{ source('iasworld', 'pardat') }} AS pardat
-    LEFT JOIN legdat_townships AS legdat
-        ON pardat.parid = legdat.parid
-        AND pardat.taxyr = legdat.taxyr
-    WHERE pardat.cur NOT IN ('Y', 'D')
-        AND CAST(pardat.taxyr AS INT) BETWEEN
-        {{ var('data_test_iasworld_year_start') }}
-        AND {{ var('data_test_iasworld_year_end') }}
-),
-
-iasworld_pardat_nbhd_matches_legdat_township AS (
-    SELECT
-        'iasworld_pardat_nbhd_matches_legdat_township' AS test_name,
-        'nbhd code first 2 digits should match legdat.user1 (township code)'
-            AS test_description,
-        'relationships' AS test_category,
-        pardat.taxyr,
-        pardat.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat.class,
-        pardat.who,
-        pardat.wen,
-        MAP(
-            ARRAY['nbhd'],
-            ARRAY[pardat.nbhd]
-        ) AS additional_fields
-    FROM pardat
-    INNER JOIN legdat_townships AS legdat
-        ON pardat.parid = legdat.parid
-        AND pardat.taxyr = legdat.taxyr
-        AND SUBSTR(pardat.nbhd, 1, 2) != legdat.township_code
-),
-
-iasworld_pardat_nbhd_matches_spatial_town_nbhd AS (
-    SELECT
-        'iasworld_pardat_nbhd_matches_spatial_town_nbhd' AS test_name,
-        'nbhd code not valid' AS test_description,
-        'relationships' AS test_category,
-        pardat.taxyr,
-        pardat.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat.class,
-        pardat.who,
-        pardat.wen,
-        MAP(
-            ARRAY['nbhd'],
-            ARRAY[pardat.nbhd]
-        ) AS additional_fields
-    FROM pardat
-    LEFT JOIN legdat_townships AS legdat
-        ON pardat.parid = legdat.parid
-        AND pardat.taxyr = legdat.taxyr
-    LEFT JOIN distinct_town_nbhd
-        ON pardat.nbhd = distinct_town_nbhd.town_nbhd
-    WHERE distinct_town_nbhd.town_nbhd IS NULL
-        AND pardat.nbhd NOT LIKE '%999'
-),
-
-iasworld_pardat_seq_all_sequential_exist AS (
-    SELECT
-        'iasworld_pardat_seq_all_sequential_exist' AS test_name,
-        'seq should be sequential' AS test_description,
-        CAST(NULL AS VARCHAR) AS test_category,
-        pardat_seq.taxyr,
-        pardat_seq.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat_seq.class,
-        pardat_seq.who,
-        pardat_seq.wen,
-        MAP(
-            ARRAY['seq', 'prev_seq'],
-            ARRAY[
-                CAST(pardat_seq.seq AS VARCHAR),
-                CAST(pardat_seq.prev_seq AS VARCHAR)
-            ]
-        ) AS additional_fields
-    FROM pardat_seq
-    LEFT JOIN legdat_townships AS legdat
-        ON pardat_seq.parid = legdat.parid
-        AND pardat_seq.taxyr = legdat.taxyr
-    WHERE NOT (pardat_seq.seq = pardat_seq.prev_seq + 1)
-),
-
-iasworld_pardat_unique_by_parid_taxyr AS (
-    SELECT
-        'iasworld_pardat_unique_by_parid_taxyr' AS test_name,
-        'pardat should be unique by parid and taxyr' AS test_description,
-        CAST(NULL AS VARCHAR) AS test_category,
-        pardat.taxyr,
-        pardat.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat.class,
-        pardat.who,
-        pardat.wen,
-        MAP(
-            ARRAY['num_duplicates'],
-            ARRAY[CAST(dupe_counts.num_dupes AS VARCHAR)]
-        ) AS additional_fields
-    FROM pardat
-    LEFT JOIN legdat_townships AS legdat
-        ON pardat.parid = legdat.parid
-        AND pardat.taxyr = legdat.taxyr
-    INNER JOIN (
-        SELECT
-            parid,
-            taxyr,
-            COUNT(*) AS num_dupes
-        FROM pardat
-        GROUP BY parid, taxyr
-        HAVING COUNT(*) > 1
-    ) AS dupe_counts
-        ON pardat.parid = dupe_counts.parid
-        AND pardat.taxyr = dupe_counts.taxyr
-)
-
-SELECT * FROM iasworld_pardat_adrno_length_lte_5
-UNION ALL
-SELECT * FROM iasworld_pardat_class_equals_luc
-UNION ALL
-SELECT * FROM iasworld_pardat_cur_in_accepted_values
-UNION ALL
-SELECT * FROM iasworld_pardat_nbhd_matches_legdat_township
-UNION ALL
-SELECT * FROM iasworld_pardat_nbhd_matches_spatial_town_nbhd
-UNION ALL
-SELECT * FROM iasworld_pardat_seq_all_sequential_exist
-UNION ALL
-SELECT * FROM iasworld_pardat_unique_by_parid_taxyr
+{{ generate_iasworld_qc_test_view(base_query, tests) }}

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -133,7 +133,6 @@ iasworld_pardat_nbhd_matches_legdat_township AS (
         ON pardat.parid = legdat.parid
         AND pardat.taxyr = legdat.taxyr
         AND SUBSTR(pardat.nbhd, 1, 2) != legdat.township_code
-    WHERE pardat.nbhd NOT LIKE '%999'
 ),
 
 iasworld_pardat_nbhd_matches_spatial_town_nbhd AS (

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -17,7 +17,7 @@
         "name": "iasworld_pardat_class_in_ccao_class_dict",
         "description": "class_code should be valid",
         "category": "class_mismatch_or_issue",
-        "condition": "class_dict_class IS NOT NULL",
+        "condition": "class_dict_class IS NOT NULL OR class IN ('EX', 'RR') OR REGEXP_LIKE(class, '[0-9]{3}[A|B]')"
         "additional_select_columns": ["class"]
     },
     {

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -1,0 +1,260 @@
+WITH legdat_townships AS (
+    SELECT
+        parid,
+        taxyr,
+        user1 AS township_code
+    FROM {{ source('iasworld', 'legdat') }}
+    WHERE cur = 'Y'
+        AND deactivat IS NULL
+),
+
+distinct_town_nbhd AS (
+    SELECT DISTINCT town_nbhd
+    FROM {{ source('spatial', 'neighborhood') }}
+),
+
+pardat_seq AS (
+    SELECT
+        parid,
+        taxyr,
+        class,
+        seq,
+        LAG(seq) OVER (PARTITION BY parid, taxyr ORDER BY seq) AS prev_seq,
+        who,
+        wen
+    FROM {{ source('iasworld', 'pardat') }}
+    WHERE CAST(taxyr AS INT) BETWEEN
+            {{ var('data_test_iasworld_year_start') }}
+            AND {{ var('data_test_iasworld_year_end') }}
+        AND cur = 'Y'
+        AND deactivat IS NULL
+),
+
+iasworld_pardat_adrno_length_lte_5 AS (
+    SELECT
+        'iasworld_pardat_adrno_length_lte_5' AS test_name,
+        'adrno should be <= 5 characters long' AS test_description,
+        'column_length' AS test_category,
+        pardat.taxyr,
+        pardat.parid,
+        CAST(NULL AS INTEGER) AS card,
+        CAST(NULL AS INTEGER) AS lline,
+        legdat.township_code,
+        pardat.class,
+        pardat.who,
+        pardat.wen,
+        MAP(
+            ARRAY['adrno'],
+            ARRAY[CAST(pardat.adrno AS VARCHAR)]
+        ) AS additional_fields
+    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    LEFT JOIN legdat_townships AS legdat
+        ON pardat.parid = legdat.parid
+        AND pardat.taxyr = legdat.taxyr
+    WHERE NOT (LENGTH(CAST(pardat.adrno AS VARCHAR)) <= 5)
+        AND CAST(pardat.taxyr AS INT) BETWEEN
+            {{ var('data_test_iasworld_year_start') }}
+            AND {{ var('data_test_iasworld_year_end') }}
+        AND pardat.cur = 'Y'
+        AND pardat.deactivat IS NULL
+),
+
+iasworld_pardat_class_equals_luc AS (
+    SELECT
+        'iasworld_pardat_class_equals_luc' AS test_name,
+        'class should be the same as luc' AS test_description,
+        'class_mismatch_or_issue' AS test_category,
+        pardat.taxyr,
+        pardat.parid,
+        CAST(NULL AS INTEGER) AS card,
+        CAST(NULL AS INTEGER) AS lline,
+        legdat.township_code,
+        pardat.class,
+        pardat.who,
+        pardat.wen,
+        MAP(
+            ARRAY['luc'],
+            ARRAY[pardat.luc]
+        ) AS additional_fields
+    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    LEFT JOIN legdat_townships AS legdat
+        ON pardat.parid = legdat.parid
+        AND pardat.taxyr = legdat.taxyr
+    WHERE NOT (pardat.class = pardat.luc)
+        AND CAST(pardat.taxyr AS INT) BETWEEN
+            {{ var('data_test_iasworld_year_start') }}
+            AND {{ var('data_test_iasworld_year_end') }}
+        AND pardat.cur = 'Y'
+        AND pardat.deactivat IS NULL
+),
+
+iasworld_pardat_cur_in_accepted_values AS (
+    SELECT
+        'iasworld_pardat_cur_in_accepted_values' AS test_name,
+        'cur should be ''Y'' or ''D''' AS test_description,
+        CAST(NULL AS VARCHAR) AS test_category,
+        pardat.taxyr,
+        pardat.parid,
+        CAST(NULL AS INTEGER) AS card,
+        CAST(NULL AS INTEGER) AS lline,
+        legdat.township_code,
+        pardat.class,
+        pardat.who,
+        pardat.wen,
+        MAP(
+            ARRAY['cur'],
+            ARRAY[pardat.cur]
+        ) AS additional_fields
+    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    LEFT JOIN legdat_townships AS legdat
+        ON pardat.parid = legdat.parid
+        AND pardat.taxyr = legdat.taxyr
+    WHERE pardat.cur NOT IN ('Y', 'D')
+        AND CAST(pardat.taxyr AS INT) BETWEEN
+            {{ var('data_test_iasworld_year_start') }}
+            AND {{ var('data_test_iasworld_year_end') }}
+),
+
+iasworld_pardat_nbhd_matches_legdat_township AS (
+    SELECT
+        'iasworld_pardat_nbhd_matches_legdat_township' AS test_name,
+        'nbhd code first 2 digits should match legdat.user1 (township code)'
+            AS test_description,
+        'relationships' AS test_category,
+        pardat.taxyr,
+        pardat.parid,
+        CAST(NULL AS INTEGER) AS card,
+        CAST(NULL AS INTEGER) AS lline,
+        legdat.township_code,
+        pardat.class,
+        pardat.who,
+        pardat.wen,
+        MAP(
+            ARRAY['nbhd'],
+            ARRAY[pardat.nbhd]
+        ) AS additional_fields
+    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    INNER JOIN legdat_townships AS legdat
+        ON pardat.parid = legdat.parid
+        AND pardat.taxyr = legdat.taxyr
+        AND SUBSTR(pardat.nbhd, 1, 2) != legdat.township_code
+    WHERE CAST(pardat.taxyr AS INT) BETWEEN
+            {{ var('data_test_iasworld_year_start') }}
+            AND {{ var('data_test_iasworld_year_end') }}
+        AND pardat.cur = 'Y'
+        AND pardat.deactivat IS NULL
+),
+
+iasworld_pardat_nbhd_matches_spatial_town_nbhd AS (
+    SELECT
+        'iasworld_pardat_nbhd_matches_spatial_town_nbhd' AS test_name,
+        'nbhd code not valid' AS test_description,
+        'relationships' AS test_category,
+        pardat.taxyr,
+        pardat.parid,
+        CAST(NULL AS INTEGER) AS card,
+        CAST(NULL AS INTEGER) AS lline,
+        legdat.township_code,
+        pardat.class,
+        pardat.who,
+        pardat.wen,
+        MAP(
+            ARRAY['nbhd'],
+            ARRAY[pardat.nbhd]
+        ) AS additional_fields
+    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    LEFT JOIN legdat_townships AS legdat
+        ON pardat.parid = legdat.parid
+        AND pardat.taxyr = legdat.taxyr
+    LEFT JOIN distinct_town_nbhd
+        ON pardat.nbhd = distinct_town_nbhd.town_nbhd
+    WHERE distinct_town_nbhd.town_nbhd IS NULL
+        AND CAST(pardat.taxyr AS INT) BETWEEN
+            {{ var('data_test_iasworld_year_start') }}
+            AND {{ var('data_test_iasworld_year_end') }}
+        AND pardat.cur = 'Y'
+        AND pardat.deactivat IS NULL
+        AND pardat.nbhd NOT LIKE '%999'
+),
+
+iasworld_pardat_seq_all_sequential_exist AS (
+    SELECT
+        'iasworld_pardat_seq_all_sequential_exist' AS test_name,
+        'seq should be sequential' AS test_description,
+        CAST(NULL AS VARCHAR) AS test_category,
+        pardat_seq.taxyr,
+        pardat_seq.parid,
+        CAST(NULL AS INTEGER) AS card,
+        CAST(NULL AS INTEGER) AS lline,
+        legdat.township_code,
+        pardat_seq.class,
+        pardat_seq.who,
+        pardat_seq.wen,
+        MAP(
+            ARRAY['seq', 'prev_seq'],
+            ARRAY[
+                CAST(pardat_seq.seq AS VARCHAR),
+                CAST(pardat_seq.prev_seq AS VARCHAR)
+            ]
+        ) AS additional_fields
+    FROM pardat_seq
+    LEFT JOIN legdat_townships AS legdat
+        ON pardat_seq.parid = legdat.parid
+        AND pardat_seq.taxyr = legdat.taxyr
+    WHERE NOT (pardat_seq.seq = pardat_seq.prev_seq + 1)
+),
+
+iasworld_pardat_unique_by_parid_taxyr AS (
+    SELECT
+        'iasworld_pardat_unique_by_parid_taxyr' AS test_name,
+        'pardat should be unique by parid and taxyr' AS test_description,
+        CAST(NULL AS VARCHAR) AS test_category,
+        pardat.taxyr,
+        pardat.parid,
+        CAST(NULL AS INTEGER) AS card,
+        CAST(NULL AS INTEGER) AS lline,
+        legdat.township_code,
+        pardat.class,
+        pardat.who,
+        pardat.wen,
+        MAP(
+            ARRAY['num_duplicates'],
+            ARRAY[CAST(dupe_counts.num_dupes AS VARCHAR)]
+        ) AS additional_fields
+    FROM {{ source('iasworld', 'pardat') }} AS pardat
+    LEFT JOIN legdat_townships AS legdat
+        ON pardat.parid = legdat.parid
+        AND pardat.taxyr = legdat.taxyr
+    INNER JOIN (
+        SELECT parid, taxyr, COUNT(*) AS num_dupes
+        FROM {{ source('iasworld', 'pardat') }}
+        WHERE CAST(taxyr AS INT) BETWEEN
+                {{ var('data_test_iasworld_year_start') }}
+                AND {{ var('data_test_iasworld_year_end') }}
+            AND cur = 'Y'
+            AND deactivat IS NULL
+        GROUP BY parid, taxyr
+        HAVING COUNT(*) > 1
+    ) AS dupe_counts
+        ON pardat.parid = dupe_counts.parid
+        AND pardat.taxyr = dupe_counts.taxyr
+    WHERE CAST(pardat.taxyr AS INT) BETWEEN
+            {{ var('data_test_iasworld_year_start') }}
+            AND {{ var('data_test_iasworld_year_end') }}
+        AND pardat.cur = 'Y'
+        AND pardat.deactivat IS NULL
+)
+
+SELECT * FROM iasworld_pardat_adrno_length_lte_5
+UNION ALL
+SELECT * FROM iasworld_pardat_class_equals_luc
+UNION ALL
+SELECT * FROM iasworld_pardat_cur_in_accepted_values
+UNION ALL
+SELECT * FROM iasworld_pardat_nbhd_matches_legdat_township
+UNION ALL
+SELECT * FROM iasworld_pardat_nbhd_matches_spatial_town_nbhd
+UNION ALL
+SELECT * FROM iasworld_pardat_seq_all_sequential_exist
+UNION ALL
+SELECT * FROM iasworld_pardat_unique_by_parid_taxyr

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -93,10 +93,7 @@
         FROM {{ source('spatial', 'neighborhood') }}
     ) AS nbhd
         ON pardat.nbhd = nbhd.town_nbhd
-    LEFT JOIN (
-        SELECT DISTINCT class_code
-        FROM {{ ref('ccao.class_dict') }}
-    ) AS class_dict
+    LEFT JOIN {{ ref('ccao.class_dict') }} AS class_dict
         ON pardat.class = class_dict.class_code
     WHERE pardat.cur = 'Y'
         AND pardat.deactivat IS NULL

--- a/dbt/models/qc/schema.yml
+++ b/dbt/models/qc/schema.yml
@@ -1,4 +1,10 @@
 models:
+  - name: qc.vw_report_iasworld_test_all
+    description: '{{ doc("view_vw_report_iasworld_test_all") }}'
+
+  - name: qc.vw_report_iasworld_test_owndat
+    description: '{{ doc("view_vw_report_iasworld_test_owndat") }}'
+
   - name: qc.vw_report_iasworld_test_pardat
     description: '{{ doc("view_vw_report_iasworld_test_pardat") }}'
 

--- a/dbt/models/qc/schema.yml
+++ b/dbt/models/qc/schema.yml
@@ -1,9 +1,6 @@
 models:
   - name: qc.vw_report_iasworld_test_pardat
-    description: >
-      Recreates iasworld.pardat data tests as a queryable view, with one row
-      per PIN failing a given test. Used to power the Tableau iasWorld QC
-      dashboard.
+    description: '{{ doc("view_vw_report_iasworld_test_pardat") }}'
 
   - name: qc.vw_change_in_ahsap_values
     description: '{{ doc("view_vw_change_in_ahsap_values") }}'

--- a/dbt/models/qc/schema.yml
+++ b/dbt/models/qc/schema.yml
@@ -1,4 +1,10 @@
 models:
+  - name: qc.vw_report_iasworld_test_pardat
+    description: >
+      Recreates iasworld.pardat data tests as a queryable view, with one row
+      per PIN failing a given test. Used to power the Tableau iasWorld QC
+      dashboard.
+
   - name: qc.vw_change_in_ahsap_values
     description: '{{ doc("view_vw_change_in_ahsap_values") }}'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,4 @@ load_macros_from_path = "dbt/macros"
 # lints
 get_s3_dependency_dir = "{% macro get_s3_dependency_dir() %}s3://bucket{% endmacro %}"
 insert_hyphens = "{% macro insert_hyphens(str) %}{% set _ = varargs %}'{{ str }}'{% endmacro %}"
+generate_iasworld_qc_test_view = "{% macro generate_iasworld_qc_test_view(base_query, tests) %}select 1{% endmacro %}"


### PR DESCRIPTION
This is the query that I have been using to test. It seems like it gets updated pretty frequently, so although it passessed yesterday, it is failing today. Here's an example of a PIN which fails in this query, but has updated info for matching class_equals_luc: Parid `25343080220000`

<img width="195" height="115" alt="image" src="https://github.com/user-attachments/assets/1a3328ff-3c75-4a59-9e8e-38208f92f3b3" />

```
WITH view_rows AS (
    SELECT test_name, parid, taxyr
    FROM z_ci_1088_create_tableau_dashboard_based_on_iasworld_tests_qc.vw_report_iasworld_test_pardat
),
test_failure_rows AS (
    SELECT 'iasworld_pardat_adrno_length_lte_5' AS test_name, parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_pardat_adrno_length_lte_5
    UNION ALL
    SELECT 'iasworld_pardat_class_equals_luc', parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_pardat_class_equals_luc
    UNION ALL
    SELECT 'iasworld_pardat_cur_in_accepted_values', parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_pardat_cur_in_accepted_values
    UNION ALL
    SELECT 'iasworld_pardat_nbhd_matches_legdat_township', parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_pardat_nbhd_matches_legdat_township
    UNION ALL
    SELECT 'iasworld_pardat_nbhd_matches_spatial_town_nbhd', parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_pardat_nbhd_matches_spatial_town_nbhd
    UNION ALL
    SELECT 'iasworld_pardat_seq_all_sequential_exist', parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_pardat_seq_all_sequential_exist
    UNION ALL
    SELECT 'iasworld_pardat_unique_by_parid_taxyr', parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_pardat_unique_by_parid_taxyr
)
SELECT
    COALESCE(v.test_name, f.test_name) AS test_name,
    COALESCE(v.parid, f.parid) AS parid,
    COALESCE(v.taxyr, f.taxyr) AS taxyr,
    CASE
        WHEN v.parid IS NULL THEN 'only in old failures'
        WHEN f.parid IS NULL THEN 'only in new failures'
    END AS source
FROM view_rows v
FULL OUTER JOIN test_failure_rows f
    ON v.test_name = f.test_name
    AND v.parid = f.parid
    AND v.taxyr = f.taxyr
WHERE v.parid IS NULL OR f.parid IS NULL
ORDER BY parid, test_name

```

owndat only produces errors for whitespaces

```
WITH view_rows AS (
    SELECT test_name, parid, taxyr
    FROM z_ci_1088_create_tableau_dashboard_based_on_iasworld_tests_qc.vw_report_iasworld_test_owndat
    WHERE test_name NOT IN ('iasworld_owndat_address_columns_no_extra_whitespace')
),
test_failure_rows AS (
    SELECT 'iasworld_owndat_cur_in_accepted_values' AS test_name, parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_owndat_cur_in_accepted_values
    UNION ALL
    SELECT 'iasworld_owndat_parid_in_pardat_parid', parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_owndat_parid_in_pardat_parid
    UNION ALL
    SELECT 'iasworld_owndat_parid_not_null', CAST(NULL AS VARCHAR) AS parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_owndat_parid_not_null
    UNION ALL
    SELECT 'iasworld_owndat_seq_all_sequential_exist', parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_owndat_seq_all_sequential_exist
    UNION ALL
    SELECT 'iasworld_owndat_unique_by_parid_taxyr', parid, taxyr
    FROM z_dev_damajor_test_failure.iasworld_owndat_unique_by_parid_taxyr
)
SELECT
    COALESCE(v.test_name, f.test_name) AS test_name,
    COALESCE(v.parid, f.parid) AS parid,
    COALESCE(v.taxyr, f.taxyr) AS taxyr,
    CASE
        WHEN v.test_name IS NULL THEN 'only in old failures'
        WHEN f.test_name IS NULL THEN 'only in new failures'
    END AS source
FROM view_rows v
FULL OUTER JOIN test_failure_rows f
    ON v.test_name = f.test_name
    AND v.parid IS NOT DISTINCT FROM f.parid
    AND v.taxyr = f.taxyr
WHERE v.test_name IS NULL OR f.test_name IS NULL
ORDER BY parid, test_name
```

It then unions both tables into the view `dbt/models/qc/qc.vw_report_iasworld_test_all.sql`