### PR TITLE
Update `test_open_data_assets.py` script to handle historical mismatches

### DIFF
--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -53,7 +53,7 @@ REQUESTS.mount(
 # (which is updated bi-weekly or monthly). We expect differences to arise for
 # prior years due to our slower open data update cadence for those years (once
 # a year) despite their relatively static nature in Athena.
-BUFFERS = {"current": 0.02, "prior": 0.2}
+BUFFERS = {"current": 0.02, "prior": 0.1}
 
 
 def main() -> None:
@@ -159,8 +159,11 @@ def main() -> None:
             "by year:"
         )
 
+        # Declaring column types for agate helps make sure number columns with
+        # values of only 0/1 aren't coerced into booleans and makes printing
+        # our year column cleaner.
         diff_column_types = {
-            DEFAULT_YEAR_FIELD: agate.Text(),
+            "year": agate.Text(),
             source_model_name: agate.Number(),
             asset_name: agate.Number(),
         }
@@ -170,10 +173,6 @@ def main() -> None:
             diff_table = agate.Table.from_object(
                 diff, column_types=diff_column_types
             )
-            # Note that agate adds thousands separators to years, even when
-            # they're strings (as in our data). This is super annoying but
-            # it's still the fastest way we know to print a clean table
-            # in Python :\
             diff_table.print_table(
                 max_rows=None, max_columns=None, max_column_width=None
             )

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -241,18 +241,15 @@ def diff_row_counts(
             )
             continue
 
-        counts_match = (
-            (
-                model_count * (1 - current_year_buffer)
-                < asset_count
-                < model_count * (1 + current_year_buffer)
-            )
+        buffer = (
+            current_year_buffer
             if model_year in [current_year, last_year]
-            else (
-                model_count * (1 - prior_year_buffer)
-                < asset_count
-                < model_count * (1 + prior_year_buffer)
-            )
+            else prior_year_buffer
+        )
+        counts_match = (
+            model_count * (1 - buffer)
+            < asset_count
+            < model_count * (1 + buffer)
         )
 
         if not counts_match:

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -47,12 +47,13 @@ REQUESTS.mount(
     "https://datacatalog.cookcountyil.gov", HTTPAdapter(max_retries=retries)
 )
 
-# Data for the most recent two years are permitted to be slightly different,
-# according to this buffer value. This is because we expect some level of
-# change in the Athena data (which is updated daily) compared to the Open Data
-# portal (which is updated bi-weekly or monthly).
-BUFFER_CURRENT = 0.02
-BUFFER_OLD = 0.5
+# Data is permitted to be slightly different, according to these buffer values.
+# This is because we expect some level of change for the most current two years
+# in the Athena data (which is updated daily) compared to the Open Data portal
+# (which is updated bi-weekly or monthly). We expect differences to arise for
+# prior years due to our slower open data update cadence for those years (once
+# a year) despite their relatively static nature in Athena.
+BUFFERS = {"current": 0.02, "prior": 0.3}
 
 
 def main() -> None:
@@ -180,8 +181,7 @@ def diff_row_counts(
     open_data_asset_row_counts: typing.List[typing.Dict],
     athena_model_year_field: str = DEFAULT_YEAR_FIELD,
     open_data_asset_year_field: str = DEFAULT_YEAR_FIELD,
-    current_year_buffer: float = BUFFER_CURRENT,
-    prior_year_buffer: float = BUFFER_OLD,
+    buffers: typing.Dict[str, float] = BUFFERS,
 ) -> typing.List[typing.Dict]:
     """Check whether two lists of row count dicts are the same. Applies a
     buffer to the current year of data to account for the fact that more
@@ -242,9 +242,9 @@ def diff_row_counts(
             continue
 
         buffer = (
-            current_year_buffer
+            buffers["current"]
             if model_year in [current_year, last_year]
-            else prior_year_buffer
+            else buffers["prior"]
         )
         counts_match = (
             model_count * (1 - buffer)

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -53,7 +53,7 @@ REQUESTS.mount(
 # (which is updated bi-weekly or monthly). We expect differences to arise for
 # prior years due to our slower open data update cadence for those years (once
 # a year) despite their relatively static nature in Athena.
-BUFFERS = {"current": 0.02, "prior": 0.1}
+BUFFERS = {"current": 0.02, "prior": 0.2}
 
 
 def main() -> None:
@@ -162,11 +162,7 @@ def main() -> None:
         # Declaring column types for agate helps make sure number columns with
         # values of only 0/1 aren't coerced into booleans and makes printing
         # our year column cleaner.
-        diff_column_types = {
-            "year": agate.Text(),
-            source_model_name: agate.Number(),
-            asset_name: agate.Number(),
-        }
+        diff_column_types = (agate.Text(), agate.Number(), agate.Number())
 
         for diff in diffs:
             print()

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -53,7 +53,7 @@ REQUESTS.mount(
 # (which is updated bi-weekly or monthly). We expect differences to arise for
 # prior years due to our slower open data update cadence for those years (once
 # a year) despite their relatively static nature in Athena.
-BUFFERS = {"current": 0.02, "prior": 0.3}
+BUFFERS = {"current": 0.02, "prior": 0.2}
 
 
 def main() -> None:
@@ -158,9 +158,18 @@ def main() -> None:
             "The following view/asset pairs had mismatching row counts "
             "by year:"
         )
+
+        diff_column_types = {
+            DEFAULT_YEAR_FIELD: agate.Text(),
+            source_model_name: agate.Number(),
+            asset_name: agate.Number(),
+        }
+
         for diff in diffs:
             print()
-            diff_table = agate.Table.from_object(diff)
+            diff_table = agate.Table.from_object(
+                diff, column_types=diff_column_types
+            )
             # Note that agate adds thousands separators to years, even when
             # they're strings (as in our data). This is super annoying but
             # it's still the fastest way we know to print a clean table

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -51,7 +51,8 @@ REQUESTS.mount(
 # according to this buffer value. This is because we expect some level of
 # change in the Athena data (which is updated daily) compared to the Open Data
 # portal (which is updated bi-weekly or monthly).
-BUFFER = 0.02
+BUFFER_CURRENT = 0.02
+BUFFER_OLD = 0.5
 
 
 def main() -> None:
@@ -179,7 +180,8 @@ def diff_row_counts(
     open_data_asset_row_counts: typing.List[typing.Dict],
     athena_model_year_field: str = DEFAULT_YEAR_FIELD,
     open_data_asset_year_field: str = DEFAULT_YEAR_FIELD,
-    current_year_buffer: float = BUFFER,
+    current_year_buffer: float = BUFFER_CURRENT,
+    prior_year_buffer: float = BUFFER_OLD,
 ) -> typing.List[typing.Dict]:
     """Check whether two lists of row count dicts are the same. Applies a
     buffer to the current year of data to account for the fact that more
@@ -246,7 +248,11 @@ def diff_row_counts(
                 < model_count * (1 + current_year_buffer)
             )
             if model_year in [current_year, last_year]
-            else asset_count == model_count
+            else (
+                model_count * (1 - prior_year_buffer)
+                < asset_count
+                < model_count * (1 + prior_year_buffer)
+            )
         )
 
         if not counts_match:

--- a/.github/scripts/test_open_data_assets.py
+++ b/.github/scripts/test_open_data_assets.py
@@ -48,11 +48,11 @@ REQUESTS.mount(
 )
 
 # Data is permitted to be slightly different, according to these buffer values.
-# This is because we expect some level of change for the most current two years
-# in the Athena data (which is updated daily) compared to the Open Data portal
-# (which is updated bi-weekly or monthly). We expect differences to arise for
-# prior years due to our slower open data update cadence for those years (once
-# a year) despite their relatively static nature in Athena.
+# We expect some level of change for the most current two years in the Athena
+# data (which is updated daily) compared to the Open Data portal (which is
+# updated bi-weekly or monthly). We also expect differences to arise for prior
+# years due to a slower open data update cadence for those years (once a year)
+# despite their relatively static nature in Athena.
 BUFFERS = {"current": 0.02, "prior": 0.2}
 
 


### PR DESCRIPTION
This PR adds an additional buffer level for prior years (earlier than the current and last) that can be adjusted independently of the current year buffer. It also formats our `agate` tables before output to avoid the comma in the year column and number columns with values of only 0/1 being coerced into booleans.

These changes were motivated by drift between row counts across less-frequently updated, older years of data on the open data portal and the athena assets that feed them. We should expect and thus allow larger discrepancies for these years since they're only updated once a year.

[Test run here.](https://github.com/ccao-data/data-architecture/actions/runs/32288770397/job/96184485930)

This will still surface errors for 1 vs 0 rows, which is a pretty small _absolute_ difference. I'm happy to try to address that case if we think it should also be allowed to pass through the buffer.

I also updated our sales asset after seeing the diff from the test run.