### PR TITLE
Alternate proposal for iasWorld test result view implementation

### DIFF
--- a/dbt/macros/generate_iasworld_qc_test_view.sql
+++ b/dbt/macros/generate_iasworld_qc_test_view.sql
@@ -7,8 +7,8 @@
         base_query: A SQL SELECT statement (as a string) that returns the
             identifying columns plus any additional columns referenced by
             the `condition` or `additional_select_columns` attributes of the
-            `tests` argument. Tables that don't include a required identifying
-            column (usually `card` or `lline`) should return
+            `tests` argument. Source tables that don't include a required
+            identifying column (usually `card` or `lline`) should return
             `CAST(NULL AS <type>) AS <column_name>` for that column to conform
             to the expected shape. Required identifying columns include:
                 - parid: varchar
@@ -20,14 +20,14 @@
                 - who: varchar
                 - wen: varchar
         tests: A list of dicts, each with keys:
-            - name: A unique, descriptive name for the test
+            - name: A unique, descriptive slug for the test
             - description: A human-readable description of what the test checks
             - category: A category slug used to group related tests
             - condition: A SQL boolean expression, evaluated against
                 `base_query`, that is TRUE when the record passes the test
                 and FALSE when it fails
             - additional_select_columns (optional): A list of column names
-                from `base_query` to include in the output as a MAP of column
+                from `base_query` to include in the output as a map of column
                 name -> stringified value for records that fail the test
 
     Returns:
@@ -44,7 +44,7 @@
                 -- noqa: disable=layout.indent
                 {% for test in tests %}
                     not ({{ test.condition }}) as {{ test.name }}
-                    {{- ", " if not loop.last }}
+                    {{- "," if not loop.last }}
                 {% endfor %}
             -- noqa: enable=layout.indent
             from base

--- a/dbt/macros/generate_iasworld_qc_test_view.sql
+++ b/dbt/macros/generate_iasworld_qc_test_view.sql
@@ -1,0 +1,140 @@
+{#-
+    Generate a QC report view that runs a set of boolean "tests" against a
+    base query and returns one row per (record, failing test) pair. We use
+    the resulting views to power iasWorld QC.
+
+    Args:
+        base_query: A SQL SELECT statement (as a string) that returns the
+            identifying columns plus any additional columns referenced by
+            the `condition` or `additional_select_columns` attributes of the
+            `tests` argument. Tables that don't include a required identifying
+            column (usually `card` or `lline`) should return
+            `CAST(NULL AS <type>) AS <column_name>` for that column to conform
+            to the expected shape. Required identifying columns include:
+                - parid: varchar
+                - taxyr: varchar
+                - card: decimal
+                - lline: decimal
+                - township_code: varchar
+                - class: varchar
+                - who: varchar
+                - wen: varchar
+        tests: A list of dicts, each with keys:
+            - name: A unique, descriptive name for the test
+            - description: A human-readable description of what the test checks
+            - category: A category slug used to group related tests
+            - condition: A SQL boolean expression, evaluated against
+                `base_query`, that is TRUE when the record passes the test
+                and FALSE when it fails
+            - additional_select_columns (optional): A list of column names
+                from `base_query` to include in the output as a MAP of column
+                name -> stringified value for records that fail the test
+
+    Returns:
+        A query that selects one row per record per failing test.
+-#}
+{% macro generate_iasworld_qc_test_view(base_query, tests) %}
+    {% do _validate_iasworld_qc_tests(tests, exceptions.raise_compiler_error) %}
+    with
+        base as ({{ base_query }}),
+
+        test_result as (
+            select
+                *,
+                -- noqa: disable=layout.indent
+                {% for test in tests %}
+                    not ({{ test.condition }}) as {{ test.name }}
+                    {{- ", " if not loop.last }}
+                {% endfor %}
+            -- noqa: enable=layout.indent
+            from base
+            where
+                taxyr
+                between '{{ var("data_test_iasworld_year_start") }}'
+                and '{{ var("data_test_iasworld_year_end") }}'
+        )
+
+    {% for test in tests %}
+        select
+            parid,
+            taxyr,
+            card,
+            lline,
+            township_code,
+            class,
+            who,
+            wen,
+            '{{ test.name }}' as test_name,
+            '{{ test.description }}' as test_description,
+            '{{ test.category }}' as test_category,
+            {% if test.additional_select_columns -%}
+                map(
+                    array[
+                        {%- for col_name in test.additional_select_columns -%}
+                            '{{ col_name }}'{{ ", " if not loop.last }}
+                        {%- endfor %}
+                    ],
+                    array[
+                        {%- for col_name in test.additional_select_columns -%}
+                            cast({{ col_name }} as varchar) {{- ", " if not loop.last }}
+                        {%- endfor %}
+                    ]
+                ) as additional_columns
+            {%- else -%} cast(null as map(varchar, varchar)) as additional_columns
+            {%- endif %}
+        from test_result
+        where {{ test.name }} {{ "UNION ALL" if not loop.last }}
+    {% endfor %}
+{% endmacro %}
+
+{#-
+    Validate that `tests` is a list of dicts, each containing the keys
+    required by `generate_iasworld_qc_test_view`. Raises a compiler error
+    (via `raise_error_func`) on the first validation failure it finds.
+
+    Args:
+        tests: The `tests` argument passed to `generate_iasworld_qc_test_view`
+        raise_error_func: A function to call with an error message when
+            validation fails. Takes `exceptions.raise_compiler_error` in
+            production, and a mock in unit tests so that the error can be
+            returned for equality comparison instead of raised
+-#}
+{% macro _validate_iasworld_qc_tests(tests, raise_error_func) %}
+    {%- set required_keys = ["name", "description", "category", "condition"] -%}
+    {%- if tests is not iterable or tests is mapping or tests is string -%}
+        {{-
+            return(
+                raise_error_func('"tests" argument must be a list, got: ' ~ tests)
+            )
+        -}}
+    {%- endif -%}
+    {%- for test in tests -%}
+        {%- if test is not mapping -%}
+            {{-
+                return(
+                    raise_error_func(
+                        'Each element of "tests" must be an object/dict,'
+                        ~ " got: "
+                        ~ test
+                    )
+                )
+            -}}
+        {%- endif -%}
+        {%- for key in required_keys -%}
+            {%- if key not in test -%}
+                {{-
+                    return(
+                        raise_error_func(
+                            'Missing required "'
+                            ~ key
+                            ~ '" key in test'
+                            ~ " config: "
+                            ~ test
+                        )
+                    )
+                -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endfor -%}
+    {{ return(none) }}
+{% endmacro %}

--- a/dbt/macros/tests/test_all.sql
+++ b/dbt/macros/tests/test_all.sql
@@ -6,4 +6,5 @@
     {% do test_generate_alias_name() %}
     {% do test_format_additional_select_columns() %}
     {% do test_insert_hyphens() %}
+    {% do test_generate_iasworld_qc_test_view() %}
 {% endmacro %}

--- a/dbt/macros/tests/test_generate_iasworld_qc_test_view.sql
+++ b/dbt/macros/tests/test_generate_iasworld_qc_test_view.sql
@@ -1,0 +1,66 @@
+{% macro test_generate_iasworld_qc_test_view() %}
+    {% do test_validate_iasworld_qc_tests_not_a_list() %}
+    {% do test_validate_iasworld_qc_tests_element_not_a_dict() %}
+    {% do test_validate_iasworld_qc_tests_missing_required_key() %}
+    {% do test_validate_iasworld_qc_tests_valid() %}
+{% endmacro %}
+
+{% macro test_validate_iasworld_qc_tests_not_a_list() %}
+    {{
+        assert_equals(
+            "test_validate_iasworld_qc_tests_not_a_list",
+            _validate_iasworld_qc_tests({"name": "foo"}, mock_raise_compiler_error),
+            "\"tests\" argument must be a list, got: {'name': 'foo'}",
+        )
+    }}
+{% endmacro %}
+
+{% macro test_validate_iasworld_qc_tests_element_not_a_dict() %}
+    {{
+        assert_equals(
+            "test_validate_iasworld_qc_tests_element_not_a_dict",
+            _validate_iasworld_qc_tests(["foo"], mock_raise_compiler_error),
+            'Each element of "tests" must be an object/dict, got: foo',
+        )
+    }}
+{% endmacro %}
+
+{% macro test_validate_iasworld_qc_tests_missing_required_key() %}
+    {{
+        assert_equals(
+            "test_validate_iasworld_qc_tests_missing_required_key",
+            _validate_iasworld_qc_tests(
+                [
+                    {
+                        "name": "foo",
+                        "description": "bar",
+                        "category": "baz",
+                    }
+                ],
+                mock_raise_compiler_error,
+            ),
+            "Missing required \"condition\" key in test config: {'name':"
+            ~ " 'foo', 'description': 'bar', 'category': 'baz'}",
+        )
+    }}
+{% endmacro %}
+
+{% macro test_validate_iasworld_qc_tests_valid() %}
+    {{
+        assert_equals(
+            "test_validate_iasworld_qc_tests_valid",
+            _validate_iasworld_qc_tests(
+                [
+                    {
+                        "name": "foo",
+                        "description": "bar",
+                        "category": "baz",
+                        "condition": "1 = 1",
+                    }
+                ],
+                mock_raise_compiler_error,
+            ),
+            none,
+        )
+    }}
+{% endmacro %}

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -1,238 +1,139 @@
-WITH legdat_townships AS (
+{%- set tests = [
+    {
+        "name": "iasworld_pardat_adrno_length_lte_5",
+        "description": "adrno should be <= 5 characters long",
+        "category": "column_length",
+        "condition": "length(adrno) <= 5",
+        "additional_select_columns": ["adrno"]
+    },
+    {
+        "name": "iasworld_pardat_class_equals_luc",
+        "description": "class should be the same as luc",
+        "category": "class_mismatch_or_issue",
+        "condition": "class = luc",
+        "additional_select_columns": ["luc"]
+    },
+    {
+        "name": "iasworld_pardat_cur_in_accepted_values",
+        "description": 'cur should be "Y" or "D"',
+        "category": "incorrect_values",
+        "condition": "cur IN ('Y', 'D')",
+        "additional_select_columns": ["cur"]
+    },
+    {
+        "name": "iasworld_pardat_nbhd_matches_legdat_township",
+        "description": "nbhd code first 2 digits should match legdat.user1 (township code)",
+        "category": "relationships",
+        "condition": "SUBSTR(nbhd, 1, 2) = township_code",
+        "additional_select_columns": ["nbhd"]
+    },
+    {
+        "name": "iasworld_pardat_nbhd_matches_town_nbhd",
+        "description": "nbhd code not valid",
+        "category": "relationships",
+        "condition": "town_nbhd IS NOT NULL OR nbhd LIKE '%999'",
+        "additional_select_columns": ["nbhd"]
+    },
+    {
+        "name": "iasworld_pardat_seq_all_sequential_exist",
+        "description": "seq should be sequential",
+        "category": "incorrect_values",
+        "condition": "seq = prev_seq + 1",
+        "additional_select_columns": ["seq", "prev_seq"]
+    },
+    {
+        "name": "iasworld_pardat_unique_by_parid_taxyr",
+        "description": "pardat should be unique by parid and taxyr",
+        "category": "duplicate_rows",
+        "condition": "num_duplicates = 1",
+        "additional_select_columns": ["num_duplicates"]
+    }
+] -%}
+
+WITH base AS (
     SELECT
-        parid,
-        taxyr,
-        user1 AS township_code
-    FROM {{ source('iasworld', 'legdat') }}
-    WHERE cur = 'Y'
-        AND deactivat IS NULL
-),
-
-distinct_town_nbhd AS (
-    SELECT DISTINCT town_nbhd
-    FROM {{ source('spatial', 'neighborhood') }}
-),
-
-pardat AS (
-    SELECT *
-    FROM {{ source('iasworld', 'pardat') }}
-    WHERE CAST(taxyr AS INT) BETWEEN
-        {{ var('data_test_iasworld_year_start') }}
-        AND {{ var('data_test_iasworld_year_end') }}
-        AND cur = 'Y'
-        AND deactivat IS NULL
-),
-
-pardat_seq AS (
-    SELECT
-        parid,
-        taxyr,
-        class,
-        seq,
-        LAG(seq) OVER (PARTITION BY parid, taxyr ORDER BY seq) AS prev_seq,
-        who,
-        wen
-    FROM pardat
-),
-
-iasworld_pardat_adrno_length_lte_5 AS (
-    SELECT
-        'iasworld_pardat_adrno_length_lte_5' AS test_name,
-        'adrno should be <= 5 characters long' AS test_description,
-        'column_length' AS test_category,
-        pardat.taxyr,
+        -- Identifying columns
         pardat.parid,
+        pardat.taxyr,
         CAST(NULL AS INTEGER) AS card,
         CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
+        legdat.user1 AS township_code,
         pardat.class,
         pardat.who,
         pardat.wen,
-        MAP(
-            ARRAY['adrno'],
-            ARRAY[CAST(pardat.adrno AS VARCHAR)]
-        ) AS additional_fields
-    FROM pardat
-    LEFT JOIN legdat_townships AS legdat
+        -- Columns to test
+        CAST(pardat.adrno AS VARCHAR) AS adrno,
+        pardat.luc,
+        pardat.cur,
+        pardat.nbhd,
+        nbhd.town_nbhd,
+        pardat.seq,
+        LAG(pardat.seq)
+            OVER (PARTITION BY pardat.parid, pardat.taxyr ORDER BY pardat.seq)
+            AS prev_seq,
+        COUNT(*)
+            OVER (PARTITION BY pardat.parid, pardat.taxyr)
+            AS num_duplicates
+    FROM iasworld.pardat AS pardat
+    LEFT JOIN iasworld.legdat AS legdat
         ON pardat.parid = legdat.parid
         AND pardat.taxyr = legdat.taxyr
-    WHERE NOT (LENGTH(CAST(pardat.adrno AS VARCHAR)) <= 5)
+        AND legdat.cur = 'Y'
+        AND legdat.deactivat IS NULL
+    LEFT JOIN (
+        SELECT DISTINCT town_nbhd
+        FROM {{ source('spatial', 'neighborhood') }}
+    ) AS nbhd
+        ON pardat.nbhd = nbhd.town_nbhd
+    WHERE pardat.cur = 'Y'
+        AND pardat.deactivat IS NULL
 ),
 
-iasworld_pardat_class_equals_luc AS (
+test_result AS (
     SELECT
-        'iasworld_pardat_class_equals_luc' AS test_name,
-        'class should be the same as luc' AS test_description,
-        'class_mismatch_or_issue' AS test_category,
-        pardat.taxyr,
-        pardat.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat.class,
-        pardat.who,
-        pardat.wen,
-        MAP(
-            ARRAY['luc'],
-            ARRAY[pardat.luc]
-        ) AS additional_fields
-    FROM pardat
-    LEFT JOIN legdat_townships AS legdat
-        ON pardat.parid = legdat.parid
-        AND pardat.taxyr = legdat.taxyr
-    WHERE NOT (pardat.class = pardat.luc)
-),
-
-iasworld_pardat_cur_in_accepted_values AS (
-    SELECT
-        'iasworld_pardat_cur_in_accepted_values' AS test_name,
-        'cur should be ''Y'' or ''D''' AS test_description,
-        CAST(NULL AS VARCHAR) AS test_category,
-        pardat.taxyr,
-        pardat.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat.class,
-        pardat.who,
-        pardat.wen,
-        MAP(
-            ARRAY['cur'],
-            ARRAY[pardat.cur]
-        ) AS additional_fields
-    FROM {{ source('iasworld', 'pardat') }} AS pardat
-    LEFT JOIN legdat_townships AS legdat
-        ON pardat.parid = legdat.parid
-        AND pardat.taxyr = legdat.taxyr
-    WHERE pardat.cur NOT IN ('Y', 'D')
-        AND CAST(pardat.taxyr AS INT) BETWEEN
-        {{ var('data_test_iasworld_year_start') }}
-        AND {{ var('data_test_iasworld_year_end') }}
-),
-
-iasworld_pardat_nbhd_matches_legdat_township AS (
-    SELECT
-        'iasworld_pardat_nbhd_matches_legdat_township' AS test_name,
-        'nbhd code first 2 digits should match legdat.user1 (township code)'
-            AS test_description,
-        'relationships' AS test_category,
-        pardat.taxyr,
-        pardat.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat.class,
-        pardat.who,
-        pardat.wen,
-        MAP(
-            ARRAY['nbhd'],
-            ARRAY[pardat.nbhd]
-        ) AS additional_fields
-    FROM pardat
-    INNER JOIN legdat_townships AS legdat
-        ON pardat.parid = legdat.parid
-        AND pardat.taxyr = legdat.taxyr
-        AND SUBSTR(pardat.nbhd, 1, 2) != legdat.township_code
-),
-
-iasworld_pardat_nbhd_matches_spatial_town_nbhd AS (
-    SELECT
-        'iasworld_pardat_nbhd_matches_spatial_town_nbhd' AS test_name,
-        'nbhd code not valid' AS test_description,
-        'relationships' AS test_category,
-        pardat.taxyr,
-        pardat.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat.class,
-        pardat.who,
-        pardat.wen,
-        MAP(
-            ARRAY['nbhd'],
-            ARRAY[pardat.nbhd]
-        ) AS additional_fields
-    FROM pardat
-    LEFT JOIN legdat_townships AS legdat
-        ON pardat.parid = legdat.parid
-        AND pardat.taxyr = legdat.taxyr
-    LEFT JOIN distinct_town_nbhd
-        ON pardat.nbhd = distinct_town_nbhd.town_nbhd
-    WHERE distinct_town_nbhd.town_nbhd IS NULL
-        AND pardat.nbhd NOT LIKE '%999'
-),
-
-iasworld_pardat_seq_all_sequential_exist AS (
-    SELECT
-        'iasworld_pardat_seq_all_sequential_exist' AS test_name,
-        'seq should be sequential' AS test_description,
-        CAST(NULL AS VARCHAR) AS test_category,
-        pardat_seq.taxyr,
-        pardat_seq.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat_seq.class,
-        pardat_seq.who,
-        pardat_seq.wen,
-        MAP(
-            ARRAY['seq', 'prev_seq'],
-            ARRAY[
-                CAST(pardat_seq.seq AS VARCHAR),
-                CAST(pardat_seq.prev_seq AS VARCHAR)
-            ]
-        ) AS additional_fields
-    FROM pardat_seq
-    LEFT JOIN legdat_townships AS legdat
-        ON pardat_seq.parid = legdat.parid
-        AND pardat_seq.taxyr = legdat.taxyr
-    WHERE NOT (pardat_seq.seq = pardat_seq.prev_seq + 1)
-),
-
-iasworld_pardat_unique_by_parid_taxyr AS (
-    SELECT
-        'iasworld_pardat_unique_by_parid_taxyr' AS test_name,
-        'pardat should be unique by parid and taxyr' AS test_description,
-        CAST(NULL AS VARCHAR) AS test_category,
-        pardat.taxyr,
-        pardat.parid,
-        CAST(NULL AS INTEGER) AS card,
-        CAST(NULL AS INTEGER) AS lline,
-        legdat.township_code,
-        pardat.class,
-        pardat.who,
-        pardat.wen,
-        MAP(
-            ARRAY['num_duplicates'],
-            ARRAY[CAST(dupe_counts.num_dupes AS VARCHAR)]
-        ) AS additional_fields
-    FROM pardat
-    LEFT JOIN legdat_townships AS legdat
-        ON pardat.parid = legdat.parid
-        AND pardat.taxyr = legdat.taxyr
-    INNER JOIN (
-        SELECT
-            parid,
-            taxyr,
-            COUNT(*) AS num_dupes
-        FROM pardat
-        GROUP BY parid, taxyr
-        HAVING COUNT(*) > 1
-    ) AS dupe_counts
-        ON pardat.parid = dupe_counts.parid
-        AND pardat.taxyr = dupe_counts.taxyr
+        *,
+    -- noqa: disable=layout.indent
+    {% for test in tests %}
+        NOT({{ test.condition }}) AS {{ test.name }}
+        {{- ", " if not loop.last }}
+    {% endfor %}
+    --noqa: enable=layout.indent
+    FROM base
+    WHERE taxyr BETWEEN '{{ var("data_test_iasworld_year_start") }}'
+        AND '{{ var("data_test_iasworld_year_end") }}'
 )
 
-SELECT * FROM iasworld_pardat_adrno_length_lte_5
-UNION ALL
-SELECT * FROM iasworld_pardat_class_equals_luc
-UNION ALL
-SELECT * FROM iasworld_pardat_cur_in_accepted_values
-UNION ALL
-SELECT * FROM iasworld_pardat_nbhd_matches_legdat_township
-UNION ALL
-SELECT * FROM iasworld_pardat_nbhd_matches_spatial_town_nbhd
-UNION ALL
-SELECT * FROM iasworld_pardat_seq_all_sequential_exist
-UNION ALL
-SELECT * FROM iasworld_pardat_unique_by_parid_taxyr
+{% for test in tests %}
+    SELECT
+        parid,
+        taxyr,
+        card,
+        lline,
+        township_code,
+        class,
+        who,
+        wen,
+        '{{ test.name }}' AS test_name,
+        '{{ test.description }}' AS test_description,
+        '{{ test.category }}' AS test_category,
+        {% if test.additional_select_columns -%}
+            MAP(
+                ARRAY[
+                    {%- for col_name in test.additional_select_columns -%}
+                        '{{ col_name }}'{{ ", " if not loop.last }}
+                    {%- endfor %}
+                ],
+                ARRAY[
+                    {%- for col_name in test.additional_select_columns -%}
+                        CAST({{ col_name }} AS VARCHAR)
+                        {{- ", " if not loop.last }}
+                    {%- endfor %}
+                ]
+            ) AS additional_columns
+        {%- else -%}
+            CAST(NULL AS MAP(varchar, varchar)) AS additional_columns
+        {%- endif %}
+    FROM test_result
+    WHERE {{ test.name }}
+    {{ "UNION ALL" if not loop.last }}
+{% endfor %}

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -28,7 +28,7 @@
         "additional_select_columns": ["nbhd"]
     },
     {
-        "name": "iasworld_pardat_nbhd_matches_town_nbhd",
+        "name": "iasworld_pardat_nbhd_matches_spatial_town_nbhd",
         "description": "nbhd code not valid",
         "category": "relationships",
         "condition": "town_nbhd IS NOT NULL OR nbhd LIKE '%999'",

--- a/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
+++ b/dbt/models/qc/qc.vw_report_iasworld_test_pardat.sql
@@ -50,7 +50,7 @@
     }
 ] -%}
 
-WITH base AS (
+{%- set base_query %}
     SELECT
         -- Identifying columns
         pardat.parid,
@@ -87,53 +87,6 @@ WITH base AS (
         ON pardat.nbhd = nbhd.town_nbhd
     WHERE pardat.cur = 'Y'
         AND pardat.deactivat IS NULL
-),
+{% endset %}
 
-test_result AS (
-    SELECT
-        *,
-    -- noqa: disable=layout.indent
-    {% for test in tests %}
-        NOT({{ test.condition }}) AS {{ test.name }}
-        {{- ", " if not loop.last }}
-    {% endfor %}
-    --noqa: enable=layout.indent
-    FROM base
-    WHERE taxyr BETWEEN '{{ var("data_test_iasworld_year_start") }}'
-        AND '{{ var("data_test_iasworld_year_end") }}'
-)
-
-{% for test in tests %}
-    SELECT
-        parid,
-        taxyr,
-        card,
-        lline,
-        township_code,
-        class,
-        who,
-        wen,
-        '{{ test.name }}' AS test_name,
-        '{{ test.description }}' AS test_description,
-        '{{ test.category }}' AS test_category,
-        {% if test.additional_select_columns -%}
-            MAP(
-                ARRAY[
-                    {%- for col_name in test.additional_select_columns -%}
-                        '{{ col_name }}'{{ ", " if not loop.last }}
-                    {%- endfor %}
-                ],
-                ARRAY[
-                    {%- for col_name in test.additional_select_columns -%}
-                        CAST({{ col_name }} AS VARCHAR)
-                        {{- ", " if not loop.last }}
-                    {%- endfor %}
-                ]
-            ) AS additional_columns
-        {%- else -%}
-            CAST(NULL AS MAP(varchar, varchar)) AS additional_columns
-        {%- endif %}
-    FROM test_result
-    WHERE {{ test.name }}
-    {{ "UNION ALL" if not loop.last }}
-{% endfor %}
+{{ generate_iasworld_qc_test_view(base_query, tests) }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,4 @@ load_macros_from_path = "dbt/macros"
 # lints
 get_s3_dependency_dir = "{% macro get_s3_dependency_dir() %}s3://bucket{% endmacro %}"
 insert_hyphens = "{% macro insert_hyphens(str) %}{% set _ = varargs %}'{{ str }}'{% endmacro %}"
+generate_iasworld_qc_test_view = "{% macro generate_iasworld_qc_test_view(base_query, tests) %}select 1{% endmacro %}"


### PR DESCRIPTION
## Background

This PR branches off of #1093 to propose an alternate design for implementing iasWorld test result views. The new design makes use of a [dbt macro](https://docs.getdbt.com/docs/build/jinja-macros?version=1.11#macros) to encapsulate as much shared logic as possible that would otherwise need to be copy/pasted across tests and views.

The macro accepts two required parameters:

- `base_query` (string): The SQL query that provides all the data necessary to run all tests for a given iasWorld table.
- `tests` (list of objects): One or more configuration objects describing each test to run on the view. Each object in the list can have the following attributes:
    - `name` (required string): The name of the test
    - `description` (required string): A human-readable description of the test
    - `category` (required string): A category slug for the test
    - `condition` (required string): A SQL expression that uses columns selected in `base_query` to produce a boolean for the test result (`TRUE` means the test passed, `FALSE` means it failed)
    - `additional_select_columns` (optional list of strings): One or more columns from `base_query` to include in the output for this test, alongside all the default identifying columns

## Testing

Run this query for evidence that our views exactly match:

```sql
with jean as (
    select test_name, count(*) as num_failures
    from z_dev_jecochr_qc.vw_report_iasworld_test_pardat
    group by 1
),

damon as (
    select test_name, count(*) as num_failures
    from z_ci_1088_create_tableau_dashboard_based_on_iasworld_tests_qc.vw_report_iasworld_test_pardat
    group by 1
)

select
    coalesce(jean.test_name, damon.test_name) as test_name,
    jean.num_failures as jean_num_failures,
    damon.num_failures as damon_num_failures
from jean
full outer join damon
    on jean.test_name = damon.test_name
```

