### PR TITLE
Add Lily Rudin to `ccao.person` model seed

### DIFF
--- a/dbt/seeds/ccao/ccao.person.csv
+++ b/dbt/seeds/ccao/ccao.person.csv
@@ -45,3 +45,4 @@ caitlin,intern
 marie,intern
 tim,fte
 rushikesh,intern
+lily,intern


### PR DESCRIPTION
Adds Lily to our model names seed. Partially closes [this offboarding ticket](https://github.com/ccao-data/people/issues/45).