### PR TITLE
Fix docs and test issues with new final model PIN/card views

### DIFF
--- a/dbt/models/model/docs.md
+++ b/dbt/models/model/docs.md
@@ -230,7 +230,7 @@ between condo and single-family models.
 
 # vw_assessment_pin_final
 
-{% docs view_vw_assessment_pin %}
+{% docs view_vw_assessment_pin_final %}
 Version of `assessment_pin` limited to final model runs and the triad that was
 reassessed. Includes additional column `model_type` to allow easy filtering
 between condo and single-family models.

--- a/dbt/models/model/model.vw_assessment_card_final.sql
+++ b/dbt/models/model/model.vw_assessment_card_final.sql
@@ -2,9 +2,12 @@
 -- runs
 SELECT
     ac.*,
+    town.triad_code AS meta_triad_code,
     fm.type AS model_type
 FROM {{ source('model', 'assessment_card') }} AS ac
 INNER JOIN {{ ref('model.final_model') }} AS fm
     ON ac.run_id = fm.run_id
     -- Model runs are specific to townships
     AND CONTAINS(fm.township_code_coverage, ac.township_code)
+LEFT JOIN {{ source('spatial', 'township') }} AS town
+    ON ac.township_code = town.township_code

--- a/dbt/models/model/schema.yml
+++ b/dbt/models/model/schema.yml
@@ -277,7 +277,7 @@ models:
             - meta_sale_document_num
             - meta_card_num
 
-  - name: vw_assessment_card_final
+  - name: model.vw_assessment_card_final
     description: '{{ doc("view_vw_assessment_card_final") }}'
     data_tests:
       - count_is_consistent:
@@ -293,7 +293,7 @@ models:
             - meta_card_num
             - meta_year
 
-  - name: vw_assessment_pin_final
+  - name: model.vw_assessment_pin_final
     description: '{{ doc("view_vw_assessment_pin_final") }}'
     data_tests:
       - count_is_consistent:


### PR DESCRIPTION
The new `model.vw_assessment_*_final` views we introduced in #1098 had a couple typos in the docs that are raising warnings whenever we run dbt commands:

```bash
$ dbt compile
15:40:45  Running with dbt=1.9.1
15:40:45  Registered adapter: athena=1.8.4
15:40:45  Unable to do partial parsing because config vars, config profile, or config target have changed
15:40:45  Unable to do partial parsing because profile has changed
15:40:48  [WARNING]: Did not find matching node for patch with name 'vw_assessment_card_final' in the 'models' section of file 'models/model/schema.yml'
15:40:48  [WARNING]: Did not find matching node for patch with name 'vw_assessment_pin_final' in the 'models' section of file 'models/model/schema.yml'
15:40:52  [WARNING]: Test 'test.ccao_data_athena.model_vw_assessment_card_final_single_triad_code_per_year.2c4c72c176' (models/model/schema.yml) depends on a node named 'vw_assessment_card_final' in package '' which was not found
15:40:52  [WARNING]: Test 'test.ccao_data_athena.model_vw_assessment_card_final_unique_pin_card_year.30be434345' (models/model/schema.yml) depends on a node named 'vw_assessment_card_final' in package '' which was not found
15:40:52  [WARNING]: Test 'test.ccao_data_athena.model_vw_assessment_pin_final_single_triad_code_per_year.e8005f8920' (models/model/schema.yml) depends on a node named 'vw_assessment_pin_final' in package '' which was not found
15:40:52  [WARNING]: Test 'test.ccao_data_athena.model_vw_assessment_pin_final_unique_pin_year.6c38fb7e82' (models/model/schema.yml) depends on a node named 'vw_assessment_pin_final' in package '' which was not found
```

This PR fixes those small issues to resolve the warnings. Confirmation that the same command issues no warnings following this diff:

```diff
$ dbt compile
15:44:01  Running with dbt=1.9.1
15:44:04  Registered adapter: athena=1.8.4
15:44:04  Unable to do partial parsing because saved manifest not found. Starting full parse.
15:44:12  Found 152 models, 20 seeds, 693 data tests, 179 sources, 13 exposures, 545 macros, 16 unit tests
15:44:12
15:44:12  Concurrency: 16 threads (target='dev')
15:44:12
```

Note that we also fold in one small fix to the test on `model.vw_assessment_card_final.meta_triad_code`, since that column didn't technically exist until now.